### PR TITLE
feat: ClaudeMdRulesPolicy for CLAUDE.md rule extraction

### DIFF
--- a/changelog.d/claude-md-rules.md
+++ b/changelog.d/claude-md-rules.md
@@ -1,0 +1,7 @@
+---
+category: Features
+---
+
+**CLAUDE.md rules policy**: New `ClaudeMdRulesPolicy` extracts objective rules from CLAUDE.md at session start, persists them to the database, and applies them on subsequent turns via `ParallelRulesPolicy`.
+  - New `session_rules` database table for per-session rule persistence
+  - `PolicyContext` now exposes `db_pool` for policies that need database access

--- a/migrations/010_add_session_rules.sql
+++ b/migrations/010_add_session_rules.sql
@@ -1,0 +1,11 @@
+-- Session rules: per-session rules extracted from CLAUDE.md (or similar sources).
+-- Each row is one rule for one session.
+
+CREATE TABLE IF NOT EXISTS session_rules (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    session_id TEXT NOT NULL,
+    rule_name TEXT NOT NULL,
+    rule_instruction TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_session_rules_session ON session_rules(session_id);

--- a/migrations/sqlite_schema.sql
+++ b/migrations/sqlite_schema.sql
@@ -147,3 +147,13 @@ CREATE TABLE IF NOT EXISTS telemetry_config (
     updated_by TEXT
 );
 INSERT OR IGNORE INTO telemetry_config (id) VALUES (1);
+
+-- Session rules (extracted per-session, e.g. from CLAUDE.md)
+CREATE TABLE IF NOT EXISTS session_rules (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    rule_name TEXT NOT NULL,
+    rule_instruction TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_session_rules_session ON session_rules(session_id);

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -382,6 +382,7 @@ async def process_anthropic_request(
             emitter=emitter,
             raw_http_request=raw_http_request,
             session_id=session_id,
+            db_pool=db_pool,
         )
 
         # Set policy name on root span for easy identification

--- a/src/luthien_proxy/policies/claude_md_rules_policy.py
+++ b/src/luthien_proxy/policies/claude_md_rules_policy.py
@@ -88,6 +88,7 @@ class ClaudeMdRulesPolicy(BasePolicy):
     """
 
     def __init__(self, config: ClaudeMdRulesConfig | dict[str, Any] | None = None) -> None:
+        """Initialize with extraction config and inner ParallelRulesPolicy."""
         self.config = self._init_config(config, ClaudeMdRulesConfig)
         self._parallel_rules = ParallelRulesPolicy(
             config={
@@ -101,6 +102,7 @@ class ClaudeMdRulesPolicy(BasePolicy):
 
     @property
     def short_policy_name(self) -> str:
+        """Human-readable policy name."""
         return "ClaudeMdRules"
 
     async def run_anthropic(
@@ -108,6 +110,7 @@ class ClaudeMdRulesPolicy(BasePolicy):
         io: "AnthropicPolicyIOProtocol",
         context: "PolicyContext",
     ) -> "AsyncIterator[AnthropicPolicyEmission]":
+        """Ensure rules are loaded/extracted, then delegate to ParallelRulesPolicy."""
         rules = await self._ensure_rules(io.request, context)
         if rules:
             self._parallel_rules.set_rules_for_request(
@@ -221,7 +224,7 @@ def _parse_extracted_rules(llm_output: str) -> list[SessionRule]:
     if text.startswith("```"):
         lines = text.split("\n")
         # Remove first and last fence lines
-        lines = [l for l in lines if not l.strip().startswith("```")]
+        lines = [line for line in lines if not line.strip().startswith("```")]
         text = "\n".join(lines).strip()
 
     # Find the JSON array in the output

--- a/src/luthien_proxy/policies/claude_md_rules_policy.py
+++ b/src/luthien_proxy/policies/claude_md_rules_policy.py
@@ -1,0 +1,255 @@
+"""ClaudeMdRulesPolicy — extract rules from CLAUDE.md and apply via ParallelRulesPolicy.
+
+On the first turn of a session, scans the system prompt for CLAUDE.md content,
+calls an LLM to extract objective rules, and persists them to the database.
+On subsequent turns, loads persisted rules and delegates to ParallelRulesPolicy.
+
+Example config:
+    policy:
+      class: "luthien_proxy.policies.claude_md_rules_policy:ClaudeMdRulesPolicy"
+      config:
+        model: "claude-haiku-4-5"
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field
+
+from luthien_proxy.policies.parallel_rules_policy import ParallelRulesPolicy, Rule
+from luthien_proxy.policies.rules_llm_utils import call_llm
+from luthien_proxy.policy_core.base_policy import BasePolicy
+from luthien_proxy.storage.session_rules import (
+    SessionRule,
+    has_rules,
+    load_rules,
+    save_rules,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from luthien_proxy.llm.types.anthropic import AnthropicRequest
+    from luthien_proxy.policy_core.anthropic_execution_interface import (
+        AnthropicPolicyEmission,
+        AnthropicPolicyIOProtocol,
+    )
+    from luthien_proxy.policy_core.policy_context import PolicyContext
+
+logger = logging.getLogger(__name__)
+
+EXTRACTION_SYSTEM_PROMPT = """\
+You extract objective, enforceable rules from developer instruction files (like CLAUDE.md).
+
+Given the content of a CLAUDE.md file, extract rules that an AI assistant should follow.
+Focus on concrete, actionable instructions — not vague preferences or context.
+
+Return a JSON array of objects, each with "name" (short slug) and "instruction" (the rule).
+If no extractable rules exist, return an empty array: []
+
+Example output:
+[
+  {"name": "no-emoji", "instruction": "Never use emoji in responses unless the user explicitly requests it."},
+  {"name": "early-returns", "instruction": "Prefer early returns over nested if statements to reduce indentation."}
+]
+
+Return ONLY the JSON array. No markdown fencing, no commentary."""
+
+
+class ClaudeMdRulesConfig(BaseModel):
+    """Configuration for ClaudeMdRulesPolicy."""
+
+    model: str = Field(
+        default="claude-haiku-4-5",
+        description="LiteLLM model string for rule extraction",
+    )
+    api_base: str | None = Field(default=None, description="Optional API base URL override")
+    api_key: str | None = Field(
+        default=None,
+        description="API key for LLM calls (falls back to env vars)",
+        json_schema_extra={"format": "password"},
+    )
+    temperature: float = Field(default=0.0, description="Sampling temperature for extraction")
+    max_tokens: int = Field(default=4096, description="Max output tokens for extraction")
+
+    model_config = {"frozen": True}
+
+
+class ClaudeMdRulesPolicy(BasePolicy):
+    """Extract rules from CLAUDE.md at session start and apply via ParallelRulesPolicy.
+
+    On each request:
+    1. If no session_id or db_pool → passthrough (no rule persistence possible)
+    2. If rules already in DB for this session → load and apply
+    3. If first turn → scan for CLAUDE.md content, extract rules, save to DB, apply
+    """
+
+    def __init__(self, config: ClaudeMdRulesConfig | dict[str, Any] | None = None) -> None:
+        self.config = self._init_config(config, ClaudeMdRulesConfig)
+        self._parallel_rules = ParallelRulesPolicy(
+            config={
+                "model": self.config.model,
+                "api_base": self.config.api_base,
+                "api_key": self.config.api_key,
+                "temperature": self.config.temperature,
+                "max_tokens": self.config.max_tokens,
+            }
+        )
+
+    @property
+    def short_policy_name(self) -> str:
+        return "ClaudeMdRules"
+
+    async def run_anthropic(
+        self,
+        io: "AnthropicPolicyIOProtocol",
+        context: "PolicyContext",
+    ) -> "AsyncIterator[AnthropicPolicyEmission]":
+        rules = await self._ensure_rules(io.request, context)
+        if rules:
+            self._parallel_rules.set_rules_for_request(
+                context, [Rule(name=r.name, instruction=r.instruction) for r in rules]
+            )
+
+        async for emission in self._parallel_rules.run_anthropic(io, context):
+            yield emission
+
+    async def _ensure_rules(
+        self,
+        request: "AnthropicRequest",
+        context: "PolicyContext",
+    ) -> list[SessionRule]:
+        """Load rules from DB, or extract from CLAUDE.md on first turn."""
+        if not context.session_id or not context.db_pool:
+            return []
+
+        already_extracted = await has_rules(context.db_pool, context.session_id)
+        if already_extracted:
+            return await load_rules(context.db_pool, context.session_id)
+
+        claude_md_content = _find_claude_md_content(request)
+        if not claude_md_content:
+            # No CLAUDE.md found — save empty sentinel to avoid re-scanning
+            await save_rules(context.db_pool, context.session_id, [])
+            return []
+
+        try:
+            rules = await self._extract_rules(claude_md_content)
+        except Exception:
+            logger.exception("Failed to extract rules from CLAUDE.md")
+            # Save empty sentinel so we don't retry on every turn
+            await save_rules(context.db_pool, context.session_id, [])
+            return []
+
+        await save_rules(context.db_pool, context.session_id, rules)
+        context.record_event(
+            "policy.claude_md_rules.extracted",
+            {"rule_count": len(rules), "rule_names": [r.name for r in rules]},
+        )
+        return rules
+
+    async def _extract_rules(self, content: str) -> list[SessionRule]:
+        """Call LLM to extract rules from CLAUDE.md content."""
+        llm_output = await call_llm(
+            messages=[
+                {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
+                {"role": "user", "content": content},
+            ],
+            model=self.config.model,
+            temperature=self.config.temperature,
+            max_tokens=self.config.max_tokens,
+            api_base=self.config.api_base,
+            api_key=self.config.api_key,
+        )
+        return _parse_extracted_rules(llm_output)
+
+
+def _find_claude_md_content(request: "AnthropicRequest") -> str | None:
+    """Scan system prompt and first user message for CLAUDE.md content.
+
+    Looks for common indicators: "CLAUDE.md", "claude.md", "Contents of",
+    "system-reminder" tags containing instruction blocks.
+    """
+    candidates: list[str] = []
+
+    # Check the system field (Anthropic API puts system prompt here)
+    system = request.get("system")
+    if isinstance(system, str):
+        candidates.append(system)
+    elif isinstance(system, list):
+        for block in system:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text", "")
+                if isinstance(text, str):
+                    candidates.append(text)
+
+    # Check the first user message (some clients embed instructions there)
+    messages = request.get("messages", [])
+    if messages:
+        first_msg = messages[0]
+        if first_msg.get("role") == "user":
+            content = first_msg.get("content")
+            if isinstance(content, str):
+                candidates.append(content)
+            elif isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text = block.get("text", "")
+                        if isinstance(text, str):
+                            candidates.append(text)
+
+    claude_md_indicators = ("CLAUDE.md", "claude.md", "claudeMd", "system-reminder")
+    matching = [c for c in candidates if any(indicator in c for indicator in claude_md_indicators)]
+
+    if not matching:
+        return None
+
+    return "\n\n".join(matching)
+
+
+def _parse_extracted_rules(llm_output: str) -> list[SessionRule]:
+    """Parse JSON array of rules from LLM output.
+
+    Handles common LLM quirks: markdown code fences, leading text before JSON.
+    """
+    text = llm_output.strip()
+
+    # Strip markdown code fences
+    if text.startswith("```"):
+        lines = text.split("\n")
+        # Remove first and last fence lines
+        lines = [l for l in lines if not l.strip().startswith("```")]
+        text = "\n".join(lines).strip()
+
+    # Find the JSON array in the output
+    start = text.find("[")
+    end = text.rfind("]")
+    if start == -1 or end == -1 or end <= start:
+        logger.warning("No JSON array found in extraction output: %.200s", text)
+        return []
+
+    try:
+        parsed = json.loads(text[start : end + 1])
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse JSON from extraction output: %.200s", text)
+        return []
+
+    if not isinstance(parsed, list):
+        return []
+
+    rules: list[SessionRule] = []
+    for item in parsed:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        instruction = item.get("instruction")
+        if isinstance(name, str) and isinstance(instruction, str) and name and instruction:
+            rules.append(SessionRule(name=name, instruction=instruction))
+
+    return rules
+
+
+__all__ = ["ClaudeMdRulesPolicy"]

--- a/src/luthien_proxy/policy_core/policy_context.py
+++ b/src/luthien_proxy/policy_core/policy_context.py
@@ -22,6 +22,8 @@ from luthien_proxy.types import RawHttpRequest
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
 
+    from luthien_proxy.utils.db import DatabasePool
+
 _tracer = trace.get_tracer(__name__)
 T = TypeVar("T")
 
@@ -51,6 +53,7 @@ class PolicyContext:
         emitter: EventEmitterProtocol | None = None,
         raw_http_request: RawHttpRequest | None = None,
         session_id: str | None = None,
+        db_pool: "DatabasePool | None" = None,
     ) -> None:
         """Initialize policy context for a request.
 
@@ -62,11 +65,13 @@ class PolicyContext:
             raw_http_request: Optional raw HTTP request data before any processing.
                               Contains original headers, body, method, and path.
             session_id: Optional session identifier extracted from client request.
+            db_pool: Optional database pool for policies that need DB access.
         """
         self.transaction_id: str = transaction_id
         self.request: Any | None = request
         self.raw_http_request: RawHttpRequest | None = raw_http_request
         self.session_id: str | None = session_id
+        self.db_pool: "DatabasePool | None" = db_pool
         self._emitter: EventEmitterProtocol = emitter or NullEventEmitter()
         self._scratchpad: dict[str, Any] = {}
         self._request_state: dict[tuple[int, type[Any]], Any] = {}
@@ -217,6 +222,7 @@ class PolicyContext:
         new_ctx.session_id = self.session_id
         new_ctx.raw_http_request = self.raw_http_request  # read-only after creation
         new_ctx._emitter = self._emitter  # holds db/redis pool — share, not copy
+        new_ctx.db_pool = self.db_pool  # connection pool — share, not copy
 
         # Independently mutable: each sub-policy gets its own copy
         new_ctx.request = self.request.model_copy(deep=True) if self.request is not None else None
@@ -238,6 +244,7 @@ class PolicyContext:
         request: Any | None = None,
         raw_http_request: RawHttpRequest | None = None,
         session_id: str | None = None,
+        db_pool: "DatabasePool | None" = None,
     ) -> "PolicyContext":
         """Create a PolicyContext suitable for unit tests.
 
@@ -248,6 +255,7 @@ class PolicyContext:
             request: Optional request object
             raw_http_request: Optional raw HTTP request data
             session_id: Optional session ID
+            db_pool: Optional database pool
 
         Returns:
             PolicyContext with null implementations for external services
@@ -258,6 +266,7 @@ class PolicyContext:
             emitter=NullEventEmitter(),
             raw_http_request=raw_http_request,
             session_id=session_id,
+            db_pool=db_pool,
         )
 
 

--- a/src/luthien_proxy/storage/session_rules.py
+++ b/src/luthien_proxy/storage/session_rules.py
@@ -1,0 +1,90 @@
+"""CRUD operations for per-session rules stored in the database.
+
+Rules are extracted once per session (e.g. from CLAUDE.md content) and persisted
+so subsequent turns can load them without re-extraction.
+
+A sentinel row (SENTINEL_RULE_NAME) is stored when extraction produces zero rules.
+This lets has_rules() distinguish "never extracted" from "extracted but empty".
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from luthien_proxy.utils.db import DatabasePool
+
+SENTINEL_RULE_NAME = "__no_rules_extracted__"
+
+
+@dataclass(frozen=True)
+class SessionRule:
+    """A named rule extracted from session content."""
+
+    name: str
+    instruction: str
+
+
+async def save_rules(db_pool: "DatabasePool", session_id: str, rules: list[SessionRule]) -> None:
+    """Persist rules for a session.
+
+    If rules is empty, inserts a sentinel row so has_rules() returns True
+    (preventing repeated extraction attempts).
+    """
+    rows_to_insert = [
+        (str(uuid.uuid4()), session_id, r.name, r.instruction) for r in rules
+    ]
+    if not rows_to_insert:
+        rows_to_insert = [(str(uuid.uuid4()), session_id, SENTINEL_RULE_NAME, "")]
+
+    async with db_pool.connection() as conn:
+        async with conn.transaction():
+            if db_pool.is_sqlite:
+                for row_id, sid, name, instruction in rows_to_insert:
+                    await conn.execute(
+                        "INSERT INTO session_rules (id, session_id, rule_name, rule_instruction) "
+                        "VALUES (?, ?, ?, ?)",
+                        row_id,
+                        sid,
+                        name,
+                        instruction,
+                    )
+            else:
+                for row_id, sid, name, instruction in rows_to_insert:
+                    await conn.execute(
+                        "INSERT INTO session_rules (id, session_id, rule_name, rule_instruction) "
+                        "VALUES ($1, $2, $3, $4)",
+                        row_id,
+                        sid,
+                        name,
+                        instruction,
+                    )
+
+
+async def load_rules(db_pool: "DatabasePool", session_id: str) -> list[SessionRule]:
+    """Load rules for a session, filtering out sentinel rows."""
+    if db_pool.is_sqlite:
+        query = "SELECT rule_name, rule_instruction FROM session_rules WHERE session_id = ? AND rule_name != ?"
+        rows = await (await db_pool.get_pool()).fetch(query, session_id, SENTINEL_RULE_NAME)
+    else:
+        query = "SELECT rule_name, rule_instruction FROM session_rules WHERE session_id = $1 AND rule_name != $2"
+        rows = await (await db_pool.get_pool()).fetch(query, session_id, SENTINEL_RULE_NAME)
+
+    return [SessionRule(name=str(row["rule_name"]), instruction=str(row["rule_instruction"])) for row in rows]
+
+
+async def has_rules(db_pool: "DatabasePool", session_id: str) -> bool:
+    """Check if rules have been extracted for this session (including sentinel)."""
+    if db_pool.is_sqlite:
+        query = "SELECT 1 FROM session_rules WHERE session_id = ? LIMIT 1"
+        row = await (await db_pool.get_pool()).fetchrow(query, session_id)
+    else:
+        query = "SELECT 1 FROM session_rules WHERE session_id = $1 LIMIT 1"
+        row = await (await db_pool.get_pool()).fetchrow(query, session_id)
+
+    return row is not None
+
+
+__all__ = ["SessionRule", "has_rules", "load_rules", "save_rules"]

--- a/src/luthien_proxy/storage/session_rules.py
+++ b/src/luthien_proxy/storage/session_rules.py
@@ -33,9 +33,7 @@ async def save_rules(db_pool: "DatabasePool", session_id: str, rules: list[Sessi
     If rules is empty, inserts a sentinel row so has_rules() returns True
     (preventing repeated extraction attempts).
     """
-    rows_to_insert = [
-        (str(uuid.uuid4()), session_id, r.name, r.instruction) for r in rules
-    ]
+    rows_to_insert = [(str(uuid.uuid4()), session_id, r.name, r.instruction) for r in rules]
     if not rows_to_insert:
         rows_to_insert = [(str(uuid.uuid4()), session_id, SENTINEL_RULE_NAME, "")]
 
@@ -44,8 +42,7 @@ async def save_rules(db_pool: "DatabasePool", session_id: str, rules: list[Sessi
             if db_pool.is_sqlite:
                 for row_id, sid, name, instruction in rows_to_insert:
                     await conn.execute(
-                        "INSERT INTO session_rules (id, session_id, rule_name, rule_instruction) "
-                        "VALUES (?, ?, ?, ?)",
+                        "INSERT INTO session_rules (id, session_id, rule_name, rule_instruction) VALUES (?, ?, ?, ?)",
                         row_id,
                         sid,
                         name,

--- a/src/luthien_proxy/utils/sqlite_schema.sql
+++ b/src/luthien_proxy/utils/sqlite_schema.sql
@@ -148,3 +148,13 @@ CREATE TABLE IF NOT EXISTS telemetry_config (
     updated_by TEXT
 );
 INSERT OR IGNORE INTO telemetry_config (id) VALUES (1);
+
+-- Session rules (extracted per-session, e.g. from CLAUDE.md)
+CREATE TABLE IF NOT EXISTS session_rules (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    rule_name TEXT NOT NULL,
+    rule_instruction TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_session_rules_session ON session_rules(session_id);

--- a/tests/luthien_proxy/unit_tests/policies/test_claude_md_rules_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_claude_md_rules_policy.py
@@ -1,0 +1,383 @@
+"""Unit tests for ClaudeMdRulesPolicy."""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from litellm.types.utils import Choices, Message, ModelResponse
+
+from conftest import DEFAULT_TEST_MODEL
+from luthien_proxy.llm.types.anthropic import AnthropicRequest, AnthropicResponse
+from luthien_proxy.policies.claude_md_rules_policy import (
+    ClaudeMdRulesPolicy,
+    _find_claude_md_content,
+    _parse_extracted_rules,
+)
+from luthien_proxy.policy_core.policy_context import PolicyContext
+from luthien_proxy.storage.session_rules import SessionRule
+
+
+def _make_litellm_response(content: str) -> ModelResponse:
+    return ModelResponse(
+        id="test-id",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(content=content, role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model="test-model",
+        object="chat.completion",
+    )
+
+
+def _make_stub_io(request: AnthropicRequest | None = None) -> MagicMock:
+    """Create a stub AnthropicPolicyIOProtocol."""
+    io = MagicMock()
+    io.request = request or {
+        "model": DEFAULT_TEST_MODEL,
+        "messages": [{"role": "user", "content": "Hello"}],
+        "max_tokens": 100,
+    }
+    io.first_backend_response = None
+
+    response: AnthropicResponse = {
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Original text"}],
+        "model": DEFAULT_TEST_MODEL,
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+    async def mock_complete(req=None):
+        return response
+
+    io.complete = mock_complete
+    return io
+
+
+class TestFindClaudeMdContent:
+    def test_finds_in_system_string(self):
+        request: AnthropicRequest = {
+            "model": DEFAULT_TEST_MODEL,
+            "system": "Contents of CLAUDE.md: Be concise.",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 100,
+        }
+        result = _find_claude_md_content(request)
+        assert result is not None
+        assert "CLAUDE.md" in result
+
+    def test_finds_in_system_blocks(self):
+        request: AnthropicRequest = {
+            "model": DEFAULT_TEST_MODEL,
+            "system": [{"type": "text", "text": "File: CLAUDE.md\nPrefer early returns."}],
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 100,
+        }
+        result = _find_claude_md_content(request)
+        assert result is not None
+        assert "early returns" in result
+
+    def test_finds_in_first_user_message(self):
+        request: AnthropicRequest = {
+            "model": DEFAULT_TEST_MODEL,
+            "messages": [
+                {"role": "user", "content": "Here is my CLAUDE.md: no jargon."},
+            ],
+            "max_tokens": 100,
+        }
+        result = _find_claude_md_content(request)
+        assert result is not None
+
+    def test_returns_none_when_no_indicators(self):
+        request: AnthropicRequest = {
+            "model": DEFAULT_TEST_MODEL,
+            "messages": [{"role": "user", "content": "Just a normal message."}],
+            "max_tokens": 100,
+        }
+        result = _find_claude_md_content(request)
+        assert result is None
+
+    def test_finds_system_reminder_tag(self):
+        request: AnthropicRequest = {
+            "model": DEFAULT_TEST_MODEL,
+            "system": "<system-reminder>Be helpful</system-reminder>",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 100,
+        }
+        result = _find_claude_md_content(request)
+        assert result is not None
+
+    def test_returns_none_for_empty_messages(self):
+        request: AnthropicRequest = {
+            "model": DEFAULT_TEST_MODEL,
+            "messages": [],
+            "max_tokens": 100,
+        }
+        result = _find_claude_md_content(request)
+        assert result is None
+
+    def test_finds_claudeMd_indicator(self):
+        """Detect the 'claudeMd' indicator used by Claude Code."""
+        request: AnthropicRequest = {
+            "model": DEFAULT_TEST_MODEL,
+            "system": "# claudeMd\nPrefer f-strings.",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 100,
+        }
+        result = _find_claude_md_content(request)
+        assert result is not None
+
+
+class TestParseExtractedRules:
+    def test_parses_valid_json_array(self):
+        output = '[{"name": "no-emoji", "instruction": "Never use emoji."}]'
+        rules = _parse_extracted_rules(output)
+        assert len(rules) == 1
+        assert rules[0].name == "no-emoji"
+        assert rules[0].instruction == "Never use emoji."
+
+    def test_parses_multiple_rules(self):
+        output = """[
+            {"name": "concise", "instruction": "Be concise."},
+            {"name": "no-jargon", "instruction": "Avoid jargon."}
+        ]"""
+        rules = _parse_extracted_rules(output)
+        assert len(rules) == 2
+
+    def test_handles_empty_array(self):
+        rules = _parse_extracted_rules("[]")
+        assert rules == []
+
+    def test_strips_markdown_fences(self):
+        output = '```json\n[{"name": "r1", "instruction": "Do it."}]\n```'
+        rules = _parse_extracted_rules(output)
+        assert len(rules) == 1
+        assert rules[0].name == "r1"
+
+    def test_handles_leading_text(self):
+        output = 'Here are the rules:\n[{"name": "r1", "instruction": "Do it."}]'
+        rules = _parse_extracted_rules(output)
+        assert len(rules) == 1
+
+    def test_returns_empty_for_no_json(self):
+        rules = _parse_extracted_rules("I found no rules to extract.")
+        assert rules == []
+
+    def test_skips_malformed_items(self):
+        output = '[{"name": "ok", "instruction": "Good"}, {"bad": true}, {"name": "", "instruction": "empty name"}]'
+        rules = _parse_extracted_rules(output)
+        assert len(rules) == 1
+        assert rules[0].name == "ok"
+
+    def test_returns_empty_for_invalid_json(self):
+        rules = _parse_extracted_rules("[{invalid json}]")
+        assert rules == []
+
+
+class TestClaudeMdRulesPolicyPassthrough:
+    """Tests for graceful degradation when session_id or db_pool is missing."""
+
+    @pytest.mark.asyncio
+    @patch("luthien_proxy.policies.rules_llm_utils.acompletion")
+    async def test_no_session_id_passthrough(self, mock_acompletion):
+        """Without session_id, passes through to ParallelRulesPolicy with no rules."""
+        mock_acompletion.return_value = _make_litellm_response("unused")
+
+        policy = ClaudeMdRulesPolicy()
+        ctx = PolicyContext.for_testing()  # no session_id
+        io = _make_stub_io()
+
+        emissions = []
+        async for emission in policy.run_anthropic(io, ctx):
+            emissions.append(emission)
+
+        assert len(emissions) == 1
+        # Should pass through without calling extraction LLM
+        mock_acompletion.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("luthien_proxy.policies.rules_llm_utils.acompletion")
+    async def test_no_db_pool_passthrough(self, mock_acompletion):
+        """Without db_pool, passes through with no rules."""
+        mock_acompletion.return_value = _make_litellm_response("unused")
+
+        policy = ClaudeMdRulesPolicy()
+        ctx = PolicyContext.for_testing(session_id="sess-1")  # no db_pool
+        io = _make_stub_io()
+
+        emissions = []
+        async for emission in policy.run_anthropic(io, ctx):
+            emissions.append(emission)
+
+        assert len(emissions) == 1
+        mock_acompletion.assert_not_called()
+
+
+class TestClaudeMdRulesPolicyExtraction:
+    """Tests for first-turn rule extraction and subsequent-turn loading."""
+
+    @pytest.mark.asyncio
+    @patch("luthien_proxy.policies.claude_md_rules_policy.save_rules")
+    @patch("luthien_proxy.policies.claude_md_rules_policy.load_rules")
+    @patch("luthien_proxy.policies.claude_md_rules_policy.has_rules")
+    @patch("luthien_proxy.policies.rules_llm_utils.acompletion")
+    async def test_first_turn_extracts_and_saves(
+        self, mock_acompletion, mock_has_rules, mock_load_rules, mock_save_rules
+    ):
+        """On first turn with CLAUDE.md, extracts rules and saves to DB."""
+        mock_has_rules.return_value = False
+        mock_save_rules.return_value = None
+
+        # Extraction LLM returns rules
+        extraction_response = _make_litellm_response(
+            '[{"name": "concise", "instruction": "Be concise."}]'
+        )
+        # Rule application LLM
+        application_response = _make_litellm_response("Concise text")
+
+        mock_acompletion.side_effect = [extraction_response, application_response]
+
+        policy = ClaudeMdRulesPolicy()
+        mock_db = MagicMock()
+        ctx = PolicyContext.for_testing(session_id="sess-1", db_pool=mock_db)
+        io = _make_stub_io(
+            request={
+                "model": DEFAULT_TEST_MODEL,
+                "system": "Contents of CLAUDE.md: Be concise always.",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 100,
+            }
+        )
+
+        emissions = []
+        async for emission in policy.run_anthropic(io, ctx):
+            emissions.append(emission)
+
+        assert len(emissions) == 1
+        # Extraction call + 1 rule application call
+        assert mock_acompletion.call_count == 2
+        # Rules were saved
+        mock_save_rules.assert_called_once()
+        saved_rules = mock_save_rules.call_args.args[2]
+        assert len(saved_rules) == 1
+        assert saved_rules[0].name == "concise"
+
+    @pytest.mark.asyncio
+    @patch("luthien_proxy.policies.claude_md_rules_policy.save_rules")
+    @patch("luthien_proxy.policies.claude_md_rules_policy.load_rules")
+    @patch("luthien_proxy.policies.claude_md_rules_policy.has_rules")
+    @patch("luthien_proxy.policies.rules_llm_utils.acompletion")
+    async def test_subsequent_turn_loads_from_db(
+        self, mock_acompletion, mock_has_rules, mock_load_rules, mock_save_rules
+    ):
+        """On subsequent turns, loads rules from DB without extraction."""
+        mock_has_rules.return_value = True
+        mock_load_rules.return_value = [SessionRule(name="concise", instruction="Be concise.")]
+
+        mock_acompletion.return_value = _make_litellm_response("Concise text")
+
+        policy = ClaudeMdRulesPolicy()
+        mock_db = MagicMock()
+        ctx = PolicyContext.for_testing(session_id="sess-1", db_pool=mock_db)
+        io = _make_stub_io()
+
+        emissions = []
+        async for emission in policy.run_anthropic(io, ctx):
+            emissions.append(emission)
+
+        assert len(emissions) == 1
+        # Only rule application, no extraction
+        assert mock_acompletion.call_count == 1
+        mock_save_rules.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("luthien_proxy.policies.claude_md_rules_policy.save_rules")
+    @patch("luthien_proxy.policies.claude_md_rules_policy.load_rules")
+    @patch("luthien_proxy.policies.claude_md_rules_policy.has_rules")
+    @patch("luthien_proxy.policies.rules_llm_utils.acompletion")
+    async def test_no_claude_md_saves_empty_sentinel(
+        self, mock_acompletion, mock_has_rules, mock_load_rules, mock_save_rules
+    ):
+        """When no CLAUDE.md found, saves empty rules (sentinel) to avoid re-scanning."""
+        mock_has_rules.return_value = False
+        mock_save_rules.return_value = None
+
+        policy = ClaudeMdRulesPolicy()
+        mock_db = MagicMock()
+        ctx = PolicyContext.for_testing(session_id="sess-1", db_pool=mock_db)
+        io = _make_stub_io()  # No CLAUDE.md in request
+
+        emissions = []
+        async for emission in policy.run_anthropic(io, ctx):
+            emissions.append(emission)
+
+        # Saved empty rules
+        mock_save_rules.assert_called_once()
+        saved_rules = mock_save_rules.call_args.args[2]
+        assert saved_rules == []
+
+        # No extraction LLM call (no CLAUDE.md content)
+        mock_acompletion.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("luthien_proxy.policies.claude_md_rules_policy.save_rules")
+    @patch("luthien_proxy.policies.claude_md_rules_policy.load_rules")
+    @patch("luthien_proxy.policies.claude_md_rules_policy.has_rules")
+    @patch("luthien_proxy.policies.rules_llm_utils.acompletion")
+    async def test_extraction_failure_saves_sentinel(
+        self, mock_acompletion, mock_has_rules, mock_load_rules, mock_save_rules
+    ):
+        """When extraction LLM fails, saves empty sentinel and continues."""
+        mock_has_rules.return_value = False
+        mock_save_rules.return_value = None
+
+        # Extraction fails, then rule application succeeds (for passthrough)
+        mock_acompletion.side_effect = [Exception("LLM error")]
+
+        policy = ClaudeMdRulesPolicy()
+        mock_db = MagicMock()
+        ctx = PolicyContext.for_testing(session_id="sess-1", db_pool=mock_db)
+        io = _make_stub_io(
+            request={
+                "model": DEFAULT_TEST_MODEL,
+                "system": "Contents of CLAUDE.md: rules here",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 100,
+            }
+        )
+
+        emissions = []
+        async for emission in policy.run_anthropic(io, ctx):
+            emissions.append(emission)
+
+        # Should have saved empty rules on failure
+        mock_save_rules.assert_called_once()
+        saved_rules = mock_save_rules.call_args.args[2]
+        assert saved_rules == []
+
+        # Response still emitted (passthrough)
+        assert len(emissions) == 1
+
+
+class TestClaudeMdRulesPolicyConfig:
+    def test_default_config(self):
+        policy = ClaudeMdRulesPolicy()
+        assert policy.config.model == "claude-haiku-4-5"
+        assert policy.config.temperature == 0.0
+
+    def test_custom_config(self):
+        policy = ClaudeMdRulesPolicy(config={"model": "claude-opus", "temperature": 0.5})
+        assert policy.config.model == "claude-opus"
+        assert policy.config.temperature == 0.5
+
+    def test_short_policy_name(self):
+        policy = ClaudeMdRulesPolicy()
+        assert policy.short_policy_name == "ClaudeMdRules"

--- a/tests/luthien_proxy/unit_tests/policies/test_claude_md_rules_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_claude_md_rules_policy.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from litellm.types.utils import Choices, Message, ModelResponse
@@ -237,9 +236,7 @@ class TestClaudeMdRulesPolicyExtraction:
         mock_save_rules.return_value = None
 
         # Extraction LLM returns rules
-        extraction_response = _make_litellm_response(
-            '[{"name": "concise", "instruction": "Be concise."}]'
-        )
+        extraction_response = _make_litellm_response('[{"name": "concise", "instruction": "Be concise."}]')
         # Rule application LLM
         application_response = _make_litellm_response("Concise text")
 

--- a/tests/luthien_proxy/unit_tests/storage/test_session_rules.py
+++ b/tests/luthien_proxy/unit_tests/storage/test_session_rules.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/luthien_proxy/unit_tests/storage/test_session_rules.py
+++ b/tests/luthien_proxy/unit_tests/storage/test_session_rules.py
@@ -1,0 +1,151 @@
+"""Unit tests for session rules storage."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from luthien_proxy.storage.session_rules import (
+    SENTINEL_RULE_NAME,
+    SessionRule,
+    has_rules,
+    load_rules,
+    save_rules,
+)
+
+
+class TestSessionRuleDataclass:
+    def test_frozen(self):
+        rule = SessionRule(name="test", instruction="Do the thing")
+        assert rule.name == "test"
+        assert rule.instruction == "Do the thing"
+        with pytest.raises(AttributeError):
+            rule.name = "changed"  # type: ignore[misc]
+
+
+def _make_mock_db_pool(*, is_sqlite: bool = True) -> MagicMock:
+    """Create a mock DatabasePool with connection context manager and pool fetch methods."""
+    mock_conn = AsyncMock()
+
+    @asynccontextmanager
+    async def _mock_transaction():
+        yield
+
+    mock_conn.transaction = _mock_transaction
+
+    pool = MagicMock()
+    pool.is_sqlite = is_sqlite
+
+    @asynccontextmanager
+    async def _mock_connection():
+        yield mock_conn
+
+    pool.connection = _mock_connection
+    pool._mock_conn = mock_conn  # expose for assertions
+
+    mock_pool_obj = AsyncMock()
+    pool.get_pool = AsyncMock(return_value=mock_pool_obj)
+
+    return pool
+
+
+class TestSaveRules:
+    @pytest.mark.asyncio
+    async def test_save_rules_inserts_rows(self):
+        db_pool = _make_mock_db_pool(is_sqlite=True)
+        rules = [
+            SessionRule(name="r1", instruction="Rule 1"),
+            SessionRule(name="r2", instruction="Rule 2"),
+        ]
+
+        await save_rules(db_pool, "session-1", rules)
+
+        mock_conn = db_pool._mock_conn
+        assert mock_conn.execute.call_count == 2
+
+        # Verify the SQL uses ? placeholders for SQLite
+        first_call = mock_conn.execute.call_args_list[0]
+        assert "?" in first_call.args[0]
+        assert first_call.args[2] == "session-1"
+        assert first_call.args[3] == "r1"
+        assert first_call.args[4] == "Rule 1"
+
+    @pytest.mark.asyncio
+    async def test_save_empty_rules_inserts_sentinel(self):
+        db_pool = _make_mock_db_pool(is_sqlite=True)
+
+        await save_rules(db_pool, "session-1", [])
+
+        mock_conn = db_pool._mock_conn
+        assert mock_conn.execute.call_count == 1
+
+        call = mock_conn.execute.call_args_list[0]
+        assert call.args[3] == SENTINEL_RULE_NAME
+        assert call.args[4] == ""
+
+    @pytest.mark.asyncio
+    async def test_save_rules_postgres_uses_dollar_placeholders(self):
+        db_pool = _make_mock_db_pool(is_sqlite=False)
+        rules = [SessionRule(name="r1", instruction="Rule 1")]
+
+        await save_rules(db_pool, "session-1", rules)
+
+        mock_conn = db_pool._mock_conn
+        first_call = mock_conn.execute.call_args_list[0]
+        assert "$1" in first_call.args[0]
+
+
+class TestLoadRules:
+    @pytest.mark.asyncio
+    async def test_load_rules_returns_session_rules(self):
+        db_pool = _make_mock_db_pool(is_sqlite=True)
+        mock_pool_obj = await db_pool.get_pool()
+        mock_pool_obj.fetch = AsyncMock(
+            return_value=[
+                {"rule_name": "r1", "rule_instruction": "Do thing 1"},
+                {"rule_name": "r2", "rule_instruction": "Do thing 2"},
+            ]
+        )
+
+        result = await load_rules(db_pool, "session-1")
+
+        assert len(result) == 2
+        assert result[0].name == "r1"
+        assert result[0].instruction == "Do thing 1"
+        assert result[1].name == "r2"
+
+    @pytest.mark.asyncio
+    async def test_load_rules_filters_sentinel(self):
+        """load_rules query excludes sentinel rows."""
+        db_pool = _make_mock_db_pool(is_sqlite=True)
+        mock_pool_obj = await db_pool.get_pool()
+        mock_pool_obj.fetch = AsyncMock(return_value=[])
+
+        result = await load_rules(db_pool, "session-1")
+
+        assert result == []
+        # Verify the query filters out the sentinel
+        call_args = mock_pool_obj.fetch.call_args
+        assert SENTINEL_RULE_NAME in call_args.args
+
+
+class TestHasRules:
+    @pytest.mark.asyncio
+    async def test_has_rules_true_when_rows_exist(self):
+        db_pool = _make_mock_db_pool(is_sqlite=True)
+        mock_pool_obj = await db_pool.get_pool()
+        mock_pool_obj.fetchrow = AsyncMock(return_value={"1": 1})
+
+        result = await has_rules(db_pool, "session-1")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_has_rules_false_when_no_rows(self):
+        db_pool = _make_mock_db_pool(is_sqlite=True)
+        mock_pool_obj = await db_pool.get_pool()
+        mock_pool_obj.fetchrow = AsyncMock(return_value=None)
+
+        result = await has_rules(db_pool, "session-1")
+        assert result is False


### PR DESCRIPTION
## Summary

- **New `ClaudeMdRulesPolicy`**: Scans system prompts for CLAUDE.md content on first turn, extracts objective rules via LLM, persists to DB, and applies via `ParallelRulesPolicy` on all subsequent turns
- **New `session_rules` table**: Postgres migration + SQLite schema for per-session rule persistence, with sentinel pattern to distinguish "never extracted" from "extracted but empty"
- **`PolicyContext.db_pool`**: Exposes the database pool to policies that need direct DB access; passed through from `anthropic_processor`

## Test plan

- [x] Unit tests for `SessionRule` dataclass, `save_rules`, `load_rules`, `has_rules` with mock DB pool
- [x] Unit tests for CLAUDE.md detection (`_find_claude_md_content`) across system string, system blocks, user messages
- [x] Unit tests for rule extraction parsing (`_parse_extracted_rules`) including JSON fences, malformed items, empty arrays
- [x] Unit tests for policy passthrough (no session_id, no db_pool)
- [x] Unit tests for first-turn extraction + save, subsequent-turn loading, extraction failure graceful degradation
- [x] Full unit test suite passes (all existing tests unaffected)
- [x] `dev_checks.sh` passes (format, lint, type check, complexity)

---
*Posted by Claude Code (Claude Opus 4.6)*