### PR TITLE
docs: improve onboarding based on Zac's feedback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,25 +1,44 @@
 # Luthien Control Environment Configuration
 # Copy this file to .env and fill in your actual values
+#
+# Quick start: Only ANTHROPIC_API_KEY is truly required.
+# Everything else has working defaults for local development.
 
-# LLM Provider API Keys (used by the proxy to authenticate to upstream providers)
-# These are the REAL API keys that the proxy uses to call OpenAI/Anthropic
-OPENAI_API_KEY=your_openai_api_key_here
+# =============================================================================
+# REQUIRED: Your LLM Provider API Key(s)
+# =============================================================================
+# The proxy uses these to authenticate to upstream providers (Anthropic, OpenAI)
+
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
-# Gateway Configuration
-# PROXY_API_KEY: The API key that clients use to authenticate to the Luthien proxy
-# Claude Code and other clients will use this key to authenticate to the proxy
+# Optional: Only needed if routing to OpenAI models
+# OPENAI_API_KEY=your_openai_api_key_here
+
+# =============================================================================
+# GATEWAY AUTHENTICATION (defaults work for local dev)
+# =============================================================================
+
+# PROXY_API_KEY: Clients use this to authenticate to the Luthien proxy
+# Claude Code connects with: ANTHROPIC_API_KEY=sk-luthien-dev-key
 PROXY_API_KEY=sk-luthien-dev-key
 
-# ADMIN_API_KEY: The API key for admin/policy management operations
-# Required for accessing /admin/* endpoints (policy configuration UI)
-# Set this to a secure value in production
+# ADMIN_API_KEY: For admin UI and policy management
+# Change this in production!
 ADMIN_API_KEY=admin-dev-key
 
-GATEWAY_HOST=localhost
-GATEWAY_PORT=8000
+# =============================================================================
+# PORT CONFIGURATION (change if you have conflicts)
+# =============================================================================
 
-# Policy Configuration
+# Gateway port - this is where you point your client
+# Change this if 8000 conflicts with another service
+GATEWAY_PORT=8000
+GATEWAY_HOST=localhost
+
+# =============================================================================
+# POLICY CONFIGURATION
+# =============================================================================
+
 # POLICY_SOURCE: How to load and persist policies
 # Options:
 #   - "db": Use database only (production, UI-managed)
@@ -32,7 +51,11 @@ POLICY_SOURCE=db-fallback-file
 # Used when POLICY_SOURCE includes "file"
 POLICY_CONFIG=/app/config/policy_config.yaml
 
-# PostgreSQL Configuration
+# =============================================================================
+# INFRASTRUCTURE (Docker services - usually leave as-is)
+# =============================================================================
+
+# PostgreSQL - stores conversation events and policy config
 POSTGRES_USER=luthien
 POSTGRES_PASSWORD=luthien_dev_password
 POSTGRES_DB=luthien_control
@@ -56,6 +79,10 @@ OLLAMA_PORT=11434
 # e.g., gpt-4o, gpt-4o-mini, or a local model via the local LLM gateway
 TEST_MODEL=gpt-4o-mini
 
+# =============================================================================
+# OBSERVABILITY (optional - for distributed tracing)
+# =============================================================================
+
 # OpenTelemetry Configuration
 # Set to http://tempo:4317 when running with observability stack (./scripts/observability.sh up)
 # Leave empty to disable tracing
@@ -73,12 +100,20 @@ ENVIRONMENT=development
 # Used by debug endpoints to generate links to Grafana Tempo traces
 GRAFANA_URL=http://localhost:3000
 
-# LLM Judge Configuration (optional, for judge-based policies)
+# =============================================================================
+# LLM JUDGE POLICIES (optional - for SimpleJudgePolicy)
+# =============================================================================
+
 # Used by ToolCallJudgePolicy and SimpleJudgePolicy
+# By default, uses local Ollama. Override to use OpenAI/Anthropic as judge.
 # LLM_JUDGE_MODEL=openai/gpt-4
 # LLM_JUDGE_API_BASE=http://localhost:11434/v1
 # LLM_JUDGE_API_KEY=your_judge_api_key
 
