### PR TITLE
Fix outdated OpenTelemetry configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,14 +169,19 @@ The observability stack is completely optional and does not affect core function
 
 ### Configuration
 
-Enable OpenTelemetry in `.env`:
+OpenTelemetry is enabled by default. To configure the endpoint in `.env`:
 
 ```bash
-OTEL_ENABLED=true
-OTEL_ENDPOINT=http://tempo:4317
+# OpenTelemetry endpoint (enabled by default)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
+
+# Optional: customize service metadata
 SERVICE_NAME=luthien-proxy
 SERVICE_VERSION=2.0.0
 ENVIRONMENT=development
+
+# To disable tracing, set:
+# OTEL_ENABLED=false
 ```
 
 ### Documentation


### PR DESCRIPTION
Update the Observability configuration section to use the current environment variables:

**Changes:**
- Use `OTEL_EXPORTER_OTLP_ENDPOINT` instead of `OTEL_ENDPOINT` (matches .env.example)
- Remove `OTEL_ENABLED=true` (enabled by default, not needed in .env)
- Clarify that tracing is enabled by default
- Show how to disable if needed (`OTEL_ENABLED=false`)

**Why:**
The previous configuration referenced `OTEL_ENABLED=true` which doesn't exist in `.env.example` and isn't needed since tracing is enabled by default.