### PR TITLE
chore:  replaced value-prop marketing copy with technical description + readme platform callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ No Docker required. This installs [`uv`](https://docs.astral.sh/uv/) (if needed)
 
 > **Claude Pro/Max users**: You don't need an API key. Luthien passes your existing Claude subscription credentials through to the Anthropic API — no extra cost, no configuration needed.
 
-> **Platform support**: Linux and macOS. Windows is not currently supported.
+> **🚨 Platform support**: Linux and macOS. Windows is **not currently supported.**
 
 After setup, use the CLI or Claude Code to manage the proxy:
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ No Docker required. This installs [`uv`](https://docs.astral.sh/uv/) (if needed)
 
 > **Claude Pro/Max users**: You don't need an API key. Luthien passes your existing Claude subscription credentials through to the Anthropic API — no extra cost, no configuration needed.
 
-> **🚨 Platform support**: Linux and macOS. Windows is **not currently supported.**
+> **🚨 Platform support**: Linux and macOS only. Windows is **not currently supported.**
 
 After setup, use the CLI or Claude Code to manage the proxy:
 

--- a/changelog.d/add-value-prop.md
+++ b/changelog.d/add-value-prop.md
@@ -1,6 +1,6 @@
 ---
 category: Chores & Docs
-pr: 
+pr: 510
 ---
 
 **Homepage subheader**: Replaced value-prop marketing copy with a plain technical description of what Luthien does, aimed at users who have already installed it

--- a/changelog.d/add-value-prop.md
+++ b/changelog.d/add-value-prop.md
@@ -1,5 +1,6 @@
 ---
 category: Chores & Docs
+pr: 
 ---
 
 **Index page subheader**: Added a plain-language description of Luthien under the gateway title on the homepage

--- a/changelog.d/add-value-prop.md
+++ b/changelog.d/add-value-prop.md
@@ -3,4 +3,4 @@ category: Chores & Docs
 pr: 
 ---
 
-**Index page subheader**: Added a plain-language description of Luthien under the gateway title on the homepage
+**Homepage subheader**: Replaced value-prop marketing copy with a plain technical description of what Luthien does, aimed at users who have already installed it

--- a/changelog.d/add-value-prop.md
+++ b/changelog.d/add-value-prop.md
@@ -1,0 +1,5 @@
+---
+category: Chores & Docs
+---
+
+**Index page subheader**: Added a plain-language description of Luthien under the gateway title on the homepage

--- a/src/luthien_proxy/static/index.html
+++ b/src/luthien_proxy/static/index.html
@@ -387,7 +387,7 @@
     <div class="container">
         <header>
             <h1>Luthien Proxy Gateway</h1>
-            <p class="subheader">Proxy between Claude Code and Anthropic. Requests are logged and run through your configured policies before reaching the API</p>
+            <p class="subheader">Proxy between Claude Code and Anthropic. Requests are logged and run through your configured policies before reaching the API.</p>
         </header>
 
         <div class="card-list">

--- a/src/luthien_proxy/static/index.html
+++ b/src/luthien_proxy/static/index.html
@@ -36,7 +36,7 @@
             font-size: clamp(1.3rem, 3vw, 1.8rem);
             font-weight: 600;
             color: #fafafa;
-            margin-bottom: 4px;
+            margin-bottom: 12px;
             letter-spacing: -0.02em;
         }
 
@@ -49,7 +49,6 @@
             color: #a1a1aa;
             font-size: 16px;
             max-width: 640px;
-            margin-top: 8px;
             margin-bottom: 12px;
             line-height: 1.6;
         }

--- a/src/luthien_proxy/static/index.html
+++ b/src/luthien_proxy/static/index.html
@@ -387,7 +387,7 @@
     <div class="container">
         <header>
             <h1>Luthien Proxy Gateway</h1>
-            <p class="subheader">Luthien sits between Claude Code and Anthropic. Every request your AI makes passes through the proxy where it's logged, inspected, and held to the rules you set. You told Claude what to do. This is how you find out if it listened.</p>
+            <p class="subheader">Proxy between Claude Code and Anthropic. Requests are logged and run through your configured policies before reaching the API</p>
         </header>
 
         <div class="card-list">

--- a/src/luthien_proxy/static/index.html
+++ b/src/luthien_proxy/static/index.html
@@ -45,6 +45,14 @@
             font-size: 14px;
         }
 
+        .subheader {
+            color: #a1a1aa;
+            font-size: 16px;
+            max-width: 640px;
+            margin-top: 8px;
+            margin-bottom: 12px;
+        }
+
         .section-label {
             font-family: 'JetBrains Mono', monospace;
             font-size: 1.1rem;
@@ -379,6 +387,7 @@
     <div class="container">
         <header>
             <h1>Luthien Proxy Gateway</h1>
+            <p class="subheader">Luthien sits between Claude Code and Anthropic. Every request your AI makes passes through the proxy where it's logged, inspected, and held to the rules you set. You told Claude what to do. This is how you find out if it listened.</p>
         </header>
 
         <div class="card-list">

--- a/src/luthien_proxy/static/index.html
+++ b/src/luthien_proxy/static/index.html
@@ -51,6 +51,7 @@
             max-width: 640px;
             margin-top: 8px;
             margin-bottom: 12px;
+            line-height: 1.6;
         }
 
         .section-label {


### PR DESCRIPTION
This pull request updates the homepage of Luthien to provide a clearer, more technically-focused description of the product, targeting users who have already installed it. The changes also include minor visual improvements to the layout and styling of the homepage header and subheader.

Homepage content and style updates:

* Replaced the marketing-focused value proposition in the homepage subheader with a concise technical description: "Proxy between Claude Code and Anthropic. Requests are logged and run through your configured policies before reaching the API." (`src/luthien_proxy/static/index.html`, `changelog.d/add-value-prop.md`)
* Added a new `.subheader` CSS class to style the subheader text, including color, font size, max width, margin, and line height for improved readability. (`src/luthien_proxy/static/index.html`)
* Increased the bottom margin of the main header to improve spacing and visual hierarchy. (`src/luthien_proxy/static/index.html`)