-# LiteLLM Configuration (optional)
+# =============================================================================
+# ADVANCED (rarely needed)
+# =============================================================================
+
+# LiteLLM Configuration
 # Master key for LiteLLM if using multi-tenant setup
 # LITELLM_MASTER_KEY=your_litellm_master_key

--- a/README.md
+++ b/README.md
@@ -1,107 +1,131 @@
 # Luthien Control
 
-Redwood-style AI Control as an LLM proxy for production agentic deployments.
+**Enforce rules on AI coding agents.** Luthien is a proxy that sits between your AI assistant (Claude Code, Codex, etc.) and the LLM backend, letting you intercept, inspect, and modify every request and response.
 
-## Quick Start
+## What Can You Do With This?
 
-### 1. Install and Start
-
-```bash
-# Install uv (if needed)
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Clone and start everything
-git clone https://github.com/LuthienResearch/luthien-proxy
-cd luthien-proxy
-
-# Configure API keys
-cp .env.example .env
-# Edit .env and add your keys:
-#   OPENAI_API_KEY=sk-proj-...
-#   ANTHROPIC_API_KEY=sk-ant-...
-
-# Start the stack
-./scripts/quick_start.sh
-```
-
-### 2. Use Claude Code or Codex through the Proxy
-
-Launch your AI assistant through the proxy using the built-in scripts:
-
-**Claude Code:**
-
-```bash
-./scripts/launch_claude_code.sh
-```
-
-**Codex:**
-
-```bash
-./scripts/launch_codex.sh
-```
-
-These scripts automatically configure the proxy settings. All requests now flow through the policy enforcement layer!
-
-### 3. Log In to Admin UI
-
-When you first visit any admin page (Activity Monitor, Policy Config, or Debug views), you'll be redirected to:
-
-```
-http://localhost:8000/login
-```
-
-**Default credentials (development):**
-- Admin API Key: `admin-dev-key`
-
-After logging in, your session persists across pages. Click "Sign Out" on any admin page to log out.
-
-⚠️ **For production deployments**: Change `ADMIN_API_KEY` in your `.env` file before exposing to a network.
-
-### 4. Monitor Activity
-
-Open the Activity Monitor in your browser to see requests in real-time:
-
-```
-http://localhost:8000/activity/monitor
-```
-
-Watch as requests flow through, see policy decisions, and inspect before/after diffs.
-
-### 5. Select a Policy
-
-Use the Policy Configuration UI to change policies without restart:
-
-```
-http://localhost:8000/policy-config
-```
-
-1. Browse available policies (NoOp, AllCaps, DebugLogging, etc.)
-2. Click to select and activate
-3. Test immediately - changes take effect instantly
-
-### 6. Create Your Own Policy
-
-Create a new policy by subclassing `SimpleJudgePolicy`:
+**Write custom policies in Python** that run on every LLM interaction:
 
 ```python
-# src/luthien_proxy/policies/my_custom_policy.py
-
 from luthien_proxy.policies.simple_judge_policy import SimpleJudgePolicy
 
-class MyCustomPolicy(SimpleJudgePolicy):
+class MyPolicy(SimpleJudgePolicy):
     """Block dangerous commands before they execute."""
 
     RULES = [
         "Never allow 'rm -rf' commands",
         "Block requests to delete production data",
-        "Prevent executing untrusted code"
+        "Require approval for any AWS credential access"
     ]
-
-    # That's it! SimpleJudgePolicy handles the LLM judge logic for you.
-    # It evaluates both requests, responses, and tool calls against your rules.
+    # That's it! The LLM judge evaluates every request/response against your rules.
 ```
 
