### PR TITLE
Fix TEST_MODEL default value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,7 @@ OLLAMA_PORT=11434
 # Test model used by local scripts (trace/sanity/tests)
 # Set this to a model that exists for your API keys when calling through the proxy
 # e.g., gpt-4o, gpt-4o-mini, or a local model via the local LLM gateway
-TEST_MODEL=gpt-5
+TEST_MODEL=gpt-4o-mini
 
 # OpenTelemetry Configuration
 # Set to http://tempo:4317 when running with observability stack (./scripts/observability.sh up)


### PR DESCRIPTION
Change `TEST_MODEL` from `gpt-5` (doesn't exist) to `gpt-4o-mini` (valid model).

Prevents confusion when users copy `.env.example` to `.env` and run tests.