### PR TITLE
feat: add fast_checks.sh for faster dev iteration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 3. Make sure we're on a feature branch (not `main`)
 4. Commit the changes, push to origin, and open a draft PR (to `main`)
 5. Implement the OBJECTIVE. Add any items that should be done but are out of scope for the current OBJECTIVE to the [Trello board](https://trello.com/b/ehoxykPf/luthien?filter=label:luthien-proxy%20TODO) (e.g. noticing an implementation bug, incorrect documentation, or code that should be refactored).
-6. Regularly run `scripts/dev_checks.sh`, then commit and push any formatting/lint fixes along with your changes to origin (on the feature branch).
+6. Regularly run `scripts/fast_checks.sh` during development (parallel pyright+pytest, no coverage, changed-file tests only). Run `scripts/dev_checks.sh` for the full gate before marking a PR ready.
 7. When the OBJECTIVE is complete, add a changelog fragment to `changelog.d/` (see `changelog.d/README.md`)
 8. Clear `dev/OBJECTIVE.md` and `dev/NOTES.md`
 9. Mark the PR as ready.
@@ -73,6 +73,7 @@ Note that both Claude Code and Codex agents work in this repo and may read from 
 2. **Develop**
 
    - Format everything with `"$(git rev-parse --show-toplevel)/scripts/format_all.sh"`.
+   - Fast iteration checks: `"$(git rev-parse --show-toplevel)/scripts/fast_checks.sh"` (parallel, no coverage, changed-file tests only).
    - Full lint + tests + type check: `"$(git rev-parse --show-toplevel)/scripts/dev_checks.sh"`.
    - Quick unit pass: `uv run pytest tests/luthien_proxy/unit_tests`.
    - *infrequently* run full e2e tests using `uv run pytest -m e2e`. This is SLOW and should be used sparingly to validate that core functionality remains intact.
@@ -137,6 +138,7 @@ Note that both Claude Code and Codex agents work in this repo and may read from 
 - Start gateway (dockerless): `./scripts/start_gateway.sh` — runs the gateway as a local Python process with SQLite, no Docker/Postgres/Redis needed
 - Run tests: `uv run pytest` (coverage: `uv run pytest --cov=src -q`)
 - Lint/format: `uv run ruff format` then `uv run ruff check --fix`. The `scripts/dev_checks.sh` script applies formatting automatically, and VS Code formats on save via Ruff. See `scripts/format_all.sh` for a quick all-in-one solution.
+- Fast checks: `scripts/fast_checks.sh` — runs ruff, shellcheck, pyright, and pytest in parallel with no coverage. By default only tests files changed since the merge-base with main; use `--all` for the full unit suite.
 - Type check: `uv run pyright`
 
 ### Deployment Modes

--- a/changelog.d/fast-checks.md
+++ b/changelog.d/fast-checks.md
@@ -1,0 +1,6 @@
+---
+category: Features
+pr: 489
+---
+
+**Fast dev checks**: Add `scripts/fast_checks.sh` for faster development iteration (~10s vs ~40s). Runs pyright and pytest in parallel with xdist, defaults to testing only changed files.

--- a/dev-README.md
+++ b/dev-README.md
@@ -26,7 +26,13 @@ uv run pytest -m e2e
 # Format and lint
 ./scripts/format_all.sh
 
-# Full dev checks (format + lint + tests + type check)
+# Fast dev checks (parallel, no coverage, changed-file tests)
+./scripts/fast_checks.sh
+
+# Fast checks with all unit tests
+./scripts/fast_checks.sh --all
+
+# Full dev checks — PR gate (format + lint + tests + type check + coverage)
 ./scripts/dev_checks.sh
 
 # Type check only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ dev = [
     "asgi-lifespan>=2.1.0",
     "luthien-cli",
     "pytest-httpx>=0.35.0",
+    "pytest-xdist>=3.5.0",
 ]
 
 [tool.uv.sources]

