### PR TITLE
refactor: tighten json payload typing

### DIFF
--- a/scripts/trace_hooks.py
+++ b/scripts/trace_hooks.py
@@ -14,9 +14,11 @@ Outputs a timeline of hook invocations and includes the full request/response st
 import asyncio
 import json
 import os
-from typing import Any, Dict, List
+from typing import List, cast
 
 import httpx
+
+from luthien_proxy.types import JSONObject
 
 PROXY_URL = os.getenv("LITELLM_URL", "http://localhost:4000")
 CONTROL_URL = os.getenv("CONTROL_PLANE_URL", "http://localhost:8081")
@@ -28,13 +30,13 @@ async def clear_logs(client: httpx.AsyncClient) -> None:
     await client.delete(f"{CONTROL_URL}/api/hooks/logs")
 
 
-async def fetch_logs(client: httpx.AsyncClient) -> List[Dict[str, Any]]:
+async def fetch_logs(client: httpx.AsyncClient) -> List[JSONObject]:
     r = await client.get(f"{CONTROL_URL}/api/hooks/logs", params={"limit": 200})
     r.raise_for_status()
-    return r.json()
+    return cast(List[JSONObject], r.json())
 
 
-def pretty(entry: Dict[str, Any]) -> str:
+def pretty(entry: JSONObject) -> str:
     hook = entry.get("hook")
     when = entry.get("when")
     t0 = entry.get("t0")

--- a/src/luthien_proxy/control_plane/app.py
+++ b/src/luthien_proxy/control_plane/app.py
@@ -12,7 +12,7 @@ import os
 from collections import Counter
 from contextlib import asynccontextmanager
 from functools import partial