-Restart the gateway and your policy appears in the Policy Config UI automatically.
+**Real-world use cases:**
+- Block dangerous shell commands before execution
+- Require human approval for sensitive operations
+- Log every tool call for compliance/audit
+- Replace AI-isms in responses (em-dashes → hyphens)
+- Route requests to different models based on task type
+- Enforce coding standards automatically
+
+**Built-in features:**
+- Real-time activity monitor — watch requests flow through
+- Policy hot-reload — switch policies without restart
+- Streaming support — works with Claude Code's streaming responses
+- OpenAI & Anthropic compatible — drop-in proxy for both APIs
+
+---
+
+## Quick Start
+
+**Point your AI assistant at the proxy with 2 environment variables:**
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8000/v1
+export ANTHROPIC_API_KEY=sk-luthien-dev-key
+```
+
+That's it. Your existing Claude Code (or any Anthropic-compatible client) now routes through Luthien.
+
+### Start the Proxy
+
+```bash
+git clone https://github.com/LuthienResearch/luthien-proxy
+cd luthien-proxy
+cp .env.example .env
+# Edit .env: add ANTHROPIC_API_KEY (your real Anthropic key)
+# Optional: change GATEWAY_PORT if 8000 conflicts with something
+
+docker compose up -d
+```
+
+**What this starts (all in Docker):**
+| Service | Port | Description |
+|---------|------|-------------|
+| Gateway | 8000 | The proxy — point your client here |
+| PostgreSQL | 5432 | Stores conversation events |
+| Redis | 6379 | Powers real-time activity streaming |
+| Local LLM | 11434 | Ollama for local judge policies |
+
+*Port conflicts? Change `GATEWAY_PORT` in `.env`*
+
+### Verify It Works
+
+```bash
+curl http://localhost:8000/health
+```
+
+Then launch Claude Code with the env vars above and make a request. You should see it in the activity monitor:
+
+```
+http://localhost:8000/activity/monitor
+```
+
+---
+
+## Create Your Own Policy
+
+This is the power feature. Policies are Python classes that hook into the request/response lifecycle:
+
+```python
+# src/luthien_proxy/policies/my_custom_policy.py
+
+from luthien_proxy.policies.simple_policy import SimplePolicy
+
+class DeSlop(SimplePolicy):
+    """Remove AI-isms from responses."""
+
+    def simple_on_response_content(self, content: str, context) -> str:
+        # Replace em-dashes with regular dashes
+        content = content.replace("—", "-")
+        content = content.replace("–", "-")
+        return content
+```
+
+For LLM-based rule enforcement, use `SimpleJudgePolicy`:
+
+```python
+from luthien_proxy.policies.simple_judge_policy import SimpleJudgePolicy
+
+class SafetyPolicy(SimpleJudgePolicy):
+    """Use an LLM judge to evaluate requests against rules."""
+
+    RULES = [
+        "Never execute commands that delete files recursively",
+        "Block any request to access environment variables containing 'SECRET' or 'KEY'",
+        "Require explicit confirmation for git push --force"
+    ]
+```
+
+Restart the gateway (`docker compose restart gateway`) and your policy appears in the Policy Config UI.
+
+**Policy lifecycle hooks:**
+- `on_request` — Before sending to LLM
+- `on_chunk` — Each streaming chunk (for real-time modifications)
+- `on_block_complete` — After a complete message/tool_use block
+- `on_response_complete` — After full response received
+
+See `src/luthien_proxy/policies/` for more examples.
 
 ---
 


### PR DESCRIPTION
## Summary

README and .env.example improvements based on feedback from Zac (Counterweight).

**README changes:**
- Lead with value prop, not quickstart
- Custom policies prominent upfront ("the hook")
- Simplified quickstart (just 2 env vars, no launcher scripts)
- Docker service table with ports

**.env.example changes:**
- Clear REQUIRED vs OPTIONAL sections
- Better comments explaining each variable

**Key feedback addressed:**
- "As soon as I see this, if I have a custom Claude Code, this is completely unusable" → Just env vars now
- "I want to know what's the epic shit I can do with your product" → Features before quickstart
- "Create your own policy was buried" → Now prominent at top

## Test plan
- [ ] README renders correctly on GitHub
- [ ] .env.example has all required variables documented

🤖 Generated with [Claude Code](https://claude.ai/code)