### PR TITLE
Remove placeholder text from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ The gateway uses an event-driven policy architecture with streaming support.
 
 ### Creating Custom Policies
 
-!!! WE NEED TO UPDATE THIS !!!
+See the "Create Your Own Policy" section in [Quick Start](#5-create-your-own-policy) for a complete example of creating a custom policy with `SimpleJudgePolicy`.
 
 ### Testing
 


### PR DESCRIPTION
Replace `!!! WE NEED TO UPDATE THIS !!!` placeholder in "Creating Custom Policies" section with a reference to the existing policy creation example in the Quick Start section.

The Quick Start already has a comprehensive example of creating a custom policy, so we just need to link to it rather than duplicating the content.