### PR TITLE
fix: strip context_management param from Anthropic requests

### DIFF
--- a/AGENTS.md.backup
+++ b/AGENTS.md.backup
@@ -1,0 +1,151 @@
+# Repository Guidelines
+
+## Purpose & Scope
+
+- Core goal: implement AI Control for LLMs with integrated gateway architecture.
+- Architecture: FastAPI gateway with integrated control plane and LiteLLM, using event-driven policies.
+- Configure upstream LLM models in `config/local_llm_config.yaml`.
+- Select a policy via `POLICY_CONFIG` that points to a YAML file (defaults to `config/policy_config.yaml`).
+  - Example: `export POLICY_CONFIG=./config/policy_config.yaml`
+
+## Development Workflow
+
+1. You will be given an OBJECTIVE to complete (e.g. 'implement this feature', 'fix this bug', 'build this UX', 'refactor this module')
+2. Make sure we're on a feature branch (not `main`)
+3. Commit the changes, push to origin, and open a draft PR (to `main`)
+4. Implement the OBJECTIVE. Add any items that should be done but are out of scope for the current OBJECTIVE to `dev/TODO.md` (e.g. noticing an implementation bug, incorrect documentation, or code that should be refactored).
+5. Regularly format + test (`scripts/dev_checks.sh`), commit, and push to origin (on the feature branch).
+6. When the OBJECTIVE is complete, update `CHANGELOG.md`
+7. Clear `dev/OBJECTIVE.md` and `dev/NOTES.md`
+8. Mark the PR as ready.
+
+### Maintaining Context
+
+Proactively update files in `dev/context/` as you learn about the codebase:
+
+- `codebase_learnings.md`: When you discover architectural patterns, module relationships, or how subsystems work together
+- `decisions.md`: When a technical decision is made (e.g., "why we use X instead of Y", "why this API is structured this way")
+- `gotchas.md`: When you encounter non-obvious behavior, edge cases, or common mistakes
+
+These files persist across sessions and help build institutional knowledge. Update them during development, not just at the end. Include timestamps (YYYY-MM-DD) when adding entries to detect when knowledge may be stale.
+
+Note that both Claude Code and Codex agents work in this repo and may read from and write to context.
+
+### Objective Workflow
+
+1. **Start a new objective**
+
+   ```bash
+   git checkout main
+   git pull
+   git checkout -b <short-handle>
+   ```
+
+   - If the branch already exists, run `git checkout <short-handle>` instead of creating it.
+   - Update `dev/OBJECTIVE.md`, then:
+
+     ```bash
+     git add dev/OBJECTIVE.md
+     git commit -m "chore: set objective to <short description>"
+     git push -u origin objective/<short-handle>
+     gh pr create --draft --fill --title "<Objective Title>"
+     ```
+
+2. **Develop**
+
+   - Format everything with `./scripts/format_all.sh`.
+   - Full lint + tests + type check: `./scripts/dev_checks.sh`.
+   - Quick unit pass: `uv run pytest tests/unit_tests`.
+   - *infrequenty* run full e2e tests using `uv run pytest -m e2e`. This is SLOW and should be used sparingly to validate that core functionality remains intact.
+   - Commit in small chunks with clear messages.
+
+3. **Wrap up the objective**
+
+   ```bash
+   ./scripts/dev_checks.sh
+   git status
+   ```
+
+   - Update `CHANGELOG.md` with a bullet referencing the objective handle.
+   - Clear `dev/NOTES.md` and `dev/OBJECTIVE.md`.
+
+   ```bash
+   git commit -a -m "<objective> is ready"
+   gh pr ready
+   ```
+
+## Project Structure & Module Organization
+
+- `dev/`: Tracking current development information
+  - `TODO.md`: TODO list. Add to this when we notice changes we should make that are out-of-scope for the current PR.
+  - `OBJECTIVE.md`: Succinct statement of the active objective with acceptance check.
+  - `NOTES.md`: Scratchpad for implementation details while the current objective is in progress.
+  - `*plan.md`: Medium- and long-term development plans may be recorded here.
+  - `context/`: Persistent knowledge accumulated across sessions (check these into git)
+    - `codebase_learnings.md`: Patterns, architecture insights, gotchas discovered while working
+    - `decisions.md`: Technical decisions made and their rationale
+    - `gotchas.md`: Non-obvious behaviors, edge cases, things that are easy to get wrong
+- `CHANGELOG.md`: Record changes as we make them (typically updated when we complete an OBJECTIVE)
+- `src/luthien_proxy/`: core package
+  - `control/`: Control plane for policy orchestration
+  - `policies/`: Event-driven policy implementations
+  - `streaming/`: Streaming pipeline and orchestration
+  - `storage/`: Conversation event persistence
+  - `ui/`: Real-time monitoring interfaces
+  - `debug/`: Debug and inspection endpoints
+  - `utils/`: Shared utilities (db, redis, validation)
+- `config/`: `policy_config.yaml`, `local_llm_config.yaml`
+- `scripts/`: developer helpers (`quick_start.sh`, `test_gateway.sh`)
+- `docker/` + `docker-compose.yaml`: local stack (db, redis, gateway, local-llm)
+- `migrations/`: SQL database migrations
+- `tests/`: unit/integration tests
+
+## Build, Test, and Development Commands
+
+- Install dev deps: `uv sync --dev`
+- Start full stack: `./scripts/quick_start.sh`
+- Run tests: `uv run pytest` (coverage: `uv run pytest --cov=src -q`)
+- Lint/format: `uv run ruff format` then `uv run ruff check --fix`. The `scripts/dev_checks.sh` script applies formatting automatically, and VS Code formats on save via Ruff. See `scripts/format_all.sh` for a quick all-in-one solution.
+- Type check: `uv run pyright`
+- Docker iterate: `docker compose restart gateway`
+
+## Tooling
+
+- Inspect the dev Postgres quickly with `uv run python scripts/query_debug_logs.py`. The helper loads `.env`, connects to `DATABASE_URL`, and prints recent conversation events and debug logs.
+- Quick Codex feedback: run `codex e "question or idea"` for a fast suggestion without starting an interactive session. Note that subsequent invocations won't persist context - pass in existing context or refer to relevant files to persist some context between calls.
+
+## Coding Style & Naming Conventions
+
+- Python 3.13; annotate public APIs and important internals. Pyright is the single static checker.
+- Formatting via Ruff: double quotes, spaces for indent (see `pyproject.toml`).
+- Naming: modules `snake_case`, classes `PascalCase`, functions and vars `snake_case`.
+- Docstrings: Google style for public modules/classes/functions; focus on WHY and non-trivial behavior.
+- Optional runtime type checking (`beartype`) for critical sections
+- String formatting: prefer f-strings over `.format()` or `%` formatting for readability and performance
+
+## Testing Guidelines
+
+- Framework: `pytest`
+- Location: under `tests/unit_tests/`, `tests/integration_tests/`, `tests/e2e_tests/`
+- Name files `test_*.py` and mirror package paths within the test-type directory.
+- Prefer fast unit tests for policies; add integration tests against gateway endpoints.
+- Use `pytest-cov` for coverage; include edge cases for streaming chunk logic.
+
+## Security & Configuration
+
+- Keep lint, test, and type-check settings consolidated in `pyproject.toml`; avoid extra config files unless necessary.
+- Copy `.env.example` to `.env`; never commit secrets.
+- Key env vars: `DATABASE_URL`, `REDIS_URL`, `POLICY_CONFIG`, `PROXY_API_KEY`.
+- Update `config/policy_config.yaml` rather than hardcoding.
+- Validate setup with test requests to the gateway at `http://localhost:8000`.
+
+## Policy Selection
+
+- Policies are loaded from the YAML file pointed to by `POLICY_CONFIG` (default `config/policy_config.yaml`).
+- Minimal YAML:
+
+  ```yaml
+  policy:
+    class: "luthien_proxy.policies.event_based_noop:EventBasedNoOpPolicy"
+    config: {}
+  ```

