### PR TITLE
Fix deprecated utcnow usage in tests

### DIFF
--- a/tests/unit_tests/control_plane/test_app_db_paths.py
+++ b/tests/unit_tests/control_plane/test_app_db_paths.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -33,13 +33,13 @@ async def test_get_debug_entries_parses_blob():
     rows = [
         {
             "id": 1,
-            "time_created": datetime.utcnow(),
+            "time_created": datetime.now(tz=timezone.utc),
             "debug_type_identifier": "t1",
             "jsonblob": {"a": 1},
         },
         {
             "id": 2,
-            "time_created": datetime.utcnow(),
+            "time_created": datetime.now(tz=timezone.utc),
             "debug_type_identifier": "t1",
             "jsonblob": json.dumps({"b": 2}),
         },
@@ -58,8 +58,16 @@ async def test_get_debug_entries_parses_blob():
 @pytest.mark.asyncio
 async def test_get_debug_types():
     rows = [
-        {"debug_type_identifier": "t1", "count": 3, "latest": datetime.utcnow()},
-        {"debug_type_identifier": "t2", "count": 1, "latest": datetime.utcnow()},
+        {
+            "debug_type_identifier": "t1",
+            "count": 3,
+            "latest": datetime.now(tz=timezone.utc),
+        },
+        {
+            "debug_type_identifier": "t2",
+            "count": 1,
+            "latest": datetime.now(tz=timezone.utc),
+        },
     ]
     conn = FakeConn(rows=rows)
 
@@ -77,7 +85,7 @@ async def test_get_debug_page():
     rows = [
         {
             "id": 1,
-            "time_created": datetime.utcnow(),
+            "time_created": datetime.now(tz=timezone.utc),
             "debug_type_identifier": "t1",
             "jsonblob": {"a": 1},
         },
@@ -122,8 +130,8 @@ async def test_trace_by_call_id_sorts_by_ns():
 @pytest.mark.asyncio
 async def test_recent_call_ids():
     rows = [
-        {"cid": "A", "cnt": 2, "latest": datetime.utcnow()},
-        {"cid": "B", "cnt": 1, "latest": datetime.utcnow()},
+        {"cid": "A", "cnt": 2, "latest": datetime.now(tz=timezone.utc)},
+        {"cid": "B", "cnt": 1, "latest": datetime.now(tz=timezone.utc)},
     ]
     conn = FakeConn(rows=rows)
 


### PR DESCRIPTION
## Summary
- replace datetime.utcnow() in control plane db path tests with timezone-aware datetime.now(tz=timezone.utc) to avoid deprecation warnings

## Testing
- ./scripts/dev_checks.sh

------
https://chatgpt.com/codex/tasks/task_e_68d1b89bf678832c9cf412d982b9b82c