### PR TITLE
Add common Mac/IDE files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,21 @@ observability/data/
 # Debug script outputs
 debug_multitool_streaming.json
 debug_multitool_nonstreaming.json
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Python tools cache
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.pytype/


### PR DESCRIPTION
Add missing entries for common development files:

**macOS:**
- `.DS_Store`
- `.AppleDouble`
- `.LSOverride`

**IDEs:**
- `.vscode/` (VS Code)
- `.idea/` (PyCharm/IntelliJ)
- `*.swp`, `*.swo` (Vim swap files)

**Python Tools:**
- `.pytest_cache/`
- `.ruff_cache/`
- `.mypy_cache/`
- `.pytype/`

Prevents IDE and OS-specific files from cluttering `git status`.