--- a/scripts/fast_checks.sh
+++ b/scripts/fast_checks.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Fast sanity checks for active development.
+# Same gates as dev_checks.sh minus coverage and report-only steps,
+# with pyright + pytest running in parallel, and pytest using xdist.
+# By default, only runs unit tests for changed files (since merge-base with main).
+# Use dev_checks.sh for the full gate before PRs.
+#
+# Options:
+#   --all    Run all unit tests, not just changed-file tests
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+RUN_ALL=0
+for arg in "$@"; do
+    case "$arg" in
+        --all) RUN_ALL=1 ;;
+        *) echo "Unknown option: $arg"; exit 1 ;;
+    esac
+done
+
+# ── Phase 1: Lint + shellcheck (fast, sequential — may fix files) ────
+
+echo "== Ruff format =="
+uv run ruff format
+
+echo "== Ruff lint (autofix) =="
+uv run ruff check --fix
+
+echo "== Ruff lint (gate) =="
+uv run ruff check
+
+echo "== Shellcheck =="
+SCRIPT_DIR="$REPO_ROOT/scripts"
+shellcheck_failed=0
+pushd "$SCRIPT_DIR" > /dev/null
+for script in *.sh; do
+    if [[ -f "$script" ]]; then
+        if ! shellcheck --shell=bash -x "$script" 2>/dev/null; then
+            shellcheck_failed=1
+        fi
+    fi
+done
+popd > /dev/null
+if [[ "$shellcheck_failed" -ne 0 ]]; then
+    echo "  Shellcheck found issues."
+    exit 1
+fi
+echo "  All scripts passed."
+
+# ── Phase 2: Resolve test targets ────────────────────────────────────
+
+PYTEST_ARGS=(-p no:cacheprovider --no-cov -q)
+test_target_msg="all unit tests"
+
+if [ "$RUN_ALL" -eq 0 ]; then
+    merge_base=$(git merge-base HEAD main 2>/dev/null || echo "")
+    if [ -n "$merge_base" ] && [ "$(git rev-parse HEAD)" != "$merge_base" ]; then
+        # Collect changed .py files (committed + staged + unstaged)
+        changed_files=$(
+            { git diff --name-only "$merge_base" HEAD -- '*.py'
+              git diff --name-only -- '*.py'
+              git diff --cached --name-only -- '*.py'
+            } | sort -u
+        )
+
+        test_files=()
+        while IFS= read -r f; do
+            [ -z "$f" ] && continue
+
+            # Changed unit test file — include if it's actually a test file
+            if [[ "$f" == tests/luthien_proxy/unit_tests/*/test_*.py ]]; then
+                if [ -f "$REPO_ROOT/$f" ]; then
+                    test_files+=("$f")
+                fi
+                continue
+            fi
+
+            # Changed CLI test file — include if it's actually a test file
+            if [[ "$f" == tests/luthien_cli/test_*.py ]]; then
+                if [ -f "$REPO_ROOT/$f" ]; then
+                    test_files+=("$f")
+                fi
+                continue
+            fi
+
+            # Changed conftest or fixture — run all tests (can't scope the impact)
+            if [[ "$f" == tests/*/conftest.py ]] || [[ "$f" == tests/luthien_proxy/fixtures/* ]]; then
+                test_files=()
+                test_target_msg="all unit tests (conftest/fixture changed)"
+                break
+            fi
+
+            # Proxy source file → corresponding unit test
+            # src/luthien_proxy/foo/bar.py → tests/luthien_proxy/unit_tests/foo/test_bar.py
+            if [[ "$f" == src/luthien_proxy/* ]]; then
+                rel="${f#src/luthien_proxy/}"
+                dir=$(dirname "$rel")
+                base=$(basename "$rel" .py)
+                test_path="tests/luthien_proxy/unit_tests/${dir}/test_${base}.py"
+                if [ -f "$REPO_ROOT/$test_path" ]; then
+                    test_files+=("$test_path")
+                fi
+                continue
+            fi
+
+            # CLI source file → corresponding test
+            # src/luthien_cli/src/luthien_cli/commands/onboard.py → tests/luthien_cli/test_onboard.py
+            # src/luthien_cli/src/luthien_cli/config.py → tests/luthien_cli/test_config.py
+            if [[ "$f" == src/luthien_cli/src/luthien_cli/* ]]; then
+                base=$(basename "$f" .py)
+                test_path="tests/luthien_cli/test_${base}.py"
+                if [ -f "$REPO_ROOT/$test_path" ]; then
+                    test_files+=("$test_path")
+                fi
+                continue
+            fi
+        done <<< "$changed_files"
+
+        # Deduplicate and set pytest args
+        if [ ${#test_files[@]} -gt 0 ]; then
+            mapfile -t test_files < <(printf '%s\n' "${test_files[@]}" | sort -u)
+            PYTEST_ARGS+=("${test_files[@]}")
+            test_target_msg="${#test_files[@]} changed-file test(s)"
+        elif [[ "$test_target_msg" != *"conftest"* ]]; then
+            # No test files matched and not a conftest trigger — run all as safety net
+            test_target_msg="all unit tests (no test files matched changes)"
+        fi
+    fi
+fi
+
+# Use xdist only when running enough tests to justify worker startup overhead
+if [[ "$test_target_msg" == "all unit"* ]]; then
+    PYTEST_ARGS+=(-n auto)
+fi
+
+# ── Phase 3: Type check + tests (parallel) ───────────────────────────
+
+PYRIGHT_LOG=$(mktemp)
+PYTEST_LOG=$(mktemp)
+trap 'rm -f "$PYRIGHT_LOG" "$PYTEST_LOG"' EXIT
+
+pyright_failed=0
+pytest_failed=0
+
+echo "== Pyright + Pytest [${test_target_msg}] (parallel) =="
+
+uv run pyright > "$PYRIGHT_LOG" 2>&1 &
+pid_pyright=$!
+
+uv run pytest "${PYTEST_ARGS[@]}" > "$PYTEST_LOG" 2>&1 &
+pid_pytest=$!
+
+wait "$pid_pyright" || pyright_failed=1
+wait "$pid_pytest"  || pytest_failed=1
+
+if [ "$pyright_failed" -ne 0 ]; then
+    echo ""
+    echo "── Pyright FAILED ──"
+    cat "$PYRIGHT_LOG"
+fi
+
+if [ "$pytest_failed" -ne 0 ]; then
+    echo ""
+    echo "── Pytest FAILED ──"
+    cat "$PYTEST_LOG"
+fi
+
+if [ "$pyright_failed" -ne 0 ] || [ "$pytest_failed" -ne 0 ]; then
+    if [ "$pyright_failed" -eq 0 ]; then
+        echo ""
+        echo "── Pyright passed ──"
+        tail -1 "$PYRIGHT_LOG"
+    fi
+    if [ "$pytest_failed" -eq 0 ]; then
+        echo ""
+        echo "── Pytest passed ──"
+        tail -3 "$PYTEST_LOG"
+    fi
+    exit 1
+fi
+
+# Both passed — show summaries
+echo ""
+tail -1 "$PYRIGHT_LOG"
+tail -3 "$PYTEST_LOG"
+echo ""
+echo "All fast checks passed."

--- a/uv.lock
+++ b/uv.lock
@@ -502,6 +502,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.128.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1020,6 +1029,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "radon" },
     { name = "ruff" },
     { name = "vulture" },
@@ -1059,6 +1069,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-httpx", specifier = ">=0.35.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "radon", specifier = ">=6.0.1" },
     { name = "ruff", specifier = ">=0.12.10" },
     { name = "vulture", specifier = ">=2.14" },
@@ -1762,6 +1773,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `scripts/fast_checks.sh` — a faster alternative to `dev_checks.sh` for active development
- Runs pyright and pytest **in parallel**, with pytest using **xdist** for multi-core test execution
- **Changed-files mode** (default): only runs unit tests for files changed since merge-base with main
- `--all` flag forces full unit test suite
- Add `pytest-xdist>=3.5.0` dev dependency
- Update CLAUDE.md and dev-README.md with fast_checks documentation

### Timing

| Mode | Wall clock | vs dev_checks |
|---|---|---|
| `dev_checks.sh` (baseline) | ~40s | — |
| `fast_checks.sh --all` | ~21s | **48% faster** |
| `fast_checks.sh` (changed files) | ~10s | **75% faster** |

### Changed-files mapping

- `src/luthien_proxy/foo/bar.py` → `tests/luthien_proxy/unit_tests/foo/test_bar.py`
- `src/luthien_cli/src/luthien_cli/commands/onboard.py` → `tests/luthien_cli/test_onboard.py`
- conftest.py or fixture changes → full test suite (can't scope impact)
- Includes staged, unstaged, and committed changes since merge-base

## Test plan

- [x] `fast_checks.sh` passes on clean main
- [x] `fast_checks.sh --all` runs full suite with xdist
- [x] Changed proxy source file correctly maps to unit test
- [x] Changed CLI source file correctly maps to CLI test
- [x] conftest.py change triggers full suite
- [x] Non-test files (conftest, fixtures) not passed as test targets
- [x] `dev_checks.sh` still passes with xdist dependency present
- [x] shellcheck passes on the new script

---
*Posted by Claude Code (claude-opus-4-6)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)