### PR TITLE
Add /v1/responses shim for Codex

### DIFF
--- a/dev/OBJECTIVE.md
+++ b/dev/OBJECTIVE.md
@@ -12,6 +12,7 @@ Acceptance
 - Non-streaming responses return a valid Responses API payload.
 - Add unit tests for streaming and non-streaming.
 - Update `scripts/launch_codex.sh` to set `wire_api=responses` once endpoint is in place.
+- Include a migration note: Codex currently emits `developer` role messages; ensure the normalization fix is present on this branch or merged before validation.
 
 Plan (TDD)
 1. Add failing tests for `/v1/responses` (streaming + non-streaming) using a minimal payload.
@@ -19,3 +20,4 @@ Plan (TDD)
 3. Implement response adapter: map OpenAI `ModelResponse` → Responses format.
 4. Implement SSE adapter: emit `response.output_text.delta` + `response.completed` events.
 5. Update Codex launcher to `wire_api=responses`.
+6. Confirm developer-role normalization is included (merge PR #162 if needed).


### PR DESCRIPTION
## Summary
- Set objective and plan for /v1/responses shim to unblock wire_api=responses

## Background
Codex now warns that chat wire API is deprecated, but the gateway only supports `/v1/chat/completions` and `/v1/messages`. We need a minimal `/v1/responses` shim to support Codex and avoid deprecation‑driven breakages.

## Scope
- Minimal request adapter (`input` → chat messages, `model`, `stream`)
- Response adapter for non‑streaming
- SSE adapter for streaming (`response.output_text.delta`, `response.completed`)
- Update Codex launcher to `wire_api=responses`

## Acceptance
- `/v1/responses` endpoint exists and routes through the policy pipeline
- Streaming and non‑streaming responses conform to Responses API shape
- Unit tests added for streaming + non‑streaming
- Developer‑role normalization fix is present (merge PR #162 if needed)

## Testing
- Not run (objective only)
