### PR TITLE
Fix: harden streaming safety and rate limits

### DIFF
--- a/src/luthien_proxy/control_plane/conversation/streams.py
+++ b/src/luthien_proxy/control_plane/conversation/streams.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import json
 import logging
 import time
+from contextlib import suppress
 from typing import AsyncGenerator
 
 from luthien_proxy.utils import redis_client
@@ -15,6 +18,70 @@ logger = logging.getLogger(__name__)
 
 _CONVERSATION_CHANNEL_PREFIX = "luthien:conversation:"
 _CONVERSATION_TRACE_CHANNEL_PREFIX = "luthien:conversation-trace:"
+DEFAULT_HEARTBEAT_INTERVAL = 15.0
+STREAM_POLL_TIMEOUT = 1.0
+
+
+async def _close_resource(resource: object) -> None:
+    """Best-effort asynchronous close for redis resources."""
+    if resource is None:
+        return
+    close_async = getattr(resource, "aclose", None)
+    if callable(close_async):
+        result = close_async()
+        if inspect.isawaitable(result):
+            with suppress(Exception):
+                await result
+        return
+    close = getattr(resource, "close", None)
+    if callable(close):
+        result = close()
+        if inspect.isawaitable(result):
+            with suppress(Exception):
+                await result
+
+
+async def _cleanup_pubsub(client: object, pubsub: object, channel: str) -> None:
+    """Ensure pubsub connections are released back to the pool."""
+    if pubsub is not None:
+        with suppress(Exception):
+            await pubsub.unsubscribe(channel)
+    await _close_resource(pubsub)
+    await _close_resource(client)
+
+
+async def _stream_channel(
+    redis: redis_client.RedisClient,
+    channel: str,
+    heartbeat_interval: float | None,
+) -> AsyncGenerator[str, None]:
+    client = redis.client()
+    pubsub = None
+    try:
+        pubsub = client.pubsub()
+        await pubsub.subscribe(channel)
+    except Exception:
+        await _cleanup_pubsub(client, pubsub, channel)
+        raise
+    interval = DEFAULT_HEARTBEAT_INTERVAL if not heartbeat_interval or heartbeat_interval <= 0 else heartbeat_interval
+    last_heartbeat = time.time()
+    try:
+        while True:
+            message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=STREAM_POLL_TIMEOUT)
+            now = time.time()
+            if message is None:
+                if now - last_heartbeat >= interval:
+                    last_heartbeat = now
+                    yield ": ping\n\n"
+                continue
+            data = message.get("data")
+            text = data.decode("utf-8", errors="ignore") if isinstance(data, bytes) else str(data)
+            last_heartbeat = now
+            yield f"data: {text}\n\n"
+    except asyncio.CancelledError:
+        raise
+    finally:
+        await _cleanup_pubsub(client, pubsub, channel)
 
 
 def conversation_channel(call_id: str) -> str:
