### PR TITLE
feat: rich DB and Redis health checks on /health

### DIFF
--- a/changelog.d/rich-health-checks.md
+++ b/changelog.d/rich-health-checks.md
@@ -1,0 +1,5 @@
+---
+category: Features
+---
+
+**Rich health checks on `/health`**: The health endpoint now probes DB (`SELECT 1`) and Redis (`ping`) in parallel and reports per-component status with latency measurements. Overall `status` reflects real infrastructure state: `healthy` / `degraded` (Redis unreachable) / `unhealthy` (DB unreachable). Returns HTTP 200 always — callers inspect the body. Redis absent (SQLite/local mode) is `not_configured` and does not affect the overall status.

--- a/changelog.d/rich-health-checks.md
+++ b/changelog.d/rich-health-checks.md
@@ -1,5 +1,6 @@
 ---
 category: Features
+pr: 516
 ---
 
 **Rich health checks on `/health`**: The health endpoint now probes DB (`SELECT 1`) and Redis (`ping`) in parallel and reports per-component status with latency measurements. Overall `status` reflects real infrastructure state: `healthy` / `degraded` (Redis unreachable) / `unhealthy` (DB unreachable). Returns HTTP 200 always — callers inspect the body. Redis absent (SQLite/local mode) is `not_configured` and does not affect the overall status.

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -366,7 +366,7 @@ def create_app(
                     await conn.execute("SELECT 1")
                 return {"status": "ok", "latency_ms": round((time.perf_counter() - t0) * 1000, 1)}
             except Exception:
-                logger.exception("Health check: DB probe failed")
+                logger.warning("Health check: DB probe failed", exc_info=True)
                 return {"status": "error", "error": "database check failed"}
 
         async def _check_redis() -> dict[str, object]:
@@ -378,7 +378,7 @@ def create_app(
                 await redis_client.ping()
                 return {"status": "ok", "latency_ms": round((time.perf_counter() - t0) * 1000, 1)}
             except Exception:
-                logger.exception("Health check: Redis probe failed")
+                logger.warning("Health check: Redis probe failed", exc_info=True)
                 return {"status": "error", "error": "redis check failed"}
 
         db_check, redis_check = await asyncio.gather(_check_db(), _check_redis())

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import logging
 import os
 import secrets
+import time
 from contextlib import asynccontextmanager
 
 import litellm
@@ -339,8 +341,9 @@ def create_app(
     async def health(request: Request):
         """Health check endpoint.
 
-        Returns gateway status, auth mode, and last observed credential type so
-        operators and the UI can surface billing mode warnings accurately.
+        Probes DB and Redis in parallel and reports per-component status so
+        operators and monitoring tools can distinguish degraded from unhealthy.
+        Returns HTTP 200 always — callers must inspect the body for status.
         """
         deps = getattr(request.app.state, "dependencies", None)
         auth_mode = None
@@ -353,12 +356,47 @@ def create_app(
             last_credential_type = deps.last_credential_info.get("type")
             last_credential_at = deps.last_credential_info.get("timestamp")
 
+        async def _check_db() -> dict[str, object]:
+            db_pool = getattr(deps, "db_pool", None) if deps else None
+            if db_pool is None:
+                return {"status": "not_configured"}
+            try:
+                t0 = time.perf_counter()
+                async with db_pool.connection() as conn:
+                    await conn.execute("SELECT 1")
+                return {"status": "ok", "latency_ms": round((time.perf_counter() - t0) * 1000, 1)}
+            except Exception:
+                logger.exception("Health check: DB probe failed")
+                return {"status": "error", "error": "database check failed"}
+
+        async def _check_redis() -> dict[str, object]:
+            redis_client = getattr(deps, "redis_client", None) if deps else None
+            if redis_client is None:
+                return {"status": "not_configured"}
+            try:
+                t0 = time.perf_counter()
+                await redis_client.ping()
+                return {"status": "ok", "latency_ms": round((time.perf_counter() - t0) * 1000, 1)}
+            except Exception:
+                logger.exception("Health check: Redis probe failed")
+                return {"status": "error", "error": "redis check failed"}
+
+        db_check, redis_check = await asyncio.gather(_check_db(), _check_redis())
+
+        if db_check["status"] == "error":
+            overall = "unhealthy"
+        elif redis_check["status"] == "error":
+            overall = "degraded"
+        else:
+            overall = "healthy"
+
         return {
-            "status": "healthy",
+            "status": overall,
             "version": PROXY_DISPLAY_VERSION,
             "auth_mode": auth_mode,
             "last_credential_type": last_credential_type,
             "last_credential_at": last_credential_at,
+            "checks": {"db": db_check, "redis": redis_check},
         }
 
     # Format HTTPExceptions and validation errors as Anthropic errors on /v1/messages paths

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -303,13 +303,24 @@ policy:
 @pytest.fixture
 def mock_db_pool():
     """Create a mock database pool for testing."""
+    from contextlib import asynccontextmanager
+
     mock = AsyncMock()
     mock_pool = AsyncMock()
-    # fetchrow returns None by default (no rows found)
     mock_pool.fetchrow = AsyncMock(return_value=None)
     mock.get_pool = AsyncMock(return_value=mock_pool)
     mock.close = AsyncMock()
     mock.is_sqlite = False
+
+    mock_conn = AsyncMock()
+    mock_conn.execute = AsyncMock(return_value=None)
+
+    @asynccontextmanager
+    async def _connection():
+        yield mock_conn
+
+    mock.connection = _connection
+    mock._mock_conn = mock_conn
     return mock
 
 
@@ -390,7 +401,7 @@ class TestCreateApp:
         assert "/v1/messages" in routes or any("/v1/messages" in str(r) for r in routes if r)
 
     def test_create_app_health_endpoint(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """Test health endpoint returns correct response shape."""
+        """Health endpoint returns healthy with DB and Redis both ok."""
         mock_redis_client.get = AsyncMock(return_value=None)
         app = create_app(
             api_key="test-key",
@@ -409,6 +420,61 @@ class TestCreateApp:
             assert data["auth_mode"] in ("proxy_key", "both", "passthrough", None)
             assert "last_credential_type" in data
             assert "last_credential_at" in data
+            assert data["checks"]["db"]["status"] == "ok"
+            assert data["checks"]["redis"]["status"] == "ok"
+
+    def test_create_app_health_endpoint_db_error(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Health endpoint returns unhealthy when DB probe fails."""
+        mock_db_pool._mock_conn.execute = AsyncMock(side_effect=Exception("connection refused"))
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            data = client.get("/health").json()
+            assert data["status"] == "unhealthy"
+            assert data["checks"]["db"]["status"] == "error"
+            assert data["checks"]["db"]["error"] == "database check failed"
+            assert "connection refused" not in data["checks"]["db"]["error"]
+
+    def test_create_app_health_endpoint_redis_error(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Health endpoint returns degraded when Redis probe fails but DB is ok."""
+        mock_redis_client.ping = AsyncMock(side_effect=Exception("timeout"))
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            data = client.get("/health").json()
+            assert data["status"] == "degraded"
+            assert data["checks"]["db"]["status"] == "ok"
+            assert data["checks"]["redis"]["status"] == "error"
+            assert data["checks"]["redis"]["error"] == "redis check failed"
+            assert "timeout" not in data["checks"]["redis"]["error"]
+
+    def test_create_app_health_endpoint_redis_not_configured(self, policy_config_file, mock_db_pool):
+        """Health endpoint shows redis not_configured when no Redis client is available."""
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=None,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            data = client.get("/health").json()
+            assert data["status"] == "healthy"
+            assert data["checks"]["db"]["status"] == "ok"
+            assert data["checks"]["redis"]["status"] == "not_configured"
 
     def test_create_app_health_endpoint_proxy_key_mode(self, policy_config_file, mock_db_pool, mock_redis_client):
         """Health endpoint reports auth_mode=proxy_key when configured."""

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -476,6 +476,41 @@ class TestCreateApp:
             assert data["checks"]["db"]["status"] == "ok"
             assert data["checks"]["redis"]["status"] == "not_configured"
 
+    def test_create_app_health_endpoint_db_not_configured(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Health endpoint shows db not_configured when db_pool is None on deps at request time."""
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            app.state.dependencies.db_pool = None
+            data = client.get("/health").json()
+            assert data["status"] == "healthy"
+            assert data["checks"]["db"]["status"] == "not_configured"
+            assert data["checks"]["redis"]["status"] == "ok"
+
+    def test_create_app_health_endpoint_both_infra_error(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """DB error takes priority over Redis error — overall status is unhealthy not degraded."""
+        mock_db_pool._mock_conn.execute = AsyncMock(side_effect=Exception("db down"))
+        mock_redis_client.ping = AsyncMock(side_effect=Exception("redis down"))
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            data = client.get("/health").json()
+            assert data["status"] == "unhealthy"
+            assert data["checks"]["db"]["status"] == "error"
+            assert data["checks"]["redis"]["status"] == "error"
+
     def test_create_app_health_endpoint_proxy_key_mode(self, policy_config_file, mock_db_pool, mock_redis_client):
         """Health endpoint reports auth_mode=proxy_key when configured."""
         mock_redis_client.get = AsyncMock(return_value=None)


### PR DESCRIPTION
Replaces PR #515 (which bundled Railway removal).

## Changes

**`src/luthien_proxy/main.py`**
- Probe DB (`SELECT 1`) and Redis (`ping`) in parallel via `asyncio.gather`
- Per-component: `status: ok|error|not_configured` + `latency_ms`
- Overall `status`: `healthy` / `degraded` (redis error) / `unhealthy` (db error)
- HTTP 200 always — callers inspect the body
- Error messages sanitized: `"database check failed"` / `"redis check failed"` (no connection strings)
- `PROXY_DISPLAY_VERSION` kept (regression from #515 fixed)

**`tests/luthien_proxy/unit_tests/test_main.py`**
- `mock_db_pool` fixture extended with `connection()` async context manager
- 4 new tests: healthy both, DB error → unhealthy, Redis error → degraded, Redis not_configured → healthy
- 1795 unit tests pass

## Addresses all review issues from #515
1. ✅ `PROXY_DISPLAY_VERSION` restored
2. ✅ Railway removal excluded (separate concern)
3. ✅ Error messages sanitized
4. ✅ DB + Redis checked concurrently with `asyncio.gather`