--- a/dev/export-for-notion/customer-discovery.md
+++ b/dev/export-for-notion/customer-discovery.md
@@ -1,0 +1,120 @@
+# Luthien Customer Discovery: The Story So Far
+## March 2025 – January 2026
+
+---
+
+## The Phases
+
+| Phase | Question | Status |
+|-------|----------|--------|
+| 1 | What won't change? | ✅ Done |
+| 2 | Is this a real problem? | ✅ Done |
+| 3 | **Can we build something useful for ourselves?** | 🔄 HERE |
+| 4 | Can we build something useful for others? | ⏳ Blocked |
+| 5 | Can we charge for it? | ⏳ Blocked |
+
+---
+
+## Phase 1: "What won't change?" (Mar–May 2025) ✅
+
+Scott joined March 2025 (trial), then as co-founder May 2025. Before iterating fast, we locked in the mission via [Theory of Change v12](https://docs.google.com/document/d/...).
+
+**Core thesis:** What would it take for Redwood's AI control agenda to actually reduce x-risk in practice?
+
+**Key fact:** 5-13 year runway → optimize for AI safety impact, not revenue.
+
+---
+
+## Phase 2: "Is this a real problem?" (Jun–Aug 2025) ✅
+
+9 discovery interviews. People started saying the same things.
+
+| Date | Name | Role | Transcript |
+|------|------|------|------------|
+| Jun 25 | Nico | CTO, Veleiro | [Link](https://docs.google.com/document/d/1u_WdPExBOLmQV4oSRZ1EX07MXUj74qsmoOxOppqLpG0/edit) |
+| Jul 1 | Saranya | Staff Engineer, IntentAI | — |
+| Jul 14 | Anthony | Sr. Developer, PauseAI | [Link](https://docs.google.com/document/d/1LIxnEXIcjL1gU7IT1wUtqzZOo4Sn49Z-ENKbrBdTI_c/edit) |
+| Jul 23 | Aleksandr | Developer Advocate | [Link](https://docs.google.com/document/d/1gXeeI23EVa41BYJ_JCFlmQPLtbEDmyQfym77SaJpwBs/edit) |
+| Jul 30 | Nathan | AI Safety Researcher | [Link](https://docs.google.com/document/d/1CbIkTinKXVUXgDycRsG73t6UwifqL0w0dB7--S8lF4I/edit) |
+| Jul 30 | Vipul & Smriti | Echovane | [Link](https://docs.google.com/document/d/1PWJDWj_2jnFPPhzQjEi6qD_6-e3FAlX3lcCeoW6016U/edit) |
+| Aug 18 | Kirk | CTO, Graphlit | [Link](https://docs.google.com/document/d/1KKJu0YwZq3bXVvlOD9LooC0l0GB8h-G3-w5BtKHeWXM/edit) |
+
+**Validated problems:** [User Frustrations Database](https://docs.google.com/spreadsheets/d/1Ob_mgKqYZphRvli37X6DJQ-TdYtgBlXb5Y9TFxmEyec/edit)
+
+**Resolution:** Problem is real. Diminishing returns on more interviews.
+
+---
+
+## Phase 3: "Can we build something useful for ourselves?" (Sep 2025–present) 🔄
+
+**Status:** In progress. Not yet useful enough for daily use.
+
+### What happened
+
+Three architecture cycles:
+1. DIY (Jan–Aug 2025): 562 commits, proved feasibility
+2. LiteLLM-everything (Aug–Oct): Delegated too much, lost control
+3. Integrated (Oct 16+): [PR #40](https://github.com/LuthienResearch/luthien-proxy/pull/40), brought critical components back in-house
+
+Demos forced shipping (EAG NYC, AI Tinkerers Oct 22-27), but product still too buggy for real dogfooding.
+
+### Current state (Jan 2026)
+
+- Too buggy for daily use
+- Scope too broad — need to narrow using existing tools (Langfuse, OpenTelemetry)
+- Scott shifted from "Claude coach me" to simpler: "just save my data"
+- demo to Seldon folks on sat (Jan 24) hit 500 errors from thinking blocks streaming bug. [PR #134](https://github.com/LuthienResearch/luthien-proxy/pull/134) fixed it, but pattern persists — need demo prep checklist, not just code fixes.
+
+Jai is also working on related side projects to solve related frustrations (run claude code remotely, on mobile etc.) that might be useful to Luthien too:
+- **Clarvis**: Web UI for managing Claude Code sessions remotely (mobile)
+- **CloudKeeper**: Wrapper around Anthropic Agents SDK for multi-session management
+- **Pluribus**: Multiple agents working on parallel branches of same repo
+
+**Jai's observation:** Models are getting noticeably better. His pdoom has gone down. This raises an open question: **does model improvement reduce the leverage of control work?** (See [Jan 20 call](https://docs.google.com/document/d/1qjjQXVsuoYo-_zCJ-lpm13h4MQ8PowbK3s-DrXne-ok/edit))
+
+### Exit criteria
+
+- [ ] Scott & Jai use it 2+ weeks without wanting to turn it off
+- [ ] At least one policy catches something real (test deletion, context rot, etc.)
+- [ ] Setup works on first try
+
+---
+
+## Phase 4: "Can we build something useful for others?" (Future) ⏳
+
+Give it away free (open-source). Gather feedback. Iterate.
+
+**Blocked on:** Phase 3 exit criteria
+
+### Pipeline ready
+
+| Type | Count |
+|------|-------|
+| Potential users (expressed interest) | 50 |
+| Networking contacts | 20+ |
+| Total tracked | 196 |
+
+[Luthien People Database](https://docs.google.com/spreadsheets/d/1lKNWdLRrkRu4VtxLsdWnKF_OFPBXAgG1aMioS9shHSM/edit)
+
+---
+
+## Phase 5: "Can we charge for it?" (Future) ⏳
+
+TBD business model. Freemium or other.
+
+**Blocked on:** Phase 4 learnings
+
+**Top uncertainty:** Can grants sustain a developer tools company long-term? (Current confidence: 60-70%)
+
+---
+
+## Source Documents
+
+- [Theory of Change v12](https://docs.google.com/document/d/.../edit)
+- [User Frustrations Database](https://docs.google.com/spreadsheets/d/1Ob_mgKqYZphRvli37X6DJQ-TdYtgBlXb5Y9TFxmEyec/edit)
+- [Luthien People Database](https://docs.google.com/spreadsheets/d/1lKNWdLRrkRu4VtxLsdWnKF_OFPBXAgG1aMioS9shHSM/edit)
+- [Josh/Scott Sync - Dec 16](https://docs.google.com/document/d/12fhPHYzGudADHVZhHz3OCakbOpPwL_9Hv0yj8mWissU/edit)
+
+---
+
+*Last updated: Sunday, January 25, 2026*

--- a/dev/export-for-notion/shipping-log.md
+++ b/dev/export-for-notion/shipping-log.md
@@ -1,0 +1,137 @@
+# Luthien Shipping Log
+
+**Time period**: Dec 1, 2025 → Jan 29, 2026
+
+---
+
+## User Stories
+
+Luthien serves 6 canonical user stories. See [full details](https://github.com/LuthienResearch/luthien-proxy/blob/main/dev/user-stories/README.md).
+
+| # | Story | Persona | Progress |
+|---|-------|---------|----------|
+| 1 | Solo Developer: Context-Aware Safety | Alex (Senior Dev) | ~40% |
+| 2 | Platform Team: Org-Wide Visibility | Jordan (Platform Eng) | ~15% |
+| 3 | Researcher: Multi-Reviewer Evaluation | Sam (PhD Student) | ~20% |
+| 4 | Policy Author: Compliance with HITL | Riley (Security Eng) | 0% |
+| 5 | Infrastructure: Observability & Unification | Core Developer | ~95% |
+| 6 | Junior Developer: Learning with Guardrails | Taylor (Junior Dev) | ~15% |
+
+---
+
+## Implementation Waves
+
+| Wave | Focus | Status |
+|------|-------|--------|
+| 0 | Infrastructure (enables all stories) | Complete |
+| 1 | Foundation (context tracking, message injection) | In progress |
+| 2 | UI & Visibility (conversation viewer, dashboards) | In progress |
+| 3 | Advanced Policies | Future |
+| 4 | Compliance & Approval | Future |
+| 5 | Platform Polish | Future |
+
+---
+
+## Goals
+
+We're using [Learn More Faster](https://www.gv.com/research-sprint): validate at each stage before investing in the next.
+
+| Goal | Description | Done When | Status |
+|------|-------------|-----------|--------|
+| 1 | Unblock dogfooding | Scott & Jai use Luthien daily | 3/4 blockers fixed |
+| 2 | Unblock guided external trials | 3 users complete 30-min session | In progress |
+| 3 | Unblock independent trials | <10 min setup | Not started |
+
+### Goal 1 Blockers
+
+| Blocker | Date | Status | PR |
+|---------|------|--------|-----|
+| Thinking blocks (non-streaming) | Jan 20 | Done | [#131](https://github.com/LuthienResearch/luthien-proxy/pull/131) |
+| Thinking blocks (streaming) | Jan 26 | Done | [#134](https://github.com/LuthienResearch/luthien-proxy/pull/134) |
+| Session viewer polish | Jan 26 | Done | [#133](https://github.com/LuthienResearch/luthien-proxy/pull/133) |
+| `context_management` param breaks Claude Code | Jan 29 | In progress | [#143](https://github.com/LuthienResearch/luthien-proxy/pull/143) (partial) |
+
+### Goal 2 Progress
+
+| Milestone | Date | Status | Notes |
+|-----------|------|--------|-------|
+| Railway deployment live | Jan 29 | Done | `luthien-proxy-production-0b7d.up.railway.app` |
+| Demo checklist created | Jan 29 | Done | [luthien-org/demo-checklist.md](https://github.com/LuthienResearch/luthien-org/blob/main/demo-checklist.md) |
+| Quick start guide | Jan 29 | Done | [luthien-org/demo-quick-start.md](https://github.com/LuthienResearch/luthien-org/blob/main/demo-quick-start.md) |
+| Counterweight demo | Jan 29 | Scheduled | 3:30pm - using Codex (Claude Code has bug) |
+
+---
+
+## PRs Shipped
+
+### December (Remote)
+
+| Date | What | PR | Who | Cat |
+|------|------|-----|-----|-----|
+| Dec 4 | E2E tests using Claude Code | [#77](https://github.com/LuthienResearch/luthien-proxy/pull/77) | Jai | Infra |
+| Dec 4 | API request tracing + debug UI | [#80](https://github.com/LuthienResearch/luthien-proxy/pull/80) | Jai | UX |
+| Dec 4 | Codebase cleanup | [#81](https://github.com/LuthienResearch/luthien-proxy/pull/81) | Jai | Infra |
+| Dec 8 | DI for EventEmitter | [#83](https://github.com/LuthienResearch/luthien-proxy/pull/83) | Jai | Infra |
+| Dec 9 | Remove prisma dependency | [#84](https://github.com/LuthienResearch/luthien-proxy/pull/84) | Jai | Infra |
+| Dec 9 | Auth for debug endpoints | [#86](https://github.com/LuthienResearch/luthien-proxy/pull/86) | Jai | Infra |
+| Dec 9 | Centralize env config (pydantic) | [#87](https://github.com/LuthienResearch/luthien-proxy/pull/87) | Jai | Infra |
+| Dec 9 | Session-based login for admin UIs | [#88](https://github.com/LuthienResearch/luthien-proxy/pull/88) | Jai | UX |
+| Dec 9 | Centralize magic numbers | [#89](https://github.com/LuthienResearch/luthien-proxy/pull/89) | Jai | Infra |
+| Dec 10 | Simplify policy storage | [#90](https://github.com/LuthienResearch/luthien-proxy/pull/90) | Jai | Infra |
+| Dec 11 | Fix migration script | [#91](https://github.com/LuthienResearch/luthien-proxy/pull/91) | Scott | Bug |
+| Dec 11 | Unify OpenAI/Anthropic endpoints | [#92](https://github.com/LuthienResearch/luthien-proxy/pull/92) | Jai | Infra |
+| Dec 11 | Named constants | [#93](https://github.com/LuthienResearch/luthien-proxy/pull/93) | Scott | Infra |
+| Dec 11 | README improvements | [#96](https://github.com/LuthienResearch/luthien-proxy/pull/96), [#99](https://github.com/LuthienResearch/luthien-proxy/pull/99), [#100](https://github.com/LuthienResearch/luthien-proxy/pull/100) | Scott | Docs |
+| Dec 13 | Session ID tracking | [#102](https://github.com/LuthienResearch/luthien-proxy/pull/102) | Jai | Infra |
+| Dec 15 | DI for create_app | [#105](https://github.com/LuthienResearch/luthien-proxy/pull/105) | Jai | Infra |
+| Dec 16 | Login page UX | [#106](https://github.com/LuthienResearch/luthien-proxy/pull/106) | Scott | UX |
+| Dec 16 | Structured span hierarchy | [#107](https://github.com/LuthienResearch/luthien-proxy/pull/107) | Jai | Infra |
+| Dec 16 | Migration validation | [#110](https://github.com/LuthienResearch/luthien-proxy/pull/110) | Jai | Infra |
+| Dec 16 | Production readiness | [#101](https://github.com/LuthienResearch/luthien-proxy/pull/101) | Scott | Infra |
+| Dec 17 | Unit test coverage 84%→90% | [#115](https://github.com/LuthienResearch/luthien-proxy/pull/115) | Jai | Infra |
+| Dec 18 | Fix proxy with images | [#104](https://github.com/LuthienResearch/luthien-proxy/pull/104) | Scott | Bug |
+| Dec 18 | Reorganize LLM types | [#117](https://github.com/LuthienResearch/luthien-proxy/pull/117) | Jai | Infra |
+| Dec 22 | Conversation History Viewer | [#119](https://github.com/LuthienResearch/luthien-proxy/pull/119) | Jai | UX |
+| Dec 22 | ParallelRulesPolicy | [#120](https://github.com/LuthienResearch/luthien-proxy/pull/120) | Jai | Infra |
+| Dec 22 | Public demo deployment | [#121](https://github.com/LuthienResearch/luthien-proxy/pull/121), [#122](https://github.com/LuthienResearch/luthien-proxy/pull/122) | Jai | Infra |
+| Dec 29 | Policy Config auto-discovery | [#123](https://github.com/LuthienResearch/luthien-proxy/pull/123) | Jai | UX |
+
+### January (Seattle / Mox)
+
+| Date | What | PR | Who | Cat |
+|------|------|-----|-----|-----|
+| Jan 9 | Extra model params passthrough | [#126](https://github.com/LuthienResearch/luthien-proxy/pull/126) | Jai | Bug |
+| Jan 9 | Policy Config UI improvements | [#125](https://github.com/LuthienResearch/luthien-proxy/pull/125) | Jai | UX |
+| Jan 17 | Convo history improvements | [#133](https://github.com/LuthienResearch/luthien-proxy/pull/133) | Scott | UX |
+| Jan 20 | Thinking blocks (non-streaming) | [#131](https://github.com/LuthienResearch/luthien-proxy/pull/131) | Scott | Bug |
+| Jan 20 | Gateway homepage fixes | [#132](https://github.com/LuthienResearch/luthien-proxy/pull/132) | Scott | UX |
+| Jan 23 | Story 6 docs | [#114](https://github.com/LuthienResearch/luthien-proxy/pull/114) | Scott | Docs |
+| Jan 23 | TODO updates | [#130](https://github.com/LuthienResearch/luthien-proxy/pull/130) | Scott | Docs |
+| Jan 24 | Thinking blocks (streaming) | [#134](https://github.com/LuthienResearch/luthien-proxy/pull/134) | Scott | Bug |
+| Jan 24 | RFC: AGENTS.md workflow | [#135](https://github.com/LuthienResearch/luthien-proxy/pull/135) | Scott | Docs |
+| Jan 26 | Refactor thinking_blocks field | [#138](https://github.com/LuthienResearch/luthien-proxy/pull/138) | Jai | Infra |
+| Jan 29 | Stricter typing in history service | [#139](https://github.com/LuthienResearch/luthien-proxy/pull/139) | Jai | Infra |
+| Jan 29 | Fix LiteLLM update issues | [#143](https://github.com/LuthienResearch/luthien-proxy/pull/143) | Jai | Bug |
+| Jan 29 | Forward backend API errors | [#146](https://github.com/LuthienResearch/luthien-proxy/pull/146) | Jai | Bug |
+| Jan 29 | PR hygiene guideline | [#149](https://github.com/LuthienResearch/luthien-proxy/pull/149) | Scott | Docs |
+| Jan 29 | StringReplacementPolicy | [#150](https://github.com/LuthienResearch/luthien-proxy/pull/150) | Jai | Feature |
+
+---
+
+## Contributors
+
+| Who | Merged | Open | Focus |
+|-----|--------|------|-------|
+| Jai | 31 | 0 | Infrastructure, foundation, policy framework |
+| Scott | 14 | 3 | Bugs, UX polish, docs |
+
+---
+
+## Related
+
+- [User Stories README](https://github.com/LuthienResearch/luthien-proxy/blob/main/dev/user-stories/README.md)
+- [UI Feedback Tracker](UI-feedback-dev-tracker.md)
+- [Demo Checklist](https://github.com/LuthienResearch/luthien-org/blob/main/demo-checklist.md)
+- [Demo Quick Start](https://github.com/LuthienResearch/luthien-org/blob/main/demo-quick-start.md)
+
+*Updated: 2026-01-29*

--- a/src/luthien_proxy/llm/llm_format_utils.py
+++ b/src/luthien_proxy/llm/llm_format_utils.py
@@ -250,6 +250,8 @@ HANDLED_KEYS = {
     "system",
     "tools",
     "tool_choice",
+    # Client-side only params (don't forward to provider)
+    "context_management",  # Claude Code context window management - not supported by Anthropic API
 }
 
 

--- a/tests/unit_tests/llm/test_llm_format_utils.py
+++ b/tests/unit_tests/llm/test_llm_format_utils.py
@@ -159,6 +159,30 @@ class TestAnthropicToOpenAIRequest:
         assert "thinking" not in result
         assert "metadata" not in result
 
+    def test_context_management_stripped(self):
+        """Test that context_management parameter is NOT forwarded.
+
+        Claude Code sends context_management for client-side context window
+        management, but Anthropic's API doesn't accept it. We must strip it.
+        """
+        anthropic_req = cast(
+            AnthropicRequest,
+            {
+                "model": "claude-sonnet-4-20250514",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 1024,
+                "context_management": {
+                    "strategy": "truncation",
+                    "max_tokens": 50000,
+                },
+            },
+        )
+
+        result = anthropic_to_openai_request(anthropic_req)
+
+        # context_management should be stripped, not forwarded
+        assert "context_management" not in result
+
     def test_with_optional_params(self):
         """Test conversion with temperature and top_p."""
         anthropic_req: AnthropicRequest = {


### PR DESCRIPTION
## Summary

- Strip `context_management` parameter from Anthropic requests before forwarding to LiteLLM/Anthropic API
- Add test to verify the param is stripped

## Problem

Claude Code sends `context_management` for client-side context window management:
```json
{
  "context_management": {
    "strategy": "truncation",
    "max_tokens": 50000
  }
}
```

Anthropic's API rejects this with: `"context_management.strategy: Extra inputs are not permitted"`

## Root Cause

In `llm_format_utils.py`, `anthropic_to_openai_request()` passes through all unknown params (lines 290-294). `context_management` wasn't in `HANDLED_KEYS`, so it got forwarded to LiteLLM → Anthropic API → 400 error.

## Fix

Add `context_management` to `HANDLED_KEYS` so it's stripped before forwarding.

## Test plan

- [x] Added unit test `test_context_management_stripped`
- [ ] Verify on Railway endpoint after merge + redeploy

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)