### PR TITLE
docs: document migration footgun

### DIFF
--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -14,6 +14,10 @@
   - Run `migrations/001_add_policy_config_table.sql` against luthien_control database
   - Verify table creation and indexes
   - Test policy persistence by enabling a policy via admin API
+- [ ] **Fix Migration Strategy** - Resolve docker-entrypoint-initdb.d footgun ([#78](https://github.com/LuthienResearch/luthien-proxy/issues/78)):
+  - Decide between Pure Prisma vs Pure SQL + tracking
+  - Currently have conflicting systems causing incremental migrations to be skipped
+  - Blocks anyone with existing DB who pulls new migrations
 - [ ] **Policy Discovery/Listing** - Implement `/admin/policy/list` endpoint:
   - Add metadata to policy classes (name, description, example, use_case)
   - Implement policy scanning/registration in PolicyManager

--- a/dev/context/gotchas.md
+++ b/dev/context/gotchas.md
@@ -55,6 +55,13 @@ If updating existing content significantly, note it: `## Topic (2025-10-08, upda
 - Use `Delta(content=text)` not `{"content": text}` - dicts break SSE assembly
 - Use `StreamingChoices` not `Choices` for streaming (utils.py create_text_chunk)
 
+## Database Migrations Don't Auto-Apply to Existing Databases (2025-12-01)
+
+- `docker-entrypoint-initdb.d` only runs on initial Postgres volume creation, not on restarts
+- Pulling new migrations won't apply them to existing databases - causes `relation does not exist` errors
+- **Fix**: `docker compose down -v && ./scripts/quick_start.sh` (wipes data) or apply manually via `docker compose exec -T db psql`
+- See [#78](https://github.com/LuthienResearch/luthien-proxy/issues/78) for root cause and long-term fix
+
 ---
 
 (Add gotchas as discovered with timestamps: YYYY-MM-DD)


### PR DESCRIPTION
Documents the database migration footgun discovered when Policy Config UI failed with `relation "policy_config" does not exist`.

## Changes
- Added migration strategy issue to TODO.md High Priority section  
- Documented docker-entrypoint-initdb.d gotcha in context/gotchas.md
- Links to #78 for full technical details and long-term fix options

## Context
The issue exists on main - `docker-entrypoint-initdb.d` only runs on initial DB creation, so new migrations aren't applied to existing databases. This PR just adds documentation so others can find the workaround quickly.

See #78 for the full root cause analysis and decision needed on migration strategy.