@@ -67,67 +134,23 @@ async def publish_trace_conversation_event(
 async def conversation_sse_stream(
     redis: redis_client.RedisClient,
     call_id: str,
+    heartbeat_interval: float | None = None,
 ) -> AsyncGenerator[str, None]:
     """Yield SSE data for a call-level channel."""
     channel = conversation_channel(call_id)
-    pubsub = redis.pubsub()
-    await pubsub.subscribe(channel)
-    heartbeat_interval = 15.0
-    last_heartbeat = time.time()
-    try:
-        while True:
-            message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
-            now = time.time()
-            if message is None:
-                if now - last_heartbeat >= heartbeat_interval:
-                    last_heartbeat = now
-                    yield ": ping\n\n"
-                continue
-            data = message.get("data")
-            if isinstance(data, bytes):
-                text = data.decode("utf-8", errors="ignore")
-            else:
-                text = str(data)
-            last_heartbeat = now
-            yield f"data: {text}\n\n"
-    finally:
-        try:
-            await pubsub.unsubscribe(channel)
-        finally:
-            await pubsub.close()
+    async for payload in _stream_channel(redis, channel, heartbeat_interval):
+        yield payload
 
 
 async def conversation_sse_stream_by_trace(
     redis: redis_client.RedisClient,
     trace_id: str,
+    heartbeat_interval: float | None = None,
 ) -> AsyncGenerator[str, None]:
     """Yield SSE data for a trace-level channel."""
     channel = conversation_trace_channel(trace_id)
-    pubsub = redis.pubsub()
-    await pubsub.subscribe(channel)
-    heartbeat_interval = 15.0
-    last_heartbeat = time.time()
-    try:
-        while True:
-            message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
-            now = time.time()
-            if message is None:
-                if now - last_heartbeat >= heartbeat_interval:
-                    last_heartbeat = now
-                    yield ": ping\n\n"
-                continue
-            data = message.get("data")
-            if isinstance(data, bytes):
-                text = data.decode("utf-8", errors="ignore")
-            else:
-                text = str(data)
-            last_heartbeat = now
-            yield f"data: {text}\n\n"
-    finally:
-        try:
-            await pubsub.unsubscribe(channel)
-        finally:
-            await pubsub.close()
+    async for payload in _stream_channel(redis, channel, heartbeat_interval):
+        yield payload
 
 
 __all__ = [

--- a/src/luthien_proxy/control_plane/rate_limiter.py
+++ b/src/luthien_proxy/control_plane/rate_limiter.py
@@ -1,0 +1,40 @@
+"""Lightweight async rate limiter utilities for the control plane."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from typing import Deque, Dict
+
+
+class SlidingWindowRateLimiter:
+    """Simple sliding-window limiter keyed by identifier."""
+
+    def __init__(self) -> None:
+        self._events: Dict[str, Deque[float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def allow(
+        self,
+        key: str,
+        max_events: int,
+        window_seconds: float,
+    ) -> bool:
+        """Return True if the request should proceed for the given key."""
+
+        if max_events <= 0 or window_seconds <= 0:
+            return True
+
+        now = time.monotonic()
+        async with self._lock:
+            bucket = self._events.setdefault(key, deque())
+            while bucket and now - bucket[0] > window_seconds:
+                bucket.popleft()
+            if len(bucket) >= max_events:
+                return False
+            bucket.append(now)
+            return True
+
+
+__all__ = ["SlidingWindowRateLimiter"]

--- a/src/luthien_proxy/control_plane/static/conversation_by_trace.js
+++ b/src/luthien_proxy/control_plane/static/conversation_by_trace.js
@@ -1,13 +1,21 @@
+function sanitizeText(value) {
+  if (value == null) {
+    return '';
+  }
+  const text = String(value);
+  return text.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g, '');
+}
+
 function el(tag, attrs = {}, ...children) {
   const node = document.createElement(tag);
   for (const [key, value] of Object.entries(attrs)) {
     if (key === 'class') {
       node.className = value;
     } else if (key === 'text') {
-      node.textContent = value;
+      node.textContent = sanitizeText(value);
     } else if (key === 'dataset' && value && typeof value === 'object') {
       for (const [dataKey, dataValue] of Object.entries(value)) {
-        node.dataset[dataKey] = dataValue;
+        node.dataset[dataKey] = sanitizeText(dataValue);
       }
     } else {
       node.setAttribute(key, value);
@@ -15,7 +23,11 @@ function el(tag, attrs = {}, ...children) {
   }
   for (const child of children) {
     if (child == null) continue;
-    node.appendChild(typeof child === 'string' ? document.createTextNode(child) : child);
+    if (typeof child === 'string') {
+      node.appendChild(document.createTextNode(sanitizeText(child)));
+    } else {
+      node.appendChild(child);
+    }
   }
   return node;
 }

--- a/src/luthien_proxy/utils/project_config.py
+++ b/src/luthien_proxy/utils/project_config.py
@@ -59,6 +59,11 @@ CONTROL_PLANE_HOST = ConfigValue[str]("CONTROL_PLANE_HOST", "0.0.0.0")
 CONTROL_PLANE_PORT = ConfigValue[int]("CONTROL_PLANE_PORT", 8081, parser=int)
 CONTROL_PLANE_LOG_LEVEL = ConfigValue[str]("CONTROL_PLANE_LOG_LEVEL", "INFO")
 STREAM_CONTEXT_TTL = ConfigValue[int]("STREAM_CONTEXT_TTL", 3600, parser=int)
+CONVERSATION_STREAM_HEARTBEAT = ConfigValue[float]("CONVERSATION_STREAM_HEARTBEAT_INTERVAL", 15.0, parser=float)
+CONVERSATION_STREAM_RATE_LIMIT_MAX = ConfigValue[int]("CONVERSATION_STREAM_RATE_LIMIT_MAX_REQUESTS", 30, parser=int)
+CONVERSATION_STREAM_RATE_LIMIT_WINDOW = ConfigValue[float](
+    "CONVERSATION_STREAM_RATE_LIMIT_WINDOW_SECONDS", 60.0, parser=float
+)
 
 
 @dataclass(frozen=True)
@@ -162,6 +167,21 @@ class ProjectConfig:
     def stream_context_ttl(self) -> int:
         """TTL for stream contexts in seconds."""
         return get_config_value(self._env_map, STREAM_CONTEXT_TTL)
+
+    @cached_property
+    def conversation_stream_heartbeat_interval(self) -> float:
+        """Heartbeat interval (seconds) for SSE conversation streams."""
+        return get_config_value(self._env_map, CONVERSATION_STREAM_HEARTBEAT)
+
+    @cached_property
+    def conversation_stream_rate_limit_max_requests(self) -> int:
+        """Maximum SSE stream requests allowed within the configured window."""
+        return get_config_value(self._env_map, CONVERSATION_STREAM_RATE_LIMIT_MAX)
+
+    @cached_property
+    def conversation_stream_rate_limit_window_seconds(self) -> float:
+        """Sliding window duration in seconds for SSE stream rate limiting."""
+        return get_config_value(self._env_map, CONVERSATION_STREAM_RATE_LIMIT_WINDOW)
 
     @cached_property
     def proxy_config(self) -> ProxyConfig:


### PR DESCRIPTION
## Summary
- guard streaming event indices with a lock to remove the race condition
- sanitize streamed frontend content and trim LiteLLM stream history while downgrading noisy logging
- harden SSE streaming with managed Redis cleanup, configurable heartbeat, and a simple rate limiter backed by new config values

## Testing
- uv run pytest


------
https://chatgpt.com/codex/tasks/task_e_68d70af8aee8832c9d64d11dd1665a9f