-from typing import Any, Optional
+from typing import Optional, TypedDict
 
 from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -59,6 +59,19 @@ from .hooks_routes import (
 from .policy_loader import load_policy_from_config
 from .utils.rate_limiter import RateLimiter
 
+
+class HealthPayload(TypedDict):
+    status: str
+    service: str
+    version: str
+
+
+class EndpointListing(TypedDict):
+    hooks: list[str]
+    ui: list[str]
+    health: str
+
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -67,13 +80,13 @@ STATIC_DIR = os.path.join(os.path.dirname(__file__), "static")
 
 
 @router.get("/health")
-async def health_check() -> dict[str, Any]:
+async def health_check() -> HealthPayload:
     """Return a simple health payload without touching external services."""
     return {"status": "healthy", "service": "luthien-control-plane", "version": "0.1.0"}
 
 
 @router.get("/endpoints")
-async def list_endpoints() -> dict[str, Any]:
+async def list_endpoints() -> EndpointListing:
     """List notable HTTP endpoints for quick discoverability."""
     return {
         "hooks": [

--- a/src/luthien_proxy/control_plane/conversation/events.py
+++ b/src/luthien_proxy/control_plane/conversation/events.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 from datetime import datetime
-from typing import Any, Dict, Iterable, Literal, Optional
+from typing import Iterable, Literal, Optional
 
 from .models import ConversationEvent, TraceEntry
 from .utils import (
@@ -19,13 +19,14 @@ from .utils import (
     require_dict,
     unwrap_response,
 )
+from luthien_proxy.types import JSONValue
 
 
 class _StreamIndexStore:
     """Track stream chunk counters per call under a re-entrant lock."""
 
     def __init__(self) -> None:
-        self._indices: Dict[str, Dict[str, int]] = {}
+        self._indices: dict[str, dict[str, int]] = {}
         self._lock = threading.RLock()
 
     def reset(self, call_id: str) -> None:
@@ -67,8 +68,8 @@ def build_conversation_events(
     hook: str,
     call_id: Optional[str],
     trace_id: Optional[str],
-    original: Any,
-    result: Any,
+    original: JSONValue | None,
+    result: JSONValue | None,
     timestamp_ns_fallback: int,
     timestamp: datetime,
 ) -> list[ConversationEvent]:
@@ -195,7 +196,7 @@ def build_conversation_events(
         return events
 
     if hook == "async_post_call_streaming_hook":
-        summary_payload = result if result is not None else original
+        summary_payload: JSONValue | None = result if result is not None else original
         summary_response = unwrap_response(summary_payload)
         final_text = ""
         try:

--- a/src/luthien_proxy/control_plane/conversation/models.py
+++ b/src/luthien_proxy/control_plane/conversation/models.py
@@ -7,6 +7,8 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
+from luthien_proxy.types import JSONObject
+
 
 class TraceEntry(BaseModel):
     """A single hook event for a call ID, optionally with nanosecond time."""
@@ -15,7 +17,7 @@ class TraceEntry(BaseModel):
     post_time_ns: Optional[int] = None
     hook: Optional[str] = None
     debug_type: Optional[str] = None
-    payload: dict[str, object]
+    payload: JSONObject
 
 
 class TraceResponse(BaseModel):
@@ -56,7 +58,7 @@ class ConversationEvent(BaseModel):
     sequence: int
     timestamp: datetime
     hook: str
-    payload: dict[str, object] = Field(default_factory=dict)
+    payload: JSONObject = Field(default_factory=dict)
 
 
 class ConversationMessageDiff(BaseModel):

--- a/src/luthien_proxy/control_plane/conversation/utils.py
+++ b/src/luthien_proxy/control_plane/conversation/utils.py
@@ -4,35 +4,39 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import Any, Iterable, Literal, Optional, Tuple
+from typing import Iterable, Literal, Optional, Tuple, cast
+
+from luthien_proxy.types import JSONArray, JSONObject, JSONValue
 
 
-def require_dict(value: Any, context: str) -> dict[str, Any]:
+def require_dict(value: object, context: str) -> JSONObject:
     """Ensure *value* is a dict, raising a descriptive error otherwise."""
     if not isinstance(value, dict):
         raise ValueError(f"{context} must be a dict; saw {type(value)!r}")
-    return value
+    if not all(isinstance(key, str) for key in value.keys()):
+        raise ValueError(f"{context} must use string keys; saw {list(value.keys())!r}")
+    return cast(JSONObject, value)
 
 
-def require_list(value: Any, context: str) -> list[Any]:
+def require_list(value: object, context: str) -> JSONArray:
     """Ensure *value* is a list, raising a descriptive error otherwise."""
     if not isinstance(value, list):
         raise ValueError(f"{context} must be a list; saw {type(value)!r}")
-    return value
+    return cast(JSONArray, value)
 
 
-def require_str(value: Any, context: str) -> str:
+def require_str(value: object, context: str) -> str:
     """Ensure *value* is a string, raising a descriptive error otherwise."""
     if not isinstance(value, str):
         raise ValueError(f"{context} must be a string; saw {type(value)!r}")
     return value
 
 
-def json_safe(value: Any) -> Any:
+def json_safe(value: object) -> JSONValue:
     """Recursively coerce *value* into a JSON-serializable structure."""
     try:
         json.dumps(value)
-        return value
+        return cast(JSONValue, value)
     except Exception:
         if isinstance(value, dict):
             return {str(k): json_safe(v) for k, v in value.items()}
@@ -46,7 +50,7 @@ def json_safe(value: Any) -> Any:
             return "<unserializable>"
 
 
-def message_content_to_text(content: Any) -> str:
+def message_content_to_text(content: JSONValue | None) -> str:
     """Flatten OpenAI-style message content into plain text."""
     if content is None:
         return ""
@@ -68,7 +72,7 @@ def message_content_to_text(content: Any) -> str:
     raise ValueError(f"Unexpected message content type: {type(content)!r}")
 
 
-def messages_from_payload(payload: Any) -> list[Tuple[str, str]]:
+def messages_from_payload(payload: object) -> list[Tuple[str, str]]:
     """Extract (role, content) tuples from a request payload."""
     payload_dict = require_dict(payload, "messages payload")
     container_key = "data" if "data" in payload_dict else "request_data"
@@ -81,7 +85,7 @@ def messages_from_payload(payload: Any) -> list[Tuple[str, str]]:
         msg_dict = require_dict(msg, f"message entry #{index}")
         role = require_str(msg_dict.get("role"), "message role")
         content = msg_dict.get("content")
-        out.append((role, message_content_to_text(content)))
+        out.append((role, message_content_to_text(cast(JSONValue | None, content))))
     return out
 
 
@@ -90,7 +94,7 @@ def format_messages(message_pairs: Iterable[Tuple[str, str]]) -> list[dict[str, 
     return [{"role": role, "content": content} for role, content in message_pairs]
 
 
-def extract_choice_index(chunk: Any) -> int:
+def extract_choice_index(chunk: object) -> int:
     """Return the index of the first choice in a streaming chunk."""
     chunk_dict = require_dict(chunk, "stream chunk")
     choices = require_list(chunk_dict.get("choices"), "stream chunk choices")
@@ -103,7 +107,7 @@ def extract_choice_index(chunk: Any) -> int:
     return idx
 
 
-def delta_from_chunk(chunk: Any) -> str:
+def delta_from_chunk(chunk: JSONValue | str | None) -> str:
     """Pull the textual delta from a streaming chunk payload."""
     if chunk is None:
         return ""
@@ -115,7 +119,7 @@ def delta_from_chunk(chunk: Any) -> str:
     return extract_delta_text(chunk_dict)
 
 
-def extract_stream_chunk(payload: Any) -> Any:
+def extract_stream_chunk(payload: object) -> JSONValue | None:
     """Peel off envelope wrappers to access the chunk payload."""
     if payload is None:
         return None
@@ -126,7 +130,7 @@ def extract_stream_chunk(payload: Any) -> Any:
     return payload_dict
 
 
-def extract_trace_id(payload: Any) -> Optional[str]:
+def extract_trace_id(payload: object) -> Optional[str]:
     """Find a trace identifier within a request payload if present."""
     if not isinstance(payload, dict):
         return None
@@ -149,7 +153,7 @@ def extract_trace_id(payload: Any) -> Optional[str]:
     return None
 
 
-def unwrap_response(payload: Any) -> Any:
+def unwrap_response(payload: object) -> JSONValue | None:
     """Return the response object nested within a hook payload."""
     if payload is None:
         return None
@@ -160,7 +164,7 @@ def unwrap_response(payload: Any) -> Any:
     return payload_dict
 
 
-def extract_response_text(response: Any) -> str:
+def extract_response_text(response: object) -> str:
     """Convert an LLM response payload into plain text."""
     if response is None:
         return ""
@@ -184,7 +188,7 @@ def extract_response_text(response: Any) -> str:
     raise ValueError("Unrecognized response payload structure")
 
 
-def extract_post_time_ns_from_any(value: Any) -> Optional[int]:
+def extract_post_time_ns_from_any(value: object) -> Optional[int]:
     """Search arbitrarily nested data for a `post_time_ns` integer."""
     if isinstance(value, dict):
         candidate = value.get("post_time_ns")
@@ -208,7 +212,7 @@ def extract_post_time_ns_from_any(value: Any) -> Optional[int]:
     return None
 
 
-def derive_sequence_ns(fallback_ns: int, *candidates: Any) -> int:
+def derive_sequence_ns(fallback_ns: int, *candidates: object) -> int:
     """Pick the first available `post_time_ns`, falling back to *fallback_ns*."""
     for candidate in candidates:
         ns = extract_post_time_ns_from_any(candidate)
@@ -217,16 +221,16 @@ def derive_sequence_ns(fallback_ns: int, *candidates: Any) -> int:
     return fallback_ns
 
 
-def strip_post_time_ns(value: Any) -> Any:
+def strip_post_time_ns(value: JSONValue) -> JSONValue:
     """Remove `post_time_ns` keys from nested structures."""
     if isinstance(value, dict):
         return {key: strip_post_time_ns(inner) for key, inner in value.items() if key != "post_time_ns"}
     if isinstance(value, list):
-        return [strip_post_time_ns(item) for item in value]
+        return [strip_post_time_ns(cast(JSONValue, item)) for item in value]
     return value
 
 
-def message_equals(a: Optional[dict[str, Any]], b: Optional[dict[str, Any]]) -> bool:
+def message_equals(a: Optional[JSONObject], b: Optional[JSONObject]) -> bool:
     """Return True if two role/content dictionaries are equal."""
     if a is None or b is None:
         return False
@@ -235,7 +239,7 @@ def message_equals(a: Optional[dict[str, Any]], b: Optional[dict[str, Any]]) -> 
     ) == (b.get("content") or "")
 
 
-def clone_messages(messages: Iterable[dict[str, Any]]) -> list[dict[str, str]]:
+def clone_messages(messages: Iterable[JSONObject]) -> list[dict[str, str]]:
     """Create shallow copies of role/content message dictionaries."""
     cloned: list[dict[str, str]] = []
     for msg in messages:

--- a/src/luthien_proxy/control_plane/debug_records.py
+++ b/src/luthien_proxy/control_plane/debug_records.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 
 from luthien_proxy.utils import db
+from luthien_proxy.types import JSONObject
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 async def record_debug_event(
     pool: db.DatabasePool,
     debug_type: str,
-    payload: dict[str, Any],
+    payload: JSONObject,
 ) -> None:
     """Persist a debug entry for later inspection (best-effort)."""
     try:

--- a/src/luthien_proxy/control_plane/dependencies.py
+++ b/src/luthien_proxy/control_plane/dependencies.py
@@ -3,17 +3,18 @@
 from __future__ import annotations
 
 from collections import Counter
-from typing import Any, Callable, Coroutine, Optional, Protocol, cast
+from typing import Awaitable, Callable, Optional, Protocol, cast
 
 from fastapi import Request
 
 from luthien_proxy.policies.base import LuthienPolicy
 from luthien_proxy.utils import db, redis_client
 from luthien_proxy.utils.project_config import ConversationStreamConfig, ProjectConfig
+from luthien_proxy.types import JSONObject
 
 from .utils.rate_limiter import RateLimiter
 
-DebugLogWriter = Callable[[str, dict[str, Any]], Coroutine[Any, Any, None]]
+DebugLogWriter = Callable[[str, JSONObject], Awaitable[None]]
 
 
 class AppState(Protocol):

--- a/src/luthien_proxy/control_plane/policy_loader.py
+++ b/src/luthien_proxy/control_plane/policy_loader.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Optional, cast
+from typing import Callable, Optional, cast
 
 import yaml
 
 from luthien_proxy.policies.base import LuthienPolicy
 from luthien_proxy.policies.noop import NoOpPolicy
 from luthien_proxy.utils.project_config import ProjectConfig
+from luthien_proxy.types import JSONObject
+from luthien_proxy.control_plane.conversation.utils import json_safe
 
 logger = logging.getLogger(__name__)
 
@@ -24,32 +26,40 @@ def load_policy_from_config(
     if not resolved_path:
         raise RuntimeError("LUTHIEN_POLICY_CONFIG must be set to load a policy")
 
-    def _read(path: str) -> tuple[Optional[str], Optional[dict[str, Any]]]:
+    def _read(path: str) -> tuple[Optional[str], Optional[JSONObject]]:
         if not os.path.exists(path):
             logger.warning("Policy config not found at %s; using NoOpPolicy", path)
             return None, None
         try:
             with open(path, "r", encoding="utf-8") as file:
                 cfg = yaml.safe_load(file) or {}
-            return cfg.get("policy"), (cfg.get("policy_options") or None)
+            policy_ref = cfg.get("policy")
+            raw_options = cfg.get("policy_options")
+            options: Optional[JSONObject] = None
+            if isinstance(raw_options, dict):
+                options = {str(k): json_safe(v) for k, v in raw_options.items()}
+            return policy_ref, options
         except Exception as exc:
             logger.error("Failed to read policy config %s: %s", path, exc)
             return None, None
 
-    def _import(ref: str):
+    def _import(ref: str) -> tuple[type[LuthienPolicy] | None, str | None, str | None]:
         try:
             module_path, class_name = ref.split(":", 1)
             module = __import__(module_path, fromlist=[class_name])
             cls = getattr(module, class_name)
-            return cls, module_path, class_name
+            if not isinstance(cls, type):
+                raise TypeError(f"{class_name} is not a class")
+            return cast(type[LuthienPolicy], cls), module_path, class_name
         except Exception as exc:
             logger.error("Failed to import policy '%s': %s", ref, exc)
             return None, None, None
 
-    def _instantiate(cls, options: Optional[dict[str, Any]]) -> LuthienPolicy:
+    def _instantiate(cls: type[LuthienPolicy], options: Optional[JSONObject]) -> LuthienPolicy:
         if options is not None:
             try:
-                return cast(Any, cls)(options=options)
+                ctor = cast(Callable[..., LuthienPolicy], cls)
+                return ctor(options=options)
             except TypeError:
                 pass
         return cls()

--- a/src/luthien_proxy/policies/all_caps.py
+++ b/src/luthien_proxy/policies/all_caps.py
@@ -8,9 +8,30 @@ Behavior:
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from copy import deepcopy
+from typing import Optional
 
 from .base import LuthienPolicy
+from luthien_proxy.control_plane.conversation.utils import require_dict, require_list
+from luthien_proxy.types import JSONObject
+
+
+def _uppercase_choices(response: JSONObject) -> JSONObject:
+    mutated = deepcopy(response)
+    choices = require_list(mutated.get("choices"), "response choices")
+    for index, choice_value in enumerate(choices):
+        choice = require_dict(choice_value, f"response choice #{index}")
+        if "delta" in choice:
+            delta = require_dict(choice["delta"], f"response choice #{index}.delta")
+            content = delta.get("content")
+            if isinstance(content, str):
+                delta["content"] = content.upper()
+        if "message" in choice:
+            message = require_dict(choice["message"], f"response choice #{index}.message")
+            content = message.get("content")
+            if isinstance(content, str):
+                message["content"] = content.upper()
+    return mutated
 
 
 class AllCapsPolicy(LuthienPolicy):
@@ -18,27 +39,18 @@ class AllCapsPolicy(LuthienPolicy):
 
     async def async_post_call_streaming_iterator_hook(
         self,
-        user_api_key_dict: Optional[dict[str, Any]],
-        response: Any,
-        request_data: dict[str, Any],
-    ) -> Optional[dict[str, Any]]:
+        user_api_key_dict: Optional[JSONObject],
+        response: JSONObject,
+        request_data: JSONObject,
+    ) -> Optional[JSONObject]:
         """Uppercase streaming delta content per chunk when possible."""
-        try:
-            response = dict(response)
-            for c in response.get("choices", []):
-                c["delta"]["content"] = c["delta"]["content"].upper()
-            return response
-        except Exception:
-            # On any failure, keep original
-            return response
+        return _uppercase_choices(response)
 
-    async def async_post_call_success_hook(self, **kwargs: Any) -> dict[str, Any]:
+    async def async_post_call_success_hook(
+        self,
+        *,
+        response_obj: JSONObject,
+        **_unused: object,
+    ) -> JSONObject:
         """Uppercase content in a non-streaming final response."""
-        try:
-            response = dict(kwargs.get("response_obj", {}))
-            for c in response.get("choices", []):
-                c["delta"]["content"] = c["delta"]["content"].upper()
-            return response
-        except Exception:
-            # On any failure, keep original
-            return kwargs.get("response_obj", {})
+        return _uppercase_choices(response_obj)

--- a/src/luthien_proxy/policies/noop.py
+++ b/src/luthien_proxy/policies/noop.py
@@ -4,9 +4,10 @@ Users can implement their own policies by providing the same methods and
 setting the LUTHIEN_POLICY env var to "module.path:ClassName".
 """
 
-from typing import Any, Optional
+from typing import Optional
 
 from .base import LuthienPolicy
+from luthien_proxy.types import JSONObject
 
 
 class NoOpPolicy(LuthienPolicy):
@@ -14,9 +15,9 @@ class NoOpPolicy(LuthienPolicy):
 
     async def async_post_call_success_hook(
         self,
-        data: dict[str, Any],
-        user_api_key_dict: Optional[dict[str, Any]],
-        response: dict[str, Any],
-    ) -> Optional[dict[str, Any]]:
+        data: JSONObject,
+        user_api_key_dict: Optional[JSONObject],
+        response: JSONObject,
+    ) -> Optional[JSONObject]:
         """Return the unmodified final response for non-streaming calls."""
         return response

--- a/src/luthien_proxy/types.py
+++ b/src/luthien_proxy/types.py
@@ -1,0 +1,18 @@
+"""Shared type aliases for structured data passed around the proxy."""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+from pydantic import JsonValue
+
+
+# NOTE: We eagerly constrain JSON-like payloads rather than relying on ``Any``
+# so that type checkers surface incorrect assumptions immediately. These
+# aliases align with Pydantic's built-in JSON semantics.
+JSONValue: TypeAlias = JsonValue
+JSONObject: TypeAlias = dict[str, JsonValue]
+JSONArray: TypeAlias = list[JsonValue]
+
+
+__all__ = ["JSONValue", "JSONObject", "JSONArray"]

--- a/src/luthien_proxy/utils/db.py
+++ b/src/luthien_proxy/utils/db.py
@@ -3,20 +3,23 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 from contextlib import asynccontextmanager
-from typing import Any, AsyncContextManager, AsyncIterator, Awaitable, Callable, Protocol
+from typing import AsyncContextManager, AsyncIterator, Awaitable, Callable, Protocol
 
 import asyncpg
 
 
+class ConnectionProtocol(Protocol):
+    async def close(self) -> None: ...
+
+
 class PoolProtocol(Protocol):
-    def acquire(self) -> AsyncContextManager[Any]: ...
+    def acquire(self) -> AsyncContextManager[ConnectionProtocol]: ...
 
-    async def close(self) -> Any: ...
+    async def close(self) -> None: ...
 
 
-ConnectFn = Callable[[str], Awaitable[Any]]
+ConnectFn = Callable[[str], Awaitable[ConnectionProtocol]]
 PoolFactory = Callable[..., Awaitable[PoolProtocol]]
 
 
@@ -30,7 +33,7 @@ def get_pool_factory() -> PoolFactory:
     return asyncpg.create_pool
 
 
-async def open_connection(connect: ConnectFn | None = None, url: str | None = None) -> Any:
+async def open_connection(connect: ConnectFn | None = None, url: str | None = None) -> ConnectionProtocol:
     """Open a database connection using the provided connector."""
     if url is None:
         raise RuntimeError("Database URL must be provided")
@@ -38,21 +41,16 @@ async def open_connection(connect: ConnectFn | None = None, url: str | None = No
     return await connector(url)
 
 
-async def close_connection(conn: Any) -> None:
-    """Close a database connection if it supports an async close."""
-    close = getattr(conn, "close", None)
-    if not callable(close):
-        return
-    result = close()
-    if inspect.isawaitable(result):
-        await result
+async def close_connection(conn: ConnectionProtocol) -> None:
+    """Close a database connection."""
+    await conn.close()
 
 
 async def create_pool(
     factory: PoolFactory | None = None,
     url: str | None = None,
-    **kwargs: Any,
-) -> Any:
+    **kwargs: object,
+) -> PoolProtocol:
     """Create a connection pool using the provided factory."""
     if url is None:
         raise RuntimeError("Database URL must be provided")
@@ -68,7 +66,7 @@ class DatabasePool:
         url: str,
         *,
         factory: PoolFactory | None = None,
-        **pool_kwargs: Any,
+        **pool_kwargs: object,
     ) -> None:
         """Initialize the database connection pool."""
         if not url:
@@ -94,7 +92,7 @@ class DatabasePool:
         return self._pool
 
     @asynccontextmanager
-    async def connection(self) -> AsyncIterator[Any]:
+    async def connection(self) -> AsyncIterator[ConnectionProtocol]:
         """Yield a connection from the shared pool."""
         pool = await self.get_pool()
         async with pool.acquire() as conn:

--- a/tests/unit_tests/control_plane/test_app_hook_generic.py
+++ b/tests/unit_tests/control_plane/test_app_hook_generic.py
@@ -1,18 +1,18 @@
 import asyncio
 from collections import Counter
-from typing import Any
 
 import pytest
 
 import luthien_proxy.control_plane.app as app_mod
 from luthien_proxy.policies.noop import NoOpPolicy
+from luthien_proxy.types import JSONObject
 
 
 class _Recorder:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.calls: list[tuple[str, JSONObject]] = []
 
-    async def __call__(self, debug_type: str, payload: dict[str, Any], *_args, **_kwargs) -> None:
+    async def __call__(self, debug_type: str, payload: JSONObject, *_args: object, **_kwargs: object) -> None:
         self.calls.append((debug_type, payload))
 
 


### PR DESCRIPTION
## Summary
- add a shared JSON type alias module and update conversation utilities to validate payloads strictly
- propagate typed payloads through hook handling, policy loading, and example policies to fail fast on malformed data
- align debug tooling, database helpers, and tests with the new JSON typing and serialization helpers

## Testing
- `uv run pytest tests/unit_tests`


------
https://chatgpt.com/codex/tasks/task_e_68d88a6449b8832c9d1d3daf5c418fc1