### PR TITLE
feat: harden conversation streaming

### DIFF
--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -8,6 +8,7 @@
 
 - [ ] 99% unit test coverage
 - [ ] Why does the control plane docker container take ~5 seconds to restart?
+- [ ] Simplify/reduce data passed from litellm to control plane
 
 ## Low Priority
 

--- a/src/luthien_proxy/control_plane/app.py
+++ b/src/luthien_proxy/control_plane/app.py
@@ -18,7 +18,10 @@ from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from luthien_proxy.control_plane.conversation import TraceEntry
+from luthien_proxy.control_plane.conversation import (
+    ConversationStreamConfig,
+    TraceEntry,
+)
 from luthien_proxy.control_plane.stream_context import StreamContextStore
 from luthien_proxy.control_plane.ui import router as ui_router
 from luthien_proxy.utils import db, redis_client
@@ -54,6 +57,7 @@ from .hooks_routes import (
     router as hooks_router,
 )
 from .policy_loader import load_policy_from_config
+from .utils.rate_limiter import RateLimiter
 
 logger = logging.getLogger(__name__)
 
@@ -97,8 +101,12 @@ def create_control_plane_app(config: ProjectConfig) -> FastAPI:
         database_pool: Optional[db.DatabasePool] = None
         redis_instance: Optional[redis_client.RedisClient] = None
         redis_manager = redis_client.RedisClientManager()
+        rate_limiter: Optional[RateLimiter] = None
+        stream_config: Optional[ConversationStreamConfig] = None
 
         try:
+            app.state.conversation_rate_limiter = None
+            app.state.conversation_stream_config = None
             database_pool = db.DatabasePool(control_cfg.database_url)
             await database_pool.get_pool()
             app.state.database_pool = database_pool
@@ -109,6 +117,14 @@ def create_control_plane_app(config: ProjectConfig) -> FastAPI:
             app.state.redis_client = redis_instance
 
             policy = load_policy_from_config(config, control_cfg.policy_config_path)
