### PR TITLE
docs: add release procedures to dev/README.md

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -83,6 +83,55 @@ uv run pytest tests/luthien_proxy/unit_tests
 uv run pytest -m e2e
 ```
 
+## Releasing
+
+Proxy releases are **fully automated** on merge to main. The `auto-tag-proxy` workflow compiles changelog fragments, cuts a versioned section in `CHANGELOG.md`, and tags the release. The existing `release.yml` and `docker-publish.yml` workflows handle GitHub Releases and Docker image publishing.
+
+### What happens on every merge to main
+
+1. Workflow checks for proxy-relevant file changes since the last `v*` tag
+2. Runs unit tests as a gate
+3. Compiles any `changelog.d/` fragments into `CHANGELOG.md`
+4. Renames `## Unreleased` to `## X.Y.Z | YYYY-MM-DD`
+5. Commits changelog, tags `vX.Y.Z`, pushes both
+6. GitHub Release is created with changelog body + wheel artifacts
+7. Docker images are built and pushed to GHCR (`gateway:X.Y.Z`, `gateway:latest`)
+
+### Patch releases (automatic)
+
+Nothing to do. Every merge to main auto-increments the patch version (v3.0.0 → v3.0.1 → v3.0.2 ...).
+
+### Minor or major releases (manual tag)
+
+To bump the minor or major version, create the tag on main before the next merge:
+
+```bash
+git checkout main && git pull
+git tag v3.1.0          # or v4.0.0 for a major bump
+git push origin v3.1.0
+```
+
+The next PR merge will auto-increment from there (v3.1.1, v3.1.2, ...).
+
+### Changelog fragments
+
+Every PR should include a `changelog.d/<name>.md` fragment:
+
+```markdown
+---
+category: Features|Fixes|Refactors|Chores & Docs
+pr: 123
+---
+
+**Short title**: Description of the change
+```
+
+See `changelog.d/README.md` for full format details. The `changelog-check` workflow reminds you if a fragment is missing.
+
+### CLI releases (separate)
+
+`luthien-cli` has its own auto-release pipeline (`auto-tag-cli.yml` → `release-cli.yml`). CLI tags use the `cli-v*` prefix and publish to PyPI. These are independent of proxy releases.
+
 ## Architecture Overview
 
 The V2 gateway is a FastAPI application with integrated LiteLLM and a streaming pipeline for policy enforcement:

--- a/dev/context/decisions.md
+++ b/dev/context/decisions.md
@@ -7,21 +7,18 @@ If updating existing content significantly, note it: `## Topic (2025-10-08, upda
 
 ---
 
-## Release Automation and CHANGELOG Enforcement (2026-03-18)
+## Auto-Release on Merge to Main (2026-04-09)
 
-**Decision**: Add two GitHub Actions workflows — a CHANGELOG reminder on PRs and a tag-based release workflow.
+**Decision**: Fully automated patch releases on every merge to main. Replaces the previous manual tag-based workflow (2026-03-18). See `dev/README.md` § Releasing for the full procedure.
 
-**How releasing works**:
-1. Maintain a `## Unreleased` section in `CHANGELOG.md` as features land
-2. When ready to release: rename `## Unreleased` to `## vX.Y.Z`, push a `vX.Y.Z` tag
-3. The release workflow automatically: checks out the repo, extracts the changelog section for that version via AWK, builds the package with `uv build`, and creates a GitHub Release with the changelog notes and dist artifacts
+**How it works**: `auto-tag-proxy.yml` fires on push to main, compiles `changelog.d/` fragments, cuts a versioned `CHANGELOG.md` section, commits it back (with `[skip auto-tag-proxy]` to prevent loops), and tags `vX.Y.Z`. Downstream workflows (`release.yml`, `docker-publish.yml`) handle GitHub Releases and Docker images. Minor/major bumps are manual (just create the tag).
 
-**CHANGELOG enforcement**: A non-blocking workflow posts a one-time reminder comment on PRs that don't modify `CHANGELOG.md`. PRs labeled `skip-changelog` or `chore` skip the check entirely. This is intentionally a reminder, not a gate — some PRs legitimately don't need changelog entries.
+**CHANGELOG enforcement**: Unchanged — non-blocking reminder on PRs missing a `changelog.d/` fragment. PRs labeled `skip-changelog` or `chore` skip the check.
 
 **Rationale**:
-- **Why non-blocking**: A hard gate would slow down chore/infra PRs and train people to add meaningless entries. A reminder is enough to catch accidental omissions.
-- **Why tag-based releases**: Simple, standard flow. No release branches or manual artifact uploads. Push a tag → get a release.
-- **Why AWK for changelog extraction**: No external dependencies, runs in any CI environment. Matches `## vX.Y.Z` or `## X.Y.Z` headers in CHANGELOG.md.
+- **Why auto-release on merge**: The manual process produced 72 uncompiled fragments over months. Manual = never.
+- **Why patch-only auto-bumps**: Simplicity. Minor/major bumps are intentional decisions that shouldn't be automated.
+- **Why rebase instead of skip on concurrent merges**: Successive merges would silently lose tags if the verify step just skipped. Rebase handles the common case; conflicts fail loudly.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add "Releasing" section to `dev/README.md` covering auto-release workflow, manual minor/major bumps, changelog fragment format, and CLI release independence
- Update `dev/context/decisions.md` to reflect the new auto-release-on-merge approach (replaces stale manual tag-based entry from 2026-03-18)

## Test plan

- [ ] Docs-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)