### PR TITLE
refactor: tighten hook payload typing

### DIFF
--- a/src/luthien_proxy/control_plane/app.py
+++ b/src/luthien_proxy/control_plane/app.py
@@ -12,7 +12,7 @@ import os
 from collections import Counter
 from contextlib import asynccontextmanager
 from functools import partial
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -67,13 +67,13 @@ STATIC_DIR = os.path.join(os.path.dirname(__file__), "static")
 
 
 @router.get("/health")
-async def health_check() -> dict[str, Any]:
+async def health_check() -> dict[str, str]:
     """Return a simple health payload without touching external services."""
     return {"status": "healthy", "service": "luthien-control-plane", "version": "0.1.0"}
 
 
 @router.get("/endpoints")
-async def list_endpoints() -> dict[str, Any]:
+async def list_endpoints() -> dict[str, list[str] | str]:
     """List notable HTTP endpoints for quick discoverability."""
     return {
         "hooks": [

--- a/src/luthien_proxy/control_plane/conversation/db.py
+++ b/src/luthien_proxy/control_plane/conversation/db.py
@@ -3,30 +3,33 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Optional
+from typing import Mapping, Optional
 
 from fastapi import HTTPException
 
+from luthien_proxy.control_plane.conversation.utils import json_safe
 from luthien_proxy.utils import db
 from luthien_proxy.utils.project_config import ProjectConfig
 
 from .models import TraceEntry
 
 
-def parse_jsonblob(raw: Any) -> dict[str, Any]:
+def parse_jsonblob(raw: object) -> dict[str, object]:
     """Deserialize a debug log JSON blob into a dictionary."""
     if isinstance(raw, dict):
         return raw
     if isinstance(raw, str):
         try:
             parsed = json.loads(raw)
-            return parsed if isinstance(parsed, dict) else {"raw": raw}
+            if isinstance(parsed, dict):
+                return parsed
+            return {"raw": json_safe(parsed)}
         except Exception:
             return {"raw": raw}
-    return {"raw": raw}
+    return {"raw": json_safe(raw)}
 
 
-def extract_post_ns(jb: dict[str, Any]) -> Optional[int]:
+def extract_post_ns(jb: dict[str, object]) -> Optional[int]:
     """Extract `post_time_ns` from a log payload when present."""
     payload = jb.get("payload")
     if not isinstance(payload, dict):
@@ -39,7 +42,7 @@ def extract_post_ns(jb: dict[str, Any]) -> Optional[int]:
     return None
 
 
-def _row_to_trace_entry(row: Any) -> TraceEntry:
+def _row_to_trace_entry(row: Mapping[str, object]) -> TraceEntry:
     jb = parse_jsonblob(row["jsonblob"])
     return TraceEntry(
         time=row["time_created"],

--- a/src/luthien_proxy/control_plane/conversation/events.py
+++ b/src/luthien_proxy/control_plane/conversation/events.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import threading
 from datetime import datetime
-from typing import Any, Dict, Iterable, Literal, Optional
+from typing import Dict, Iterable, Literal, Optional
 
 from .models import ConversationEvent, TraceEntry
 from .utils import (
+    JSONValue,
     delta_from_chunk,
     derive_sequence_ns,
     extract_choice_index,
@@ -67,8 +68,8 @@ def build_conversation_events(
     hook: str,
     call_id: Optional[str],
     trace_id: Optional[str],
-    original: Any,
-    result: Any,
+    original: JSONValue | None,
+    result: JSONValue | None,
     timestamp_ns_fallback: int,
     timestamp: datetime,
 ) -> list[ConversationEvent]:

--- a/src/luthien_proxy/control_plane/conversation/models.py
+++ b/src/luthien_proxy/control_plane/conversation/models.py
@@ -7,7 +7,6 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
-
 class TraceEntry(BaseModel):
     """A single hook event for a call ID, optionally with nanosecond time."""
 

--- a/src/luthien_proxy/control_plane/debug_records.py
+++ b/src/luthien_proxy/control_plane/debug_records.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 
+from luthien_proxy.control_plane.conversation.utils import JSONValue
 from luthien_proxy.utils import db
 
 logger = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 async def record_debug_event(
     pool: db.DatabasePool,
     debug_type: str,
-    payload: dict[str, Any],
+    payload: dict[str, JSONValue],
 ) -> None:
     """Persist a debug entry for later inspection (best-effort)."""
     try:

--- a/src/luthien_proxy/control_plane/debug_routes.py
+++ b/src/luthien_proxy/control_plane/debug_routes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
@@ -26,7 +26,7 @@ class DebugEntry(BaseModel):
     id: str
     time_created: datetime
     debug_type_identifier: str
-    jsonblob: dict[str, Any]
+    jsonblob: dict[str, object]
 
 
 class DebugTypeInfo(BaseModel):
@@ -77,6 +77,8 @@ async def get_debug_entries(
                         jb = json.loads(jb)
                     except Exception:
                         jb = {"raw": jb}
+                if not isinstance(jb, dict):
+                    jb = {"raw": jb}
                 entries.append(
                     DebugEntry(
                         id=str(row["id"]),
@@ -164,6 +166,8 @@ async def get_debug_page(
                         jb = json.loads(jb)
                     except Exception:
                         jb = {"raw": jb}
+                if not isinstance(jb, dict):
+                    jb = {"raw": jb}
                 items.append(
                     DebugEntry(
                         id=str(row["id"]),

--- a/src/luthien_proxy/control_plane/dependencies.py
+++ b/src/luthien_proxy/control_plane/dependencies.py
@@ -3,17 +3,18 @@
 from __future__ import annotations
 
 from collections import Counter
-from typing import Any, Callable, Coroutine, Optional, Protocol, cast
+from typing import Awaitable, Callable, Optional, Protocol, cast
 
 from fastapi import Request
 
+from luthien_proxy.control_plane.conversation.utils import JSONValue
 from luthien_proxy.policies.base import LuthienPolicy
 from luthien_proxy.utils import db, redis_client
 from luthien_proxy.utils.project_config import ConversationStreamConfig, ProjectConfig
 
 from .utils.rate_limiter import RateLimiter
 
-DebugLogWriter = Callable[[str, dict[str, Any]], Coroutine[Any, Any, None]]
+DebugLogWriter = Callable[[str, dict[str, JSONValue]], Awaitable[None]]
 
 
 class AppState(Protocol):

--- a/src/luthien_proxy/control_plane/hooks_routes.py
+++ b/src/luthien_proxy/control_plane/hooks_routes.py
@@ -10,7 +10,7 @@ import time
 from collections import Counter
 from copy import deepcopy
 from datetime import datetime, timezone
-from typing import Any, Awaitable, Callable, Optional, cast
+from typing import Awaitable, Callable, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import StreamingResponse
@@ -34,7 +34,7 @@ from luthien_proxy.control_plane.conversation import (
     publish_trace_conversation_event,
     strip_post_time_ns,
 )
-from luthien_proxy.control_plane.conversation.utils import extract_trace_id
+from luthien_proxy.control_plane.conversation.utils import JSONValue, extract_trace_id
 from luthien_proxy.control_plane.utils.hooks import extract_call_id_for_hook
 from luthien_proxy.policies.base import LuthienPolicy
 from luthien_proxy.utils import db, redis_client
@@ -84,17 +84,17 @@ async def get_hook_counters(
 @router.post("/api/hooks/{hook_name}")
 async def hook_generic(
     hook_name: str,
-    payload: dict[str, Any],
+    payload: dict[str, JSONValue],
     debug_writer: DebugLogWriter = Depends(get_debug_log_writer),
     policy: LuthienPolicy = Depends(get_active_policy),
     counters: Counter[str] = Depends(get_hook_counter_state),
     redis_conn: redis_client.RedisClient = Depends(get_redis_client),
-) -> Any:
+) -> JSONValue:
     """Generic hook endpoint for any CustomLogger hook."""
     try:
         record_payload = json_safe(payload)
         stored_payload = deepcopy(record_payload)
-        record = {
+        record: dict[str, JSONValue] = {
             "hook": hook_name,
             "payload": record_payload,
         }
@@ -106,7 +106,7 @@ async def hook_generic(
         except Exception:
             pass
 
-        stored_record: dict[str, Any] = {"hook": hook_name, "payload": stored_payload}
+        stored_record: dict[str, JSONValue] = {"hook": hook_name, "payload": stored_payload}
         trace_id = extract_trace_id(payload)
         if trace_id:
             record["litellm_trace_id"] = trace_id
@@ -117,13 +117,15 @@ async def hook_generic(
         name = hook_name.lower()
         counters[name] += 1
         handler = cast(
-            Optional[Callable[..., Awaitable[Any]]],
+            Optional[Callable[..., Awaitable[dict[str, JSONValue] | None]]],
             getattr(policy, name, None),
         )
 
-        handler_result = None
+        handler_result: dict[str, JSONValue] | None = None
         if handler:
             policy_payload = strip_post_time_ns(payload)
+            if not isinstance(policy_payload, dict):
+                raise TypeError("Policy payload must remain a JSON object")
             signature = inspect.signature(handler)
             parameters = signature.parameters
             accepts_var_kw = any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values())
@@ -133,11 +135,13 @@ async def hook_generic(
                 parameter_names = {name for name in parameters.keys() if name != "self"}
                 filtered_payload = {k: v for k, v in policy_payload.items() if k in parameter_names}
             handler_result = await handler(**filtered_payload)
-        final_result = handler_result if handler_result is not None else payload
+            if handler_result is not None and not isinstance(handler_result, dict):
+                raise TypeError("Policy handlers must return a JSON object or None")
+        final_result: dict[str, JSONValue] = handler_result if handler_result is not None else payload
 
         sanitized_result = json_safe(final_result)
 
-        result_record = {
+        result_record: dict[str, JSONValue] = {
             "hook": hook_name,
             "litellm_call_id": record.get("litellm_call_id"),
             "original": stored_payload,

--- a/tests/unit_tests/control_plane/test_app_hook_generic.py
+++ b/tests/unit_tests/control_plane/test_app_hook_generic.py
@@ -1,6 +1,5 @@
 import asyncio
 from collections import Counter
-from typing import Any
 
 import pytest
 
@@ -10,9 +9,9 @@ from luthien_proxy.policies.noop import NoOpPolicy
 
 class _Recorder:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.calls: list[tuple[str, dict[str, object]]] = []
 
-    async def __call__(self, debug_type: str, payload: dict[str, Any], *_args, **_kwargs) -> None:
+    async def __call__(self, debug_type: str, payload: dict[str, object], *_args, **_kwargs) -> None:
         self.calls.append((debug_type, payload))
 
 


### PR DESCRIPTION
## Summary
- introduce a JSONValue alias and use it across conversation utilities to validate hook payload shapes
- enforce structured hook payloads throughout the hook ingestion flow, including the FastAPI dependencies, debug logging, and policy loader
- narrow lightweight endpoint return types to concrete dict signatures to remove defensive Any usage

## Testing
- uv run pytest --no-cov tests/unit_tests/control_plane/test_app_hook_generic.py

------
https://chatgpt.com/codex/tasks/task_e_68d88a6449b8832c9d1d3daf5c418fc1