### PR TITLE
docs: add PR hygiene guideline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,14 @@
 7. Clear `dev/OBJECTIVE.md` and `dev/NOTES.md`
 8. Mark the PR as ready.
 
+### One PR = One Concern
+
+- **Bug fix discovered while building a feature?** Separate PR.
+- **Infrastructure change needed for a feature?** Separate PR, feature depends on it.
+- **Ask:** "Could these be reviewed/merged independently?" If yes, split them.
+
+This keeps PRs focused, easier to review, and allows independent merging. (Added 2026-01-29 after PR #141 bundled a SimplePolicy fix with the DeSlop feature.)
+
 ### Maintaining Context
 
 Proactively update files in `dev/context/` as you learn about the codebase:


### PR DESCRIPTION
## Summary

Adds "One PR = One Concern" guideline to Development Workflow section.

**The rule:**
- Bug fix discovered while building a feature? Separate PR.
- Infrastructure change needed for a feature? Separate PR, feature depends on it.
- Ask: "Could these be reviewed/merge independently?" If yes, split them.

**Context:** Learned from PR #141 which bundled a SimplePolicy bug fix with the DeSlop feature. Jai's feedback: "break this into small commits... if there's anything else that's discrete, break that off too."

🤖 Generated with [Claude Code](https://claude.ai/code)