### PR TITLE
Clean up completed TODO item

### DIFF
--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -12,7 +12,6 @@
 
 ### Code Quality
 
-- [ ] **Replace magic numbers with named constants** - queue_size, max_chunks_queued, truncation lengths
 - [ ] **Factor out common gateway route logic** - Extract duplicate pipeline setup from `/v1/chat/completions` and `/v1/messages`
 
 ### Documentation (High)


### PR DESCRIPTION
Remove 'Replace magic numbers with named constants' from TODO.md since it was completed in PR #93.