### PR TITLE
refactor: remove legacy proxy fallbacks

### DIFF
--- a/src/luthien_proxy/control_plane/utils/hooks.py
+++ b/src/luthien_proxy/control_plane/utils/hooks.py
@@ -42,19 +42,15 @@ def extract_call_id_for_hook(hook: str, payload: JSONObject) -> Optional[str]:
         ],
         "async_post_call_success_hook": [
             ["data", "litellm_metadata", "model_info", "id"],
-            ["data", "litellm_call_id"],  # Fallback/legacy
         ],
         "async_post_call_streaming_iterator_hook": [
             ["request_data", "litellm_metadata", "model_info", "id"],
-            ["request_data", "litellm_call_id"],  # Fallback/legacy
         ],
         "async_post_call_streaming_hook": [
             ["data", "litellm_metadata", "model_info", "id"],
-            ["data", "litellm_call_id"],  # Fallback/legacy
         ],
         "async_post_call_failure_hook": [
             ["request_data", "litellm_metadata", "model_info", "id"],
-            ["request_data", "litellm_call_id"],  # Fallback/legacy
         ],
     }
     paths = hook_to_id_paths.get(hook)

--- a/src/luthien_proxy/policies/base.py
+++ b/src/luthien_proxy/policies/base.py
@@ -61,27 +61,6 @@ class LuthienPolicy(ABC, CustomLogger):
             yield chunk
 
     # ------------------------------------------------------------------
-    # Legacy HTTP hook compatibility
-    # ------------------------------------------------------------------
-    async def async_post_call_streaming_iterator_hook(
-        self,
-        user_api_key_dict: Optional[dict],
-        response: dict,
-        request_data: dict,
-    ) -> Optional[dict]:
-        """Fallback path used by the legacy HTTP hook endpoint."""
-        stream_id = str(request_data.get("litellm_call_id") or "fallback-stream")
-        context = self.create_stream_context(stream_id, request_data)
-
-        async def single_chunk_stream() -> AsyncIterator[dict]:
-            yield response
-
-        async for transformed in self.generate_response_stream(context, single_chunk_stream()):
-            return transformed
-
-        return response
-
-    # ------------------------------------------------------------------
     # Debug logging helpers
     # ------------------------------------------------------------------
     def set_debug_log_writer(self, writer: Optional[DebugLogWriter]) -> None:

--- a/src/luthien_proxy/utils/conversation_parsing.py
+++ b/src/luthien_proxy/utils/conversation_parsing.py
@@ -77,26 +77,6 @@ def parse_tool_calls(value: Any, *, allow_empty: bool = False) -> list[dict[str,
     return parsed
 
 
-def parse_legacy_function_call(payload: Any) -> dict[str, str]:
-    """Parse a legacy function_call payload into tool call format."""
-    if not isinstance(payload, Mapping):
-        raise TypeError("function_call payload must be a mapping")
-    name = payload.get("name")
-    if not isinstance(name, str) or not name:
-        raise ValueError("function_call name must be a non-empty string")
-    arguments = payload.get("arguments")
-    if not isinstance(arguments, str):
-        raise TypeError("function_call arguments must be a string")
-    raw_id = payload.get("id")
-    identifier = raw_id if isinstance(raw_id, str) and raw_id else "legacy_function_call"
-    return {
-        "id": identifier,
-        "type": "function",
-        "name": name,
-        "arguments": arguments,
-    }
-
-
 def content_to_text(content: Any) -> str:
     """Convert message content to plain text string."""
     if content is None:
@@ -168,7 +148,6 @@ __all__ = [
     "require_call_id",
     "extract_trace_id",
     "parse_tool_calls",
-    "parse_legacy_function_call",
     "content_to_text",
     "format_messages",
 ]

--- a/tests/unit_tests/control_plane/utils/test_hooks.py
+++ b/tests/unit_tests/control_plane/utils/test_hooks.py
@@ -6,21 +6,21 @@ def test_extract_call_id_known_hooks():
     assert (
         extract_call_id_for_hook(
             "async_post_call_success_hook",
-            {"data": {"litellm_call_id": "B"}},
+            {"data": {"litellm_metadata": {"model_info": {"id": "B"}}}},
         )
         == "B"
     )
     assert (
         extract_call_id_for_hook(
             "async_post_call_streaming_iterator_hook",
-            {"request_data": {"litellm_call_id": "C"}},
+            {"request_data": {"litellm_metadata": {"model_info": {"id": "C"}}}},
         )
         == "C"
     )
     assert (
         extract_call_id_for_hook(
             "async_post_call_streaming_hook",
-            {"data": {"litellm_call_id": "D"}},
+            {"data": {"litellm_metadata": {"model_info": {"id": "D"}}}},
         )
         == "D"
     )


### PR DESCRIPTION
## Summary
- remove legacy LiteLLM call-id fallbacks now that only modern payloads are supported
- simplify tool call buffering to handle only `tool_calls` entries and drop legacy function_call parsing
- delete the HTTP streaming iterator fallback from the base policy

## Testing
- uv run pytest tests/unit_tests/policies/test_tool_call_buffer_policy.py tests/unit_tests/control_plane/utils/test_hooks.py

------
https://chatgpt.com/codex/tasks/task_e_68e79d4d356c832c8d1e544b2e61e88f