### PR TITLE
docs: add TODO items from split-apis PR #169 review

### DIFF
--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -49,6 +49,10 @@
 
 ### Code Improvements
 
+- [ ] **Anthropic-only policy configuration support** - Current implementation requires all policies to implement both OpenAI and Anthropic interfaces. There's no way to configure an Anthropic-only policy through the config system. Noted as Phase 2 work in split-apis design doc. Reference: PR #169, 2026-02-03.
+- [ ] **Simplify streaming span context management** - The attach/detach pattern in `anthropic_processor.py:275-303` is correct but complex. Consider wrapping in a context manager for better maintainability. Reference: PR #169, 2026-02-03.
+- [ ] **Add runtime validation for Anthropic TypedDict assignments** - `anthropic_processor.py:238` uses direct dict-to-TypedDict assignment after basic field validation. Consider adding runtime validation for production robustness. Reference: PR #169, 2026-02-03.
+
 - [ ] **llm_format_utils.py: Replace defensive fallbacks with exceptions** - Several places silently mask errors instead of failing fast. Reference: refactoring session 2026-01-26.
   - `_convert_anthropic_image_block()` returns `None` for unknown source types - should raise
   - `_categorize_content_blocks()` silently skips non-dict blocks (`if not isinstance(block, dict): continue`) - should raise


### PR DESCRIPTION
## Summary
- Add TODO items identified during PR #169 code review

## Changes
- Anthropic-only policy configuration support (Phase 2 work)
- Simplify streaming span context management (context manager opportunity)
- Add runtime validation for Anthropic TypedDict assignments

🤖 Generated with [Claude Code](https://claude.com/claude-code)