+
+            stream_config = control_cfg.conversation_stream_config
+            rate_limiter = RateLimiter(
+                max_events=stream_config.rate_limit_max_requests,
+                window_seconds=stream_config.rate_limit_window_seconds,
+            )
+            app.state.conversation_rate_limiter = rate_limiter
+            app.state.conversation_stream_config = stream_config
 
             stream_store = StreamContextStore(
                 redis_client=redis_instance,
@@ -127,6 +143,8 @@ def create_control_plane_app(config: ProjectConfig) -> FastAPI:
             app.state.database_pool = None
             app.state.redis_client = None
             app.state.redis_manager = None
+            app.state.conversation_rate_limiter = None
+            app.state.conversation_stream_config = None
             if database_pool is not None:
                 await database_pool.close()
             await redis_manager.close_all()

--- a/src/luthien_proxy/control_plane/conversation/__init__.py
+++ b/src/luthien_proxy/control_plane/conversation/__init__.py
@@ -37,6 +37,7 @@ from .models import (
 )
 from .snapshots import build_call_snapshots
 from .streams import (
+    ConversationStreamConfig,
     conversation_sse_stream,
     conversation_sse_stream_by_trace,
     publish_conversation_event,
@@ -61,6 +62,7 @@ __all__ = [
     "publish_trace_conversation_event",
     "conversation_sse_stream",
     "conversation_sse_stream_by_trace",
+    "ConversationStreamConfig",
     "fetch_trace_entries",
     "fetch_trace_entries_by_trace",
     "json_safe",

--- a/src/luthien_proxy/control_plane/conversation/events.py
+++ b/src/luthien_proxy/control_plane/conversation/events.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from datetime import datetime
 from typing import Any, Dict, Iterable, Literal, Optional
 
@@ -20,24 +21,28 @@ from .utils import (
 )
 
 _stream_indices: Dict[str, Dict[str, int]] = {}
+_stream_indices_lock = threading.RLock()
 
 
 def reset_stream_indices(call_id: str) -> None:
     """Initialise per-stream chunk indices for a call."""
-    _stream_indices[call_id] = {"original": 0, "final": 0}
+    with _stream_indices_lock:
+        _stream_indices[call_id] = {"original": 0, "final": 0}
 
 
 def next_chunk_index(call_id: str, stream: Literal["original", "final"]) -> int:
     """Return and advance the next chunk index for the given stream."""
-    state = _stream_indices.setdefault(call_id, {"original": 0, "final": 0})
-    idx = state[stream]
-    state[stream] = idx + 1
-    return idx
+    with _stream_indices_lock:
+        state = _stream_indices.setdefault(call_id, {"original": 0, "final": 0})
+        idx = state[stream]
+        state[stream] = idx + 1
+        return idx
 
 
 def clear_stream_indices(call_id: str) -> None:
     """Forget chunk indices for a completed call."""
-    _stream_indices.pop(call_id, None)
+    with _stream_indices_lock:
+        _stream_indices.pop(call_id, None)
 
 
 # TODO: refactor this logic, it's a mess

--- a/src/luthien_proxy/control_plane/conversation/streams.py
+++ b/src/luthien_proxy/control_plane/conversation/streams.py
@@ -1,13 +1,15 @@
-"""Streaming helpers for conversation events."""
+"""Redis-backed streaming helpers for conversation events."""
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Optional
 
 from luthien_proxy.utils import redis_client
+from luthien_proxy.utils.project_config import ConversationStreamConfig
 
 from .models import ConversationEvent
 
@@ -15,6 +17,12 @@ logger = logging.getLogger(__name__)
 
 _CONVERSATION_CHANNEL_PREFIX = "luthien:conversation:"
 _CONVERSATION_TRACE_CHANNEL_PREFIX = "luthien:conversation-trace:"
+_DEFAULT_STREAM_CONFIG = ConversationStreamConfig(
+    heartbeat_seconds=15.0,
+    redis_poll_timeout_seconds=1.0,
+    rate_limit_max_requests=60,
+    rate_limit_window_seconds=60.0,
+)
 
 
 def conversation_channel(call_id: str) -> str:
@@ -64,70 +72,76 @@ async def publish_trace_conversation_event(
         logger.error("Failed to publish trace conversation event: %s", exc)
 
 
+async def _stream_from_channel(
+    redis: redis_client.RedisClient,
+    channel: str,
+    config: Optional[ConversationStreamConfig] = None,
+) -> AsyncGenerator[str, None]:
+    """Internal helper yielding SSE frames for a redis pub/sub channel."""
+
+    settings = config or _DEFAULT_STREAM_CONFIG
+    heartbeat_interval = max(0.5, settings.heartbeat_seconds)
+    timeout = max(0.1, settings.redis_poll_timeout_seconds)
+    async with redis.pubsub(close_connection=False) as pubsub:
+        await pubsub.subscribe(channel)
+        last_heartbeat = time.monotonic()
+        try:
+            while True:
+                try:
+                    message = await pubsub.get_message(
+                        ignore_subscribe_messages=True,
+                        timeout=timeout,
+                    )
+                except asyncio.CancelledError:  # pragma: no cover - cooperative cancellation
+                    raise
+                except Exception as exc:  # pragma: no cover - defensive logging
+                    logger.error("conversation stream poll error on %s: %s", channel, exc)
+                    await asyncio.sleep(timeout)
+                    continue
+
+                now = time.monotonic()
+                if message is None:
+                    if now - last_heartbeat >= heartbeat_interval:
+                        last_heartbeat = now
+                        yield ": ping\n\n"
+                    continue
+
+                data = message.get("data")
+                if isinstance(data, bytes):
+                    text = data.decode("utf-8", errors="ignore")
+                else:
+                    text = str(data)
+                last_heartbeat = now
+                yield f"data: {text}\n\n"
+        finally:
+            try:
+                await pubsub.unsubscribe(channel)
+            except Exception:  # pragma: no cover - best-effort cleanup
+                logger.debug("Failed to unsubscribe from %s", channel, exc_info=True)
+
+
 async def conversation_sse_stream(
     redis: redis_client.RedisClient,
     call_id: str,
+    config: Optional[ConversationStreamConfig] = None,
 ) -> AsyncGenerator[str, None]:
     """Yield SSE data for a call-level channel."""
+
     channel = conversation_channel(call_id)
-    pubsub = redis.pubsub()
-    await pubsub.subscribe(channel)
-    heartbeat_interval = 15.0
-    last_heartbeat = time.time()
-    try:
-        while True:
-            message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
-            now = time.time()
-            if message is None:
-                if now - last_heartbeat >= heartbeat_interval:
-                    last_heartbeat = now
-                    yield ": ping\n\n"
-                continue
-            data = message.get("data")
-            if isinstance(data, bytes):
-                text = data.decode("utf-8", errors="ignore")
-            else:
-                text = str(data)
-            last_heartbeat = now
-            yield f"data: {text}\n\n"
-    finally:
-        try:
-            await pubsub.unsubscribe(channel)
-        finally:
-            await pubsub.close()
+    async for chunk in _stream_from_channel(redis, channel, config=config):
+        yield chunk
 
 
 async def conversation_sse_stream_by_trace(
     redis: redis_client.RedisClient,
     trace_id: str,
+    config: Optional[ConversationStreamConfig] = None,
 ) -> AsyncGenerator[str, None]:
     """Yield SSE data for a trace-level channel."""
+
     channel = conversation_trace_channel(trace_id)
-    pubsub = redis.pubsub()
-    await pubsub.subscribe(channel)
-    heartbeat_interval = 15.0
-    last_heartbeat = time.time()
-    try:
-        while True:
-            message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
-            now = time.time()
-            if message is None:
-                if now - last_heartbeat >= heartbeat_interval:
-                    last_heartbeat = now
-                    yield ": ping\n\n"
-                continue
-            data = message.get("data")
-            if isinstance(data, bytes):
-                text = data.decode("utf-8", errors="ignore")
-            else:
-                text = str(data)
-            last_heartbeat = now
-            yield f"data: {text}\n\n"
-    finally:
-        try:
-            await pubsub.unsubscribe(channel)
-        finally:
-            await pubsub.close()
+    async for chunk in _stream_from_channel(redis, channel, config=config):
+        yield chunk
 
 
 __all__ = [
@@ -137,4 +151,5 @@ __all__ = [
     "conversation_sse_stream_by_trace",
     "conversation_channel",
     "conversation_trace_channel",
+    "ConversationStreamConfig",
 ]

--- a/src/luthien_proxy/control_plane/dependencies.py
+++ b/src/luthien_proxy/control_plane/dependencies.py
@@ -9,7 +9,9 @@ from fastapi import Request
 
 from luthien_proxy.policies.base import LuthienPolicy
 from luthien_proxy.utils import db, redis_client
-from luthien_proxy.utils.project_config import ProjectConfig
+from luthien_proxy.utils.project_config import ConversationStreamConfig, ProjectConfig
+
+from .utils.rate_limiter import RateLimiter
 
 DebugLogWriter = Callable[[str, dict[str, Any]], Coroutine[Any, Any, None]]
 
@@ -23,6 +25,8 @@ class AppState(Protocol):
     debug_log_writer: DebugLogWriter | None
     database_pool: db.DatabasePool | None
     redis_client: redis_client.RedisClient | None
+    conversation_rate_limiter: RateLimiter | None
+    conversation_stream_config: ConversationStreamConfig | None
 
 
 def _require_app_state(request: Request) -> AppState:
@@ -99,6 +103,32 @@ def get_redis_client(request: Request) -> redis_client.RedisClient:
     return client
 
 
+def get_conversation_rate_limiter(request: Request) -> RateLimiter:
+    """Return the configured conversation SSE rate limiter."""
+
+    state = _require_app_state(request)
+    try:
+        limiter = state.conversation_rate_limiter
+    except AttributeError as exc:
+        raise RuntimeError("Conversation rate limiter not configured") from exc
+    if limiter is None:
+        raise RuntimeError("Conversation rate limiter not configured")
+    return limiter
+
+
+def get_conversation_stream_config(request: Request) -> ConversationStreamConfig:
+    """Return the configured conversation stream settings."""
+
+    state = _require_app_state(request)
+    try:
+        cfg = state.conversation_stream_config
+    except AttributeError as exc:
+        raise RuntimeError("Conversation stream config not available") from exc
+    if cfg is None:
+        raise RuntimeError("Conversation stream config not available")
+    return cfg
+
+
 __all__ = [
     "AppState",
     "DebugLogWriter",
@@ -108,4 +138,6 @@ __all__ = [
     "get_debug_log_writer",
     "get_database_pool",
     "get_redis_client",
+    "get_conversation_rate_limiter",
+    "get_conversation_stream_config",
 ]

--- a/src/luthien_proxy/control_plane/dependencies.py
+++ b/src/luthien_proxy/control_plane/dependencies.py
@@ -105,7 +105,6 @@ def get_redis_client(request: Request) -> redis_client.RedisClient:
 
 def get_conversation_rate_limiter(request: Request) -> RateLimiter:
     """Return the configured conversation SSE rate limiter."""
-
     state = _require_app_state(request)
     try:
         limiter = state.conversation_rate_limiter
@@ -118,7 +117,6 @@ def get_conversation_rate_limiter(request: Request) -> RateLimiter:
 
 def get_conversation_stream_config(request: Request) -> ConversationStreamConfig:
     """Return the configured conversation stream settings."""
-
     state = _require_app_state(request)
     try:
         cfg = state.conversation_stream_config

--- a/src/luthien_proxy/control_plane/hooks_routes.py
+++ b/src/luthien_proxy/control_plane/hooks_routes.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Optional, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import StreamingResponse
 
 from luthien_proxy.control_plane.conversation import (
@@ -38,7 +38,7 @@ from luthien_proxy.control_plane.conversation.utils import extract_trace_id
 from luthien_proxy.control_plane.utils.hooks import extract_call_id_for_hook
 from luthien_proxy.policies.base import LuthienPolicy
 from luthien_proxy.utils import db, redis_client
-from luthien_proxy.utils.project_config import ProjectConfig
+from luthien_proxy.utils.project_config import ConversationStreamConfig, ProjectConfig
 
 from .dependencies import (
     DebugLogWriter,
@@ -47,12 +47,32 @@ from .dependencies import (
     get_debug_log_writer,
     get_hook_counter_state,
     get_project_config,
+    get_conversation_rate_limiter,
+    get_conversation_stream_config,
     get_redis_client,
 )
+
+from .utils.rate_limiter import RateLimiter
 
 router = APIRouter()
 
 logger = logging.getLogger(__name__)
+
+
+async def enforce_conversation_rate_limit(
+    request: Request,
+    limiter: RateLimiter = Depends(get_conversation_rate_limiter),
+) -> None:
+    """Apply rate limiting for SSE streaming endpoints."""
+
+    client_host = request.client.host if request.client else "unknown"
+    key = f"{client_host}:{request.url.path}"
+    allowed = await limiter.try_acquire(key)
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many streaming requests, please slow down.",
+        )
 
 
 @router.get("/api/hooks/counters")
@@ -267,9 +287,11 @@ async def conversation_snapshot(
 async def conversation_stream(
     call_id: str = Query(..., min_length=4),
     redis_conn: redis_client.RedisClient = Depends(get_redis_client),
+    _: None = Depends(enforce_conversation_rate_limit),
+    stream_config: ConversationStreamConfig = Depends(get_conversation_stream_config),
 ) -> StreamingResponse:
     """Stream live conversation deltas for a call ID via SSE."""
-    stream = conversation_sse_stream(redis_conn, call_id)
+    stream = conversation_sse_stream(redis_conn, call_id, config=stream_config)
     return StreamingResponse(stream, media_type="text/event-stream")
 
 
@@ -291,9 +313,11 @@ async def conversation_snapshot_by_trace(
 async def conversation_stream_by_trace(
     trace_id: str = Query(..., min_length=4),
     redis_conn: redis_client.RedisClient = Depends(get_redis_client),
+    _: None = Depends(enforce_conversation_rate_limit),
+    stream_config: ConversationStreamConfig = Depends(get_conversation_stream_config),
 ) -> StreamingResponse:
     """Stream live conversation deltas for a trace id via SSE."""
-    stream = conversation_sse_stream_by_trace(redis_conn, trace_id)
+    stream = conversation_sse_stream_by_trace(redis_conn, trace_id, config=stream_config)
     return StreamingResponse(stream, media_type="text/event-stream")
 
 

--- a/src/luthien_proxy/control_plane/hooks_routes.py
+++ b/src/luthien_proxy/control_plane/hooks_routes.py
@@ -43,15 +43,14 @@ from luthien_proxy.utils.project_config import ConversationStreamConfig, Project
 from .dependencies import (
     DebugLogWriter,
     get_active_policy,
+    get_conversation_rate_limiter,
+    get_conversation_stream_config,
     get_database_pool,
     get_debug_log_writer,
     get_hook_counter_state,
     get_project_config,
-    get_conversation_rate_limiter,
-    get_conversation_stream_config,
     get_redis_client,
 )
-
 from .utils.rate_limiter import RateLimiter
 
 router = APIRouter()
@@ -64,7 +63,6 @@ async def enforce_conversation_rate_limit(
     limiter: RateLimiter = Depends(get_conversation_rate_limiter),
 ) -> None:
     """Apply rate limiting for SSE streaming endpoints."""
-
     client_host = request.client.host if request.client else "unknown"
     key = f"{client_host}:{request.url.path}"
     allowed = await limiter.try_acquire(key)

--- a/src/luthien_proxy/control_plane/static/conversation_by_trace.js
+++ b/src/luthien_proxy/control_plane/static/conversation_by_trace.js
@@ -1,21 +1,40 @@
+const SAFE_ATTR_PATTERN = /^[a-zA-Z_][\w:-]*$/;
+
+function sanitizeText(value) {
+  if (value == null) return '';
+  const text = String(value);
+  return text.replace(/[\u2028\u2029]/g, '');
+}
+
 function el(tag, attrs = {}, ...children) {
   const node = document.createElement(tag);
   for (const [key, value] of Object.entries(attrs)) {
     if (key === 'class') {
       node.className = value;
     } else if (key === 'text') {
-      node.textContent = value;
+      node.textContent = sanitizeText(value);
     } else if (key === 'dataset' && value && typeof value === 'object') {
       for (const [dataKey, dataValue] of Object.entries(value)) {
-        node.dataset[dataKey] = dataValue;
+        node.dataset[dataKey] = sanitizeText(dataValue);
       }
     } else {
-      node.setAttribute(key, value);
+      if (typeof key === 'string' && key.toLowerCase().startsWith('on')) {
+        throw new Error(`Event handler attributes are not allowed (saw ${key})`);
+      }
+      if (typeof key === 'string' && !SAFE_ATTR_PATTERN.test(key)) {
+        throw new Error(`Attribute name ${key} contains unsupported characters`);
+      }
+      const safeValue = typeof value === 'string' ? sanitizeText(value) : value;
+      node.setAttribute(key, safeValue);
     }
   }
   for (const child of children) {
     if (child == null) continue;
-    node.appendChild(typeof child === 'string' ? document.createTextNode(child) : child);
+    if (typeof child === 'string') {
+      node.appendChild(document.createTextNode(sanitizeText(child)));
+    } else {
+      node.appendChild(child);
+    }
   }
   return node;
 }

--- a/src/luthien_proxy/control_plane/static/conversation_view.js
+++ b/src/luthien_proxy/control_plane/static/conversation_view.js
@@ -1,21 +1,40 @@
+const SAFE_ATTR_PATTERN = /^[a-zA-Z_][\w:-]*$/;
+
+function sanitizeText(value) {
+  if (value == null) return '';
+  const text = String(value);
+  return text.replace(/[\u2028\u2029]/g, '');
+}
+
 function el(tag, attrs = {}, ...children) {
   const node = document.createElement(tag);
   for (const [key, value] of Object.entries(attrs)) {
     if (key === 'class') {
       node.className = value;
     } else if (key === 'text') {
-      node.textContent = value;
+      node.textContent = sanitizeText(value);
     } else if (key === 'dataset' && value && typeof value === 'object') {
       for (const [dataKey, dataValue] of Object.entries(value)) {
-        node.dataset[dataKey] = dataValue;
+        node.dataset[dataKey] = sanitizeText(dataValue);
       }
     } else {
-      node.setAttribute(key, value);
+      if (typeof key === 'string' && key.toLowerCase().startsWith('on')) {
+        throw new Error(`Event handler attributes are not allowed (saw ${key})`);
+      }
+      if (typeof key === 'string' && !SAFE_ATTR_PATTERN.test(key)) {
+        throw new Error(`Attribute name ${key} contains unsupported characters`);
+      }
+      const safeValue = typeof value === 'string' ? sanitizeText(value) : value;
+      node.setAttribute(key, safeValue);
     }
   }
   for (const child of children) {
     if (child == null) continue;
-    node.appendChild(typeof child === 'string' ? document.createTextNode(child) : child);
+    if (typeof child === 'string') {
+      node.appendChild(document.createTextNode(sanitizeText(child)));
+    } else {
+      node.appendChild(child);
+    }
   }
   return node;
 }

--- a/src/luthien_proxy/control_plane/utils/rate_limiter.py
+++ b/src/luthien_proxy/control_plane/utils/rate_limiter.py
@@ -1,0 +1,65 @@
+"""Asynchronous rate limiting utilities for FastAPI dependencies."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Dict
+
+
+class RateLimitExceeded(Exception):
+    """Raised when a rate limit would be exceeded."""
+
+
+@dataclass
+class _Bucket:
+    timestamps: Deque[float]
+
+
+class RateLimiter:
+    """Simple async token bucket rate limiter keyed by string identifiers."""
+
+    def __init__(self, max_events: int, window_seconds: float) -> None:
+        if max_events <= 0:
+            raise ValueError("max_events must be positive")
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+        self._max_events = max_events
+        self._window = window_seconds
+        self._lock = asyncio.Lock()
+        self._buckets: Dict[str, _Bucket] = {}
+
+    async def try_acquire(self, key: str) -> bool:
+        """Attempt to record an event for key, returning False if rate limited."""
+
+        now = time.monotonic()
+        async with self._lock:
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                bucket = _Bucket(deque())
+                self._buckets[key] = bucket
+            timestamps = bucket.timestamps
+            cutoff = now - self._window
+            while timestamps and timestamps[0] <= cutoff:
+                timestamps.popleft()
+            if len(timestamps) >= self._max_events:
+                return False
+            timestamps.append(now)
+            return True
+
+    async def acquire_or_raise(self, key: str) -> None:
+        """Acquire a slot for key or raise RateLimitExceeded."""
+
+        allowed = await self.try_acquire(key)
+        if not allowed:
+            raise RateLimitExceeded(f"Rate limit exceeded for key: {key}")
+
+    def clear(self) -> None:
+        """Reset all rate limit buckets (used in tests)."""
+
+        self._buckets.clear()
+
+
+__all__ = ["RateLimiter", "RateLimitExceeded"]

--- a/src/luthien_proxy/control_plane/utils/rate_limiter.py
+++ b/src/luthien_proxy/control_plane/utils/rate_limiter.py
@@ -22,6 +22,7 @@ class RateLimiter:
     """Simple async token bucket rate limiter keyed by string identifiers."""
 
     def __init__(self, max_events: int, window_seconds: float) -> None:
+        """Initialise a RateLimiter allowing max_events per window_seconds."""
         if max_events <= 0:
             raise ValueError("max_events must be positive")
         if window_seconds <= 0:
@@ -33,7 +34,6 @@ class RateLimiter:
 
     async def try_acquire(self, key: str) -> bool:
         """Attempt to record an event for key, returning False if rate limited."""
-
         now = time.monotonic()
         async with self._lock:
             bucket = self._buckets.get(key)
@@ -51,14 +51,12 @@ class RateLimiter:
 
     async def acquire_or_raise(self, key: str) -> None:
         """Acquire a slot for key or raise RateLimitExceeded."""
-
         allowed = await self.try_acquire(key)
         if not allowed:
             raise RateLimitExceeded(f"Rate limit exceeded for key: {key}")
 
     def clear(self) -> None:
         """Reset all rate limit buckets (used in tests)."""
-
         self._buckets.clear()
 
 

--- a/tests/integration_tests/control_plane/test_conversation_streaming.py
+++ b/tests/integration_tests/control_plane/test_conversation_streaming.py
@@ -1,0 +1,78 @@
+import asyncio
+from collections import deque
+
+import pytest
+
+from luthien_proxy.control_plane.conversation.streams import (
+    ConversationStreamConfig,
+    conversation_sse_stream,
+)
+
+
+class _FakePubSub:
+    def __init__(self, messages: deque[dict]):
+        self._messages = messages
+        self.unsubscribed = False
+        self.closed = False
+        self.channel = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.close()
+
+    async def subscribe(self, channel: str) -> None:
+        self.channel = channel
+
+    async def unsubscribe(self, channel: str) -> None:
+        self.unsubscribed = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def get_message(self, *, ignore_subscribe_messages: bool, timeout: float):
+        await asyncio.sleep(0)
+        if self._messages:
+            return self._messages.popleft()
+        try:
+            await asyncio.sleep(timeout)
+        except asyncio.CancelledError:
+            return None
+        return None
+
+
+class _FakeRedis:
+    def __init__(self, pubsub: _FakePubSub):
+        self._pubsub = pubsub
+        self.pubsub_call_kwargs = None
+
+    def pubsub(self, **kwargs):
+        self.pubsub_call_kwargs = kwargs
+        return self._pubsub
+
+
+@pytest.mark.asyncio
+async def test_conversation_stream_yields_events_and_heartbeat():
+    messages = deque([{"data": b'{"hello":"world"}'}])
+    fake_pubsub = _FakePubSub(messages)
+    redis = _FakeRedis(fake_pubsub)
+    config = ConversationStreamConfig(
+        heartbeat_seconds=0.01,
+        redis_poll_timeout_seconds=0.01,
+        rate_limit_max_requests=10,
+        rate_limit_window_seconds=1.0,
+    )
+
+    stream = conversation_sse_stream(redis, "call-123", config=config)
+
+    first = await asyncio.wait_for(anext(stream), timeout=0.5)
+    assert first == 'data: {"hello":"world"}\n\n'
+
+    await asyncio.sleep(0.02)
+    second = await asyncio.wait_for(anext(stream), timeout=0.5)
+    assert second == ": ping\n\n"
+
+    await stream.aclose()
+    await asyncio.sleep(0)
+    assert redis.pubsub_call_kwargs == {"close_connection": False}

--- a/tests/unit_tests/control_plane/test_rate_limiter.py
+++ b/tests/unit_tests/control_plane/test_rate_limiter.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import pytest
+
+from luthien_proxy.control_plane.utils.rate_limiter import RateLimitExceeded, RateLimiter
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_blocks_after_threshold():
+    limiter = RateLimiter(max_events=2, window_seconds=0.05)
+    assert await limiter.try_acquire("client") is True
+    assert await limiter.try_acquire("client") is True
+    assert await limiter.try_acquire("client") is False
+    await asyncio.sleep(0.06)
+    assert await limiter.try_acquire("client") is True
+
+
+@pytest.mark.asyncio
+async def test_acquire_or_raise_raises_when_exceeded():
+    limiter = RateLimiter(max_events=1, window_seconds=0.1)
+    await limiter.acquire_or_raise("client")
+    with pytest.raises(RateLimitExceeded):
+        await limiter.acquire_or_raise("client")
+    await asyncio.sleep(0.11)
+    await limiter.acquire_or_raise("client")

--- a/tests/unit_tests/control_plane/test_rate_limiter.py
+++ b/tests/unit_tests/control_plane/test_rate_limiter.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from luthien_proxy.control_plane.utils.rate_limiter import RateLimitExceeded, RateLimiter
+from luthien_proxy.control_plane.utils.rate_limiter import RateLimiter, RateLimitExceeded
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_litellm_callback.py
+++ b/tests/unit_tests/test_litellm_callback.py
@@ -214,7 +214,8 @@ def test_update_cumulative_choices():
     new_tokens = []
     response = {"choices": [{"index": 0, "delta": {"content": "Hello"}}, {"index": 1, "delta": {"content": "World"}}]}
 
-    LuthienCallback._update_cumulative_choices(cumulative_choices, cumulative_tokens, new_tokens, response)
+    callback = LuthienCallback()
+    callback._update_cumulative_choices(cumulative_choices, cumulative_tokens, new_tokens, response)
 
     assert len(cumulative_choices) == 2
     assert len(cumulative_tokens) == 2
@@ -235,4 +236,5 @@ def test_update_cumulative_choices_missing_index():
     }
 
     with pytest.raises(ValueError, match="choice missing index"):
-        LuthienCallback._update_cumulative_choices(cumulative_choices, cumulative_tokens, new_tokens, response)
+        callback = LuthienCallback()
+        callback._update_cumulative_choices(cumulative_choices, cumulative_tokens, new_tokens, response)


### PR DESCRIPTION
## Summary
- guard conversation stream chunk indices and LiteLLM chunk buffers against race conditions and unbounded growth
- sanitize conversation trace UI helpers to avoid DOM injection when rendering user-controlled content
- add configurable SSE stream settings with rate limiting plus coverage for streaming behaviour and limiter edge cases

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d70af8aee8832c9d64d11dd1665a9f