### PR TITLE
feat: add agent-tutorial reference to onboarding message

### DIFF
--- a/changelog.d/onboarding-agent-tutorial.md
+++ b/changelog.d/onboarding-agent-tutorial.md
@@ -1,0 +1,6 @@
+---
+category: Features
+pr: 512
+---
+
+**Onboarding policy**: Added `!luthien agent-tutorial` to the welcome message quick reference.

--- a/src/luthien_proxy/policies/onboarding_policy.py
+++ b/src/luthien_proxy/policies/onboarding_policy.py
@@ -49,6 +49,8 @@ tool call judges, or write your own.
 - `!luthien logs` — view gateway logs
 - `!luthien config` — manage settings
 - `!luthien down` / `!luthien up` — stop/start the gateway
+- `!luthien agent-tutorial` — how to create and activate policies via the CLI and API \
+(run this if you need to implement or manage policies)
 
 ---"""
 


### PR DESCRIPTION
## Summary

- Adds `!luthien agent-tutorial` to the onboarding policy's quick reference section
- Keeps the welcome message concise — no inline API docs or curl examples
- Depends on #511 (the CLI command this references)

## Test plan

- [ ] Onboarding policy unit tests pass
- [ ] First-turn welcome message includes the agent-tutorial line
- [ ] Message renders correctly with gateway_url substitution


---
*Posted by Claude Code (Opus 4.6)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)