### PR TITLE
feat: Prometheus /metrics endpoint

### DIFF
--- a/changelog.d/prometheus-metrics.md
+++ b/changelog.d/prometheus-metrics.md
@@ -12,3 +12,5 @@ Metrics exposed:
 - `luthien_active_requests` — in-flight request gauge
 
 Implementation: `MetricsAwareUsageCollector` extends `UsageCollector` as a drop-in replacement — the existing external telemetry sender is unaffected. OTel `MeterProvider` with `PrometheusMetricReader` wired at startup alongside the existing `TracerProvider`.
+
+Note: `/metrics` is unauthenticated (standard Prometheus convention). Public deployments should restrict access at the network layer (ingress allowlist or private subnet).

--- a/changelog.d/prometheus-metrics.md
+++ b/changelog.d/prometheus-metrics.md
@@ -8,7 +8,7 @@ pr: 517
 Metrics exposed:
 - `luthien_requests_total{streaming}` — cumulative request counter (completed requests)
 - `luthien_tokens_total{type}` — cumulative token counter (`input` / `output`)
-- `luthien_request_duration_seconds{status}` — request latency histogram for `/v1/messages`
+- `luthien_request_ttfb_seconds{status}` — time-to-first-byte histogram for `/v1/messages` (BaseHTTPMiddleware limitation)
 - `luthien_active_requests` — in-flight request gauge
 
 Implementation: `MetricsAwareUsageCollector` extends `UsageCollector` as a drop-in replacement — the existing external telemetry sender is unaffected. OTel `MeterProvider` with `PrometheusMetricReader` wired at startup alongside the existing `TracerProvider`.

--- a/changelog.d/prometheus-metrics.md
+++ b/changelog.d/prometheus-metrics.md
@@ -8,7 +8,7 @@ pr: 517
 Metrics exposed:
 - `luthien_requests_completed_total{streaming}` — completed request counter
 - `luthien_tokens_total{type}` — cumulative token counter (`input` / `output`)
-- `luthien_request_ttfb_seconds{status,streaming}` — latency histogram for `/v1/messages` (full duration for non-streaming, TTFB for streaming)
+- `luthien_request_duration_seconds{status,streaming}` — latency histogram for `/v1/messages` (full duration for non-streaming, TTFB for streaming — use `streaming` label to split)
 - `luthien_active_requests` — in-flight request gauge
 
 Implementation: `MetricsAwareUsageCollector` extends `UsageCollector` as a drop-in replacement — the existing external telemetry sender is unaffected. OTel `MeterProvider` with `PrometheusMetricReader` wired at startup alongside the existing `TracerProvider`.

--- a/changelog.d/prometheus-metrics.md
+++ b/changelog.d/prometheus-metrics.md
@@ -1,0 +1,14 @@
+---
+category: Features
+pr: 517
+---
+
+**Prometheus `/metrics` endpoint**: The gateway now exposes Prometheus-compatible metrics at `/metrics` via the OpenTelemetry Prometheus exporter.
+
+Metrics exposed:
+- `luthien_requests_total{streaming}` — cumulative request counter (completed requests)
+- `luthien_tokens_total{type}` — cumulative token counter (`input` / `output`)
+- `luthien_request_duration_seconds{status}` — request latency histogram for `/v1/messages`
+- `luthien_active_requests` — in-flight request gauge
+
+Implementation: `MetricsAwareUsageCollector` extends `UsageCollector` as a drop-in replacement — the existing external telemetry sender is unaffected. OTel `MeterProvider` with `PrometheusMetricReader` wired at startup alongside the existing `TracerProvider`.

--- a/changelog.d/prometheus-metrics.md
+++ b/changelog.d/prometheus-metrics.md
@@ -6,7 +6,7 @@ pr: 517
 **Prometheus `/metrics` endpoint**: The gateway now exposes Prometheus-compatible metrics at `/metrics` via the OpenTelemetry Prometheus exporter.
 
 Metrics exposed:
-- `luthien_requests_total{streaming}` — cumulative request counter (completed requests)
+- `luthien_requests_completed_total{streaming}` — completed request counter
 - `luthien_tokens_total{type}` — cumulative token counter (`input` / `output`)
 - `luthien_request_ttfb_seconds{status}` — time-to-first-byte histogram for `/v1/messages` (BaseHTTPMiddleware limitation)
 - `luthien_active_requests` — in-flight request gauge

--- a/changelog.d/prometheus-metrics.md
+++ b/changelog.d/prometheus-metrics.md
@@ -8,9 +8,11 @@ pr: 517
 Metrics exposed:
 - `luthien_requests_completed_total{streaming}` — completed request counter
 - `luthien_tokens_total{type}` — cumulative token counter (`input` / `output`)
-- `luthien_request_ttfb_seconds{status}` — time-to-first-byte histogram for `/v1/messages` (BaseHTTPMiddleware limitation)
+- `luthien_request_ttfb_seconds{status,streaming}` — latency histogram for `/v1/messages` (full duration for non-streaming, TTFB for streaming)
 - `luthien_active_requests` — in-flight request gauge
 
 Implementation: `MetricsAwareUsageCollector` extends `UsageCollector` as a drop-in replacement — the existing external telemetry sender is unaffected. OTel `MeterProvider` with `PrometheusMetricReader` wired at startup alongside the existing `TracerProvider`.
 
-Note: `/metrics` is unauthenticated (standard Prometheus convention). Public deployments should restrict access at the network layer (ingress allowlist or private subnet).
+Notes:
+- `/metrics` is unauthenticated (standard Prometheus convention). Public deployments should restrict access at the network layer (ingress allowlist or private subnet).
+- Multi-worker deployments (`uvicorn --workers N`) will report per-worker metrics; Prometheus scrapes will hit whichever worker the OS load-balances to. Current scripts run single-worker.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
     "opentelemetry-instrumentation-fastapi>=0.41b0",
     "opentelemetry-instrumentation-redis>=0.41b0",
+    "opentelemetry-exporter-prometheus>=0.41b0",
     "psycopg>=3.2.9",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.0.0",

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -14,6 +14,7 @@ from contextlib import asynccontextmanager
 import litellm
 import uvicorn
 from fastapi import FastAPI, Request
+from fastapi.concurrency import run_in_threadpool
 from fastapi.exceptions import HTTPException as FastAPIHTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
@@ -143,27 +144,36 @@ async def request_validation_error_handler(request: Request, exc: Exception) -> 
 
 
 class LatencyMiddleware(BaseHTTPMiddleware):
-    """Record TTFB and in-flight gauge for /v1/messages requests.
+    """Record latency histogram and in-flight gauge for /v1/messages only.
 
-    NOTE: BaseHTTPMiddleware.dispatch returns at TTFB (first byte), not
-    stream completion. For non-streaming requests this measures full latency;
-    for streaming it measures only time-to-first-byte. Both the histogram
-    and gauge reflect this asymmetry.
-    Pure-ASGI middleware would be needed for true stream-duration metrics.
+    Only instruments the primary completion endpoint. Passthrough routes
+    (/v1/models, /v1/messages/count_tokens, etc.) are intentionally excluded
+    because they have different latency profiles.
+
+    Measurement semantics depend on response type:
+      - Non-streaming: full request duration (body fully produced)
+      - Streaming (text/event-stream): time-to-first-byte only
+    A ``streaming`` label on the histogram lets dashboards split the two
+    distributions. Pure-ASGI middleware would be needed for true
+    stream-duration metrics.
     """
 
     async def dispatch(self, request: Request, call_next):
         if request.url.path != "/v1/messages":
             return await call_next(request)
-        active_requests.add(1)
         t0 = time.perf_counter()
         response = None
         try:
+            active_requests.add(1)
             response = await call_next(request)
             return response
         finally:
             status = str(response.status_code) if response is not None else "error"
-            request_duration.record(time.perf_counter() - t0, {"status": status})
+            is_streaming = response is not None and "text/event-stream" in response.headers.get("content-type", "")
+            request_duration.record(
+                time.perf_counter() - t0,
+                {"status": status, "streaming": str(is_streaming).lower()},
+            )
             active_requests.add(-1)
 
 
@@ -411,8 +421,8 @@ def create_app(
 
     @app.get("/metrics", include_in_schema=False)
     async def prometheus_metrics() -> Response:
-        # No auth required; standard for Prometheus scraping
-        return Response(generate_latest(REGISTRY), media_type=CONTENT_TYPE_LATEST)
+        body = await run_in_threadpool(generate_latest, REGISTRY)
+        return Response(body, media_type=CONTENT_TYPE_LATEST)
 
     app.add_middleware(LatencyMiddleware)
 

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -7,6 +7,7 @@ import enum
 import logging
 import os
 import secrets
+import time
 from collections.abc import MutableMapping
 from contextlib import asynccontextmanager
 
@@ -15,8 +16,9 @@ import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.exceptions import HTTPException as FastAPIHTTPException
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
+from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, generate_latest
 from pydantic import ValidationError
 from redis.asyncio import Redis
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -32,6 +34,7 @@ from luthien_proxy.gateway_routes import router as gateway_router
 from luthien_proxy.history import routes as history_routes
 from luthien_proxy.llm import anthropic_client_cache
 from luthien_proxy.llm.anthropic_client import AnthropicClient
+from luthien_proxy.metrics import MetricsAwareUsageCollector, active_requests, request_duration
 from luthien_proxy.observability.emitter import EventEmitter
 from luthien_proxy.observability.event_publisher import (
     EventPublisherProtocol,
@@ -46,6 +49,7 @@ from luthien_proxy.session import router as session_router
 from luthien_proxy.settings import Settings, clear_settings_cache, get_settings
 from luthien_proxy.telemetry import (
     configure_logging,
+    configure_metrics,
     configure_tracing,
     instrument_app,
     instrument_redis,
@@ -65,9 +69,10 @@ from luthien_proxy.utils.migration_check import check_migrations
 from luthien_proxy.utils.url import sanitize_url_for_logging
 from luthien_proxy.version import PROXY_DISPLAY_VERSION
 
-# Configure OpenTelemetry tracing and logging EARLY (before app creation)
-# This ensures the tracer provider is set up before any spans are created
+# Configure OpenTelemetry tracing, metrics, and logging EARLY (before app creation)
+# This ensures the tracer/meter providers are set up before any spans or metrics are created
 configure_tracing()
+configure_metrics()
 configure_logging()
 instrument_redis()
 
@@ -267,7 +272,7 @@ def create_app(
         _usage_collector: UsageCollector | None = None
         _telemetry_sender: TelemetrySender | None = None
         if _telemetry_config.enabled:
-            _usage_collector = UsageCollector()
+            _usage_collector = MetricsAwareUsageCollector()
             _telemetry_sender = TelemetrySender(
                 config=_telemetry_config,
                 collector=_usage_collector,
@@ -377,6 +382,28 @@ def create_app(
             "last_credential_type": last_credential_type,
             "last_credential_at": last_credential_at,
         }
+
+    @app.get("/metrics", include_in_schema=False)
+    async def prometheus_metrics() -> Response:
+        return Response(generate_latest(REGISTRY), media_type=CONTENT_TYPE_LATEST)
+
+    class _LatencyMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request: Request, call_next):
+            if request.url.path != "/v1/messages":
+                return await call_next(request)
+            active_requests.add(1)
+            t0 = time.perf_counter()
+            try:
+                response = await call_next(request)
+                return response
+            finally:
+                request_duration.record(
+                    time.perf_counter() - t0,
+                    {"status": str(getattr(response, "status_code", 0))},
+                )
+                active_requests.add(-1)
+
+    app.add_middleware(_LatencyMiddleware)
 
     # Format HTTPExceptions and validation errors as Anthropic errors on /v1/messages paths
     app.add_exception_handler(FastAPIHTTPException, http_exception_handler)

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -142,6 +142,31 @@ async def request_validation_error_handler(request: Request, exc: Exception) -> 
     return JSONResponse(status_code=422, content={"detail": validation_exc.errors()})
 
 
+class LatencyMiddleware(BaseHTTPMiddleware):
+    """Record TTFB and in-flight gauge for /v1/messages requests.
+
+    NOTE: BaseHTTPMiddleware.dispatch returns at TTFB (first byte), not
+    stream completion. For non-streaming requests this measures full latency;
+    for streaming it measures only time-to-first-byte. Both the histogram
+    and gauge reflect this asymmetry.
+    Pure-ASGI middleware would be needed for true stream-duration metrics.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path != "/v1/messages":
+            return await call_next(request)
+        active_requests.add(1)
+        t0 = time.perf_counter()
+        response = None
+        try:
+            response = await call_next(request)
+            return response
+        finally:
+            status = str(response.status_code) if response is not None else "error"
+            request_duration.record(time.perf_counter() - t0, {"status": status})
+            active_requests.add(-1)
+
+
 def create_app(
     api_key: str | None,
     admin_key: str | None,
@@ -389,25 +414,7 @@ def create_app(
         # No auth required; standard for Prometheus scraping
         return Response(generate_latest(REGISTRY), media_type=CONTENT_TYPE_LATEST)
 
-    class _LatencyMiddleware(BaseHTTPMiddleware):
-        # NOTE: BaseHTTPMiddleware.dispatch returns at TTFB (first byte), not
-        # stream completion. Both the histogram and gauge reflect TTFB timing.
-        # Pure-ASGI middleware would be needed for true stream-duration metrics.
-        async def dispatch(self, request: Request, call_next):
-            if request.url.path != "/v1/messages":
-                return await call_next(request)
-            active_requests.add(1)
-            t0 = time.perf_counter()
-            response = None
-            try:
-                response = await call_next(request)
-                return response
-            finally:
-                status = str(response.status_code) if response is not None else "error"
-                request_duration.record(time.perf_counter() - t0, {"status": status})
-                active_requests.add(-1)
-
-    app.add_middleware(_LatencyMiddleware)
+    app.add_middleware(LatencyMiddleware)
 
     # Format HTTPExceptions and validation errors as Anthropic errors on /v1/messages paths
     app.add_exception_handler(FastAPIHTTPException, http_exception_handler)

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -332,7 +332,7 @@ def create_app(
     class StaticCacheMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request: Request, call_next):
             response = await call_next(request)
-            if request.url.path.startswith("/api/") or request.url.path == "/health":
+            if request.url.path.startswith("/api/") or request.url.path in ("/health", "/metrics"):
                 # Prevent CDN/edge caching of API and health responses (Railway, Cloudflare, etc.)
                 response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
             elif request.url.path.startswith("/static/"):
@@ -385,6 +385,7 @@ def create_app(
 
     @app.get("/metrics", include_in_schema=False)
     async def prometheus_metrics() -> Response:
+        # No auth required; standard for Prometheus scraping
         return Response(generate_latest(REGISTRY), media_type=CONTENT_TYPE_LATEST)
 
     class _LatencyMiddleware(BaseHTTPMiddleware):
@@ -393,14 +394,13 @@ def create_app(
                 return await call_next(request)
             active_requests.add(1)
             t0 = time.perf_counter()
+            response = None
             try:
                 response = await call_next(request)
                 return response
             finally:
-                request_duration.record(
-                    time.perf_counter() - t0,
-                    {"status": str(getattr(response, "status_code", 0))},
-                )
+                status = str(response.status_code) if response is not None else "error"
+                request_duration.record(time.perf_counter() - t0, {"status": status})
                 active_requests.add(-1)
 
     app.add_middleware(_LatencyMiddleware)

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -389,14 +389,12 @@ def create_app(
         # No auth required; standard for Prometheus scraping
         return Response(generate_latest(REGISTRY), media_type=CONTENT_TYPE_LATEST)
 
-    _METERED_PATHS = frozenset({"/v1/messages", "/v1/chat/completions"})
-
     class _LatencyMiddleware(BaseHTTPMiddleware):
         # NOTE: BaseHTTPMiddleware.dispatch returns at TTFB (first byte), not
         # stream completion. Both the histogram and gauge reflect TTFB timing.
         # Pure-ASGI middleware would be needed for true stream-duration metrics.
         async def dispatch(self, request: Request, call_next):
-            if request.url.path not in _METERED_PATHS:
+            if request.url.path != "/v1/messages":
                 return await call_next(request)
             active_requests.add(1)
             t0 = time.perf_counter()

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -161,10 +161,10 @@ class LatencyMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         if request.url.path != "/v1/messages":
             return await call_next(request)
+        active_requests.add(1)
         t0 = time.perf_counter()
         response = None
         try:
-            active_requests.add(1)
             response = await call_next(request)
             return response
         finally:

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -269,10 +269,11 @@ def create_app(
             db_pool=db_pool,
             env_value=settings.usage_telemetry,
         )
-        _usage_collector: UsageCollector | None = None
+        # Always create MetricsAwareUsageCollector so Prometheus counters
+        # work regardless of the phone-home telemetry setting.
+        _usage_collector: UsageCollector = MetricsAwareUsageCollector()
         _telemetry_sender: TelemetrySender | None = None
         if _telemetry_config.enabled:
-            _usage_collector = MetricsAwareUsageCollector()
             _telemetry_sender = TelemetrySender(
                 config=_telemetry_config,
                 collector=_usage_collector,
@@ -280,7 +281,7 @@ def create_app(
             )
             _telemetry_sender.start()
         else:
-            logger.info("Usage telemetry disabled")
+            logger.info("Usage telemetry disabled (Prometheus metrics still active)")
 
         # Create Dependencies container with all services
         _dependencies = Dependencies(
@@ -389,6 +390,9 @@ def create_app(
         return Response(generate_latest(REGISTRY), media_type=CONTENT_TYPE_LATEST)
 
     class _LatencyMiddleware(BaseHTTPMiddleware):
+        # NOTE: BaseHTTPMiddleware.dispatch returns at TTFB (first byte), not
+        # stream completion. Both the histogram and gauge reflect TTFB timing.
+        # Pure-ASGI middleware would be needed for true stream-duration metrics.
         async def dispatch(self, request: Request, call_next):
             if request.url.path != "/v1/messages":
                 return await call_next(request)

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -389,12 +389,14 @@ def create_app(
         # No auth required; standard for Prometheus scraping
         return Response(generate_latest(REGISTRY), media_type=CONTENT_TYPE_LATEST)
 
+    _METERED_PATHS = frozenset({"/v1/messages", "/v1/chat/completions"})
+
     class _LatencyMiddleware(BaseHTTPMiddleware):
         # NOTE: BaseHTTPMiddleware.dispatch returns at TTFB (first byte), not
         # stream completion. Both the histogram and gauge reflect TTFB timing.
         # Pure-ASGI middleware would be needed for true stream-duration metrics.
         async def dispatch(self, request: Request, call_next):
-            if request.url.path != "/v1/messages":
+            if request.url.path not in _METERED_PATHS:
                 return await call_next(request)
             active_requests.add(1)
             t0 = time.perf_counter()

--- a/src/luthien_proxy/metrics.py
+++ b/src/luthien_proxy/metrics.py
@@ -7,7 +7,7 @@ telemetry.py before the first request to wire them to the Prometheus exporter.
 Exposed metrics:
   luthien_requests_total{streaming}          — cumulative request counter
   luthien_tokens_total{type}                 — cumulative token counter (input/output)
-  luthien_request_duration_seconds{status}   — request latency histogram
+  luthien_request_ttfb_seconds{status}       — time-to-first-byte histogram (BaseHTTPMiddleware limitation)
   luthien_active_requests                    — in-flight request gauge
 """
 
@@ -34,8 +34,8 @@ token_counter = _meter.create_counter(
 )
 
 request_duration = _meter.create_histogram(
-    "luthien_request_duration_seconds",
-    description="LLM request latency in seconds",
+    "luthien_request_ttfb_seconds",
+    description="Time-to-first-byte for LLM requests in seconds (BaseHTTPMiddleware measures TTFB, not full streaming duration)",
     unit="s",
 )
 

--- a/src/luthien_proxy/metrics.py
+++ b/src/luthien_proxy/metrics.py
@@ -12,8 +12,8 @@ load-balances to, producing incomplete numbers. Current scripts run single-worke
 Exposed metrics:
   luthien_requests_completed_total{streaming} — completed request counter
   luthien_tokens_total{type}                  — cumulative token counter (input/output)
-  luthien_request_ttfb_seconds{status}        — time-to-first-byte histogram
-  luthien_active_requests                     — in-flight request gauge (TTFB-scoped)
+  luthien_request_ttfb_seconds{status}        — latency histogram (full for non-streaming, TTFB for streaming)
+  luthien_active_requests                     — in-flight gauge (TTFB-scoped for streaming)
 """
 
 from __future__ import annotations
@@ -40,7 +40,7 @@ token_counter = _meter.create_counter(
 
 request_duration = _meter.create_histogram(
     "luthien_request_ttfb_seconds",
-    description="Time-to-first-byte for LLM requests in seconds (BaseHTTPMiddleware measures TTFB, not full streaming duration)",
+    description="Request latency in seconds: full response time for non-streaming, TTFB only for streaming (BaseHTTPMiddleware limitation)",
     unit="s",
 )
 

--- a/src/luthien_proxy/metrics.py
+++ b/src/luthien_proxy/metrics.py
@@ -1,0 +1,76 @@
+"""Prometheus-compatible metric instruments for the Luthien gateway.
+
+Instruments are created lazily via get_meter() so they pick up whatever
+MeterProvider is configured at call time. Call configure_metrics() in
+telemetry.py before the first request to wire them to the Prometheus exporter.
+
+Exposed metrics:
+  luthien_requests_total{streaming}          — cumulative request counter
+  luthien_tokens_total{type}                 — cumulative token counter (input/output)
+  luthien_request_duration_seconds{status}   — request latency histogram
+  luthien_active_requests                    — in-flight request gauge
+"""
+
+from __future__ import annotations
+
+from opentelemetry import metrics
+
+from luthien_proxy.usage_telemetry.collector import UsageCollector
+
+_METER_NAME = "luthien.proxy"
+
+_meter = metrics.get_meter(_METER_NAME)
+
+request_counter = _meter.create_counter(
+    "luthien_requests_total",
+    description="Total LLM proxy requests completed",
+    unit="1",
+)
+
+token_counter = _meter.create_counter(
+    "luthien_tokens_total",
+    description="Total tokens consumed (input and output)",
+    unit="1",
+)
+
+request_duration = _meter.create_histogram(
+    "luthien_request_duration_seconds",
+    description="LLM request latency in seconds",
+    unit="s",
+)
+
+active_requests = _meter.create_up_down_counter(
+    "luthien_active_requests",
+    description="Number of LLM requests currently in flight",
+    unit="1",
+)
+
+
+class MetricsAwareUsageCollector(UsageCollector):
+    """UsageCollector that also increments Prometheus metric instruments.
+
+    Drop-in replacement for UsageCollector. The external telemetry sender
+    (snapshot_and_reset) is unaffected — it still gets the same counters.
+    """
+
+    def record_completed(self, *, is_streaming: bool) -> None:
+        """Record completed request and increment Prometheus request counter."""
+        super().record_completed(is_streaming=is_streaming)
+        request_counter.add(1, {"streaming": str(is_streaming).lower()})
+
+    def record_tokens(self, *, input_tokens: int, output_tokens: int) -> None:
+        """Record token usage and increment Prometheus token counter."""
+        super().record_tokens(input_tokens=input_tokens, output_tokens=output_tokens)
+        if input_tokens:
+            token_counter.add(input_tokens, {"type": "input"})
+        if output_tokens:
+            token_counter.add(output_tokens, {"type": "output"})
+
+
+__all__ = [
+    "MetricsAwareUsageCollector",
+    "active_requests",
+    "request_counter",
+    "request_duration",
+    "token_counter",
+]

--- a/src/luthien_proxy/metrics.py
+++ b/src/luthien_proxy/metrics.py
@@ -66,8 +66,10 @@ class MetricsAwareUsageCollector(UsageCollector):
     def record_tokens(self, *, input_tokens: int, output_tokens: int) -> None:
         """Record token usage and increment Prometheus token counter."""
         super().record_tokens(input_tokens=input_tokens, output_tokens=output_tokens)
-        token_counter.add(input_tokens, {"type": "input"})
-        token_counter.add(output_tokens, {"type": "output"})
+        if input_tokens:
+            token_counter.add(input_tokens, {"type": "input"})
+        if output_tokens:
+            token_counter.add(output_tokens, {"type": "output"})
 
 
 __all__ = [

--- a/src/luthien_proxy/metrics.py
+++ b/src/luthien_proxy/metrics.py
@@ -12,7 +12,7 @@ load-balances to, producing incomplete numbers. Current scripts run single-worke
 Exposed metrics:
   luthien_requests_completed_total{streaming} — completed request counter
   luthien_tokens_total{type}                  — cumulative token counter (input/output)
-  luthien_request_ttfb_seconds{status}        — latency histogram (full for non-streaming, TTFB for streaming)
+  luthien_request_duration_seconds{status,streaming} — latency histogram (full for non-streaming, TTFB for streaming)
   luthien_active_requests                     — in-flight gauge (TTFB-scoped for streaming)
 """
 
@@ -39,8 +39,8 @@ token_counter = _meter.create_counter(
 )
 
 request_duration = _meter.create_histogram(
-    "luthien_request_ttfb_seconds",
-    description="Request latency in seconds: full response time for non-streaming, TTFB only for streaming (BaseHTTPMiddleware limitation)",
+    "luthien_request_duration_seconds",
+    description="Request latency: full duration for non-streaming, TTFB for streaming (use streaming label to split)",
     unit="s",
 )
 
@@ -66,9 +66,9 @@ class MetricsAwareUsageCollector(UsageCollector):
     def record_tokens(self, *, input_tokens: int, output_tokens: int) -> None:
         """Record token usage and increment Prometheus token counter."""
         super().record_tokens(input_tokens=input_tokens, output_tokens=output_tokens)
-        if input_tokens:
+        if input_tokens > 0:
             token_counter.add(input_tokens, {"type": "input"})
-        if output_tokens:
+        if output_tokens > 0:
             token_counter.add(output_tokens, {"type": "output"})
 
 

--- a/src/luthien_proxy/metrics.py
+++ b/src/luthien_proxy/metrics.py
@@ -1,14 +1,19 @@
 """Prometheus-compatible metric instruments for the Luthien gateway.
 
-Instruments are created lazily via get_meter() so they pick up whatever
-MeterProvider is configured at call time. Call configure_metrics() in
-telemetry.py before the first request to wire them to the Prometheus exporter.
+Instruments are created eagerly at import time against the global MeterProvider.
+OTel's _ProxyMeter delegates to the real provider once configure_metrics()
+(telemetry.py) sets it — so import order doesn't matter as long as
+configure_metrics() runs before the first request.
+
+NOTE: In multi-worker deployments (uvicorn --workers N), each worker maintains
+independent in-memory metrics. Prometheus will scrape whichever worker the OS
+load-balances to, producing incomplete numbers. Current scripts run single-worker.
 
 Exposed metrics:
-  luthien_requests_total{streaming}          — cumulative request counter
-  luthien_tokens_total{type}                 — cumulative token counter (input/output)
-  luthien_request_ttfb_seconds{status}       — time-to-first-byte histogram (BaseHTTPMiddleware limitation)
-  luthien_active_requests                    — in-flight request gauge (TTFB-scoped, see description)
+  luthien_requests_completed_total{streaming} — completed request counter
+  luthien_tokens_total{type}                  — cumulative token counter (input/output)
+  luthien_request_ttfb_seconds{status}        — time-to-first-byte histogram
+  luthien_active_requests                     — in-flight request gauge (TTFB-scoped)
 """
 
 from __future__ import annotations
@@ -22,8 +27,8 @@ _METER_NAME = "luthien.proxy"
 _meter = metrics.get_meter(_METER_NAME)
 
 request_counter = _meter.create_counter(
-    "luthien_requests_total",
-    description="Total LLM proxy requests completed",
+    "luthien_requests_completed_total",
+    description="Total LLM proxy requests that completed successfully",
     unit="1",
 )
 
@@ -61,10 +66,8 @@ class MetricsAwareUsageCollector(UsageCollector):
     def record_tokens(self, *, input_tokens: int, output_tokens: int) -> None:
         """Record token usage and increment Prometheus token counter."""
         super().record_tokens(input_tokens=input_tokens, output_tokens=output_tokens)
-        if input_tokens:
-            token_counter.add(input_tokens, {"type": "input"})
-        if output_tokens:
-            token_counter.add(output_tokens, {"type": "output"})
+        token_counter.add(input_tokens, {"type": "input"})
+        token_counter.add(output_tokens, {"type": "output"})
 
 
 __all__ = [

--- a/src/luthien_proxy/metrics.py
+++ b/src/luthien_proxy/metrics.py
@@ -8,7 +8,7 @@ Exposed metrics:
   luthien_requests_total{streaming}          — cumulative request counter
   luthien_tokens_total{type}                 — cumulative token counter (input/output)
   luthien_request_ttfb_seconds{status}       — time-to-first-byte histogram (BaseHTTPMiddleware limitation)
-  luthien_active_requests                    — in-flight request gauge
+  luthien_active_requests                    — in-flight request gauge (TTFB-scoped, see description)
 """
 
 from __future__ import annotations
@@ -41,7 +41,7 @@ request_duration = _meter.create_histogram(
 
 active_requests = _meter.create_up_down_counter(
     "luthien_active_requests",
-    description="Number of LLM requests currently in flight",
+    description="LLM requests in flight (decrements at TTFB due to BaseHTTPMiddleware; streaming requests appear shorter than actual)",
     unit="1",
 )
 

--- a/src/luthien_proxy/telemetry.py
+++ b/src/luthien_proxy/telemetry.py
@@ -21,6 +21,7 @@ from opentelemetry.exporter.prometheus import PrometheusMetricReader
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.redis import RedisInstrumentor
 from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.view import ExplicitBucketHistogramAggregation, View
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -140,20 +141,38 @@ def configure_tracing() -> trace.Tracer:
     return trace.get_tracer(__name__)
 
 
+_metrics_configured = False
+
+
 def configure_metrics() -> None:
     """Configure OpenTelemetry metrics with a Prometheus exporter.
 
-    Registers a PrometheusMetricReader into prometheus_client's global REGISTRY
-    so that generate_latest() in the /metrics endpoint includes all OTel metrics.
-    The OTel SDK silently ignores duplicate set_meter_provider calls, so calling
-    this more than once is safe but redundant.
+    Registers a PrometheusMetricReader into prometheus_client's global REGISTRY.
+    Guarded to run exactly once — a second call is a no-op because
+    PrometheusMetricReader raises ValueError on duplicate REGISTRY registration.
 
     Intentionally does not gate on otel_enabled: Prometheus scraping is useful
     even when OTLP trace export is disabled (e.g. local dev without Tempo).
     """
+    global _metrics_configured  # noqa: PLW0603
+    if _metrics_configured:
+        return
+    _metrics_configured = True
+
     resource = _build_resource()
     reader = PrometheusMetricReader()
-    provider = MeterProvider(resource=resource, metric_readers=[reader])
+
+    # OTel default histogram boundaries are [0, 5, 10, 25, ... 10000] — designed
+    # for milliseconds. LLM TTFB ranges from ~0.1s to 120s, so we need custom
+    # buckets to get useful p50/p95/p99 percentiles.
+    ttfb_view = View(
+        instrument_name="luthien_request_ttfb_seconds",
+        aggregation=ExplicitBucketHistogramAggregation(
+            boundaries=(0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0),
+        ),
+    )
+
+    provider = MeterProvider(resource=resource, metric_readers=[reader], views=[ttfb_view])
     metrics.set_meter_provider(provider)
 
     logger.info("Prometheus metrics endpoint enabled at /metrics")

--- a/src/luthien_proxy/telemetry.py
+++ b/src/luthien_proxy/telemetry.py
@@ -170,7 +170,7 @@ def configure_metrics() -> None:
         # for milliseconds. LLM TTFB ranges from ~0.1s to 120s, so we need custom
         # buckets to get useful p50/p95/p99 percentiles.
         ttfb_view = View(
-            instrument_name="luthien_request_ttfb_seconds",
+            instrument_name="luthien_request_duration_seconds",
             aggregation=ExplicitBucketHistogramAggregation(
                 boundaries=(0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0),
             ),

--- a/src/luthien_proxy/telemetry.py
+++ b/src/luthien_proxy/telemetry.py
@@ -14,11 +14,13 @@ import logging
 from collections.abc import Generator
 from contextlib import contextmanager
 
-from opentelemetry import trace
+from opentelemetry import metrics, trace
 from opentelemetry.context import Context, attach, detach
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.prometheus import PrometheusMetricReader
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.redis import RedisInstrumentor
+from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -140,6 +142,31 @@ def configure_tracing() -> trace.Tracer:
     return trace.get_tracer(__name__)
 
 
+def configure_metrics() -> None:
+    """Configure OpenTelemetry metrics with a Prometheus exporter.
+
+    Registers a PrometheusMetricReader into prometheus_client's global REGISTRY
+    so that generate_latest() in the /metrics endpoint includes all OTel metrics.
+    Safe to call multiple times — subsequent calls are no-ops.
+    """
+    otel_enabled, _, service_name, service_version, environment = _get_otel_config()
+
+    resource = Resource.create(
+        {
+            "service.name": service_name,
+            "service.version": service_version,
+            "deployment.environment": environment,
+        }
+    )
+
+    reader = PrometheusMetricReader()
+    provider = MeterProvider(resource=resource, metric_readers=[reader])
+    metrics.set_meter_provider(provider)
+
+    if otel_enabled:
+        logger.info("Prometheus metrics configured")
+
+
 def instrument_app(app) -> None:
     """Instrument FastAPI application with OpenTelemetry.
 
@@ -155,7 +182,7 @@ def instrument_app(app) -> None:
     if not get_settings().otel_enabled:
         return
 
-    FastAPIInstrumentor.instrument_app(app)
+    FastAPIInstrumentor.instrument_app(app, excluded_urls="/metrics")
     logger.info("FastAPI instrumented with OpenTelemetry")
 
 
@@ -249,6 +276,7 @@ __all__ = [
     "tracer",
     "configure_tracing",
     "configure_logging",
+    "configure_metrics",
     "instrument_app",
     "instrument_redis",
 ]

--- a/src/luthien_proxy/telemetry.py
+++ b/src/luthien_proxy/telemetry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from collections.abc import Generator
 from contextlib import contextmanager
 
@@ -141,6 +142,7 @@ def configure_tracing() -> trace.Tracer:
     return trace.get_tracer(__name__)
 
 
+_metrics_lock = threading.Lock()
 _metrics_configured = False
 
 
@@ -157,23 +159,26 @@ def configure_metrics() -> None:
     global _metrics_configured  # noqa: PLW0603
     if _metrics_configured:
         return
-    _metrics_configured = True
+    with _metrics_lock:
+        if _metrics_configured:
+            return
 
-    resource = _build_resource()
-    reader = PrometheusMetricReader()
+        resource = _build_resource()
+        reader = PrometheusMetricReader()
 
-    # OTel default histogram boundaries are [0, 5, 10, 25, ... 10000] — designed
-    # for milliseconds. LLM TTFB ranges from ~0.1s to 120s, so we need custom
-    # buckets to get useful p50/p95/p99 percentiles.
-    ttfb_view = View(
-        instrument_name="luthien_request_ttfb_seconds",
-        aggregation=ExplicitBucketHistogramAggregation(
-            boundaries=(0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0),
-        ),
-    )
+        # OTel default histogram boundaries are [0, 5, 10, 25, ... 10000] — designed
+        # for milliseconds. LLM TTFB ranges from ~0.1s to 120s, so we need custom
+        # buckets to get useful p50/p95/p99 percentiles.
+        ttfb_view = View(
+            instrument_name="luthien_request_ttfb_seconds",
+            aggregation=ExplicitBucketHistogramAggregation(
+                boundaries=(0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0),
+            ),
+        )
 
-    provider = MeterProvider(resource=resource, metric_readers=[reader], views=[ttfb_view])
-    metrics.set_meter_provider(provider)
+        provider = MeterProvider(resource=resource, metric_readers=[reader], views=[ttfb_view])
+        metrics.set_meter_provider(provider)
+        _metrics_configured = True
 
     logger.info("Prometheus metrics endpoint enabled at /metrics")
 

--- a/src/luthien_proxy/telemetry.py
+++ b/src/luthien_proxy/telemetry.py
@@ -78,6 +78,17 @@ def _get_otel_config() -> tuple[bool, str, str, str, str]:
     )
 
 
+def _build_resource() -> Resource:
+    _, _, service_name, service_version, environment = _get_otel_config()
+    return Resource.create(
+        {
+            "service.name": service_name,
+            "service.version": service_version,
+            "deployment.environment": environment,
+        }
+    )
+
+
 def _silence_otel_loggers() -> None:
     """Suppress noisy gRPC and OTel exporter logs.
 
@@ -105,36 +116,23 @@ def configure_tracing() -> trace.Tracer:
     Returns:
         Configured tracer for manual instrumentation
     """
-    otel_enabled, otel_endpoint, service_name, service_version, environment = _get_otel_config()
+    otel_enabled, otel_endpoint, service_name, _, _ = _get_otel_config()
 
     if not otel_enabled:
         logger.debug("OpenTelemetry disabled (OTEL_ENABLED=false)")
         _silence_otel_loggers()
         return trace.get_tracer(__name__)
 
-    # Define resource attributes
-    resource = Resource.create(
-        {
-            "service.name": service_name,
-            "service.version": service_version,
-            "deployment.environment": environment,
-        }
-    )
-
-    # Create tracer provider
+    resource = _build_resource()
     provider = TracerProvider(resource=resource)
 
-    # Configure OTLP exporter (sends to Tempo)
     otlp_exporter = OTLPSpanExporter(
         endpoint=otel_endpoint,
-        insecure=True,  # No TLS for local dev
+        insecure=True,
     )
 
-    # Use batch processor for efficiency (batches spans before export)
     processor = BatchSpanProcessor(otlp_exporter)
     provider.add_span_processor(processor)
-
-    # Set as global tracer provider
     trace.set_tracer_provider(provider)
 
     logger.info(f"OpenTelemetry configured: {service_name} → {otel_endpoint}")
@@ -153,22 +151,12 @@ def configure_metrics() -> None:
     Intentionally does not gate on otel_enabled: Prometheus scraping is useful
     even when OTLP trace export is disabled (e.g. local dev without Tempo).
     """
-    otel_enabled, _, service_name, service_version, environment = _get_otel_config()
-
-    resource = Resource.create(
-        {
-            "service.name": service_name,
-            "service.version": service_version,
-            "deployment.environment": environment,
-        }
-    )
-
+    resource = _build_resource()
     reader = PrometheusMetricReader()
     provider = MeterProvider(resource=resource, metric_readers=[reader])
     metrics.set_meter_provider(provider)
 
-    if otel_enabled:
-        logger.info("Prometheus metrics configured")
+    logger.info("Prometheus metrics endpoint enabled at /metrics")
 
 
 def instrument_app(app) -> None:

--- a/src/luthien_proxy/telemetry.py
+++ b/src/luthien_proxy/telemetry.py
@@ -147,7 +147,11 @@ def configure_metrics() -> None:
 
     Registers a PrometheusMetricReader into prometheus_client's global REGISTRY
     so that generate_latest() in the /metrics endpoint includes all OTel metrics.
-    Safe to call multiple times — subsequent calls are no-ops.
+    The OTel SDK silently ignores duplicate set_meter_provider calls, so calling
+    this more than once is safe but redundant.
+
+    Intentionally does not gate on otel_enabled: Prometheus scraping is useful
+    even when OTLP trace export is disabled (e.g. local dev without Tempo).
     """
     otel_enabled, _, service_name, service_version, environment = _get_otel_config()
 

--- a/tests/luthien_proxy/e2e_tests/sqlite/conftest.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/conftest.py
@@ -54,6 +54,9 @@ def sqlite_gateway_url(mock_anthropic):
         old_env[k] = os.environ.get(k)
         os.environ[k] = v
 
+    # Flush cached settings so create_app() picks up the env vars set above.
+    # Without this, get_settings() may return a stale instance that lacks
+    # ANTHROPIC_API_KEY, causing credential resolution to fail.
     clear_settings_cache()
     app = create_app(
         api_key=_API_KEY,

--- a/tests/luthien_proxy/e2e_tests/sqlite/conftest.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/conftest.py
@@ -18,7 +18,6 @@ import pytest
 import uvicorn
 
 from luthien_proxy.main import create_app
-from luthien_proxy.settings import clear_settings_cache
 from luthien_proxy.utils.db import DatabasePool
 from luthien_proxy.utils.migration_check import check_migrations
 
@@ -54,10 +53,6 @@ def sqlite_gateway_url(mock_anthropic):
         old_env[k] = os.environ.get(k)
         os.environ[k] = v
 
-    # Flush cached settings so create_app() picks up the env vars set above.
-    # Without this, get_settings() may return a stale instance that lacks
-    # ANTHROPIC_API_KEY, causing credential resolution to fail.
-    clear_settings_cache()
     app = create_app(
         api_key=_API_KEY,
         admin_key=_ADMIN_API_KEY,

--- a/tests/luthien_proxy/e2e_tests/sqlite/conftest.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/conftest.py
@@ -18,6 +18,7 @@ import pytest
 import uvicorn
 
 from luthien_proxy.main import create_app
+from luthien_proxy.settings import clear_settings_cache
 from luthien_proxy.utils.db import DatabasePool
 from luthien_proxy.utils.migration_check import check_migrations
 
@@ -53,6 +54,7 @@ def sqlite_gateway_url(mock_anthropic):
         old_env[k] = os.environ.get(k)
         os.environ[k] = v
 
+    clear_settings_cache()
     app = create_app(
         api_key=_API_KEY,
         admin_key=_ADMIN_API_KEY,

--- a/tests/luthien_proxy/e2e_tests/sqlite/test_metrics_endpoint.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/test_metrics_endpoint.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.sqlite_e2e
 _EXPECTED_FAMILIES = {
     "luthien_requests_completed",
     "luthien_tokens",
-    "luthien_request_ttfb_seconds",
+    "luthien_request_duration_seconds",
     "luthien_active_requests",
 }
 
@@ -109,11 +109,13 @@ async def test_metrics_histogram_buckets(gateway_url, api_key, mock_anthropic):
         )
 
         families = _parse_families((await client.get(f"{gateway_url}/metrics")).text)
-        ttfb = families.get("luthien_request_ttfb_seconds")
-        assert ttfb is not None, "Missing luthien_request_ttfb_seconds family"
+        duration = families.get("luthien_request_duration_seconds")
+        assert duration is not None, "Missing luthien_request_duration_seconds family"
 
         bucket_les = sorted(
-            float(s.labels["le"]) for s in ttfb.samples if s.name.endswith("_bucket") and s.labels.get("le") != "+Inf"
+            float(s.labels["le"])
+            for s in duration.samples
+            if s.name.endswith("_bucket") and s.labels.get("le") != "+Inf"
         )
         expected = sorted(_TTFB_BUCKET_BOUNDARIES)
         assert bucket_les == expected, f"Bucket boundaries mismatch: got {bucket_les}, expected {expected}"

--- a/tests/luthien_proxy/e2e_tests/sqlite/test_metrics_endpoint.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/test_metrics_endpoint.py
@@ -135,7 +135,7 @@ async def test_metrics_contains_expected_families_after_request(gateway_url, moc
         assert metrics_resp.status_code == 200
         body = metrics_resp.text
 
-        assert "luthien_requests" in body, f"Missing luthien_requests in:\n{body[:500]}"
+        assert "luthien_requests_completed" in body, f"Missing luthien_requests_completed in:\n{body[:500]}"
         assert "luthien_tokens" in body, f"Missing luthien_tokens in:\n{body[:500]}"
         assert "luthien_request_ttfb_seconds" in body, f"Missing luthien_request_ttfb_seconds in:\n{body[:500]}"
         assert "luthien_active_requests" in body, f"Missing luthien_active_requests in:\n{body[:500]}"
@@ -167,7 +167,7 @@ async def test_metrics_no_double_suffixes(gateway_url, mock_server):
         metrics_resp = await client.get(f"{gateway_url}/metrics")
         body = metrics_resp.text
 
-        assert "luthien_requests_total_total" not in body, "Double _total suffix detected"
+        assert "luthien_requests_completed_total_total" not in body, "Double _total suffix detected"
         assert "luthien_tokens_total_total" not in body, "Double _total suffix detected"
         assert "luthien_request_ttfb_seconds_seconds" not in body, "Double _seconds suffix detected"
 

--- a/tests/luthien_proxy/e2e_tests/sqlite/test_metrics_endpoint.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/test_metrics_endpoint.py
@@ -1,0 +1,179 @@
+"""sqlite_e2e tests for the /metrics Prometheus endpoint.
+
+Boots a self-contained SQLite gateway + mock Anthropic server and verifies:
+1. /metrics returns 200 with Prometheus content type
+2. After a request through the gateway, metric families appear in the output
+3. Metric names match what the changelog advertises (no OTel suffix mangling)
+
+Run:  uv run pytest tests/luthien_proxy/e2e_tests/sqlite/test_metrics_endpoint.py -v --timeout=60
+"""
+
+import asyncio
+import os
+import socket
+import tempfile
+import threading
+import time
+
+import httpx
+import pytest
+import uvicorn
+from tests.luthien_proxy.e2e_tests.mock_anthropic.responses import text_response
+from tests.luthien_proxy.e2e_tests.mock_anthropic.server import MockAnthropicServer
+
+from luthien_proxy.main import create_app
+from luthien_proxy.settings import clear_settings_cache
+from luthien_proxy.utils.db import DatabasePool
+from luthien_proxy.utils.migration_check import check_migrations
+
+pytestmark = pytest.mark.sqlite_e2e
+
+_API_KEY = "test-metrics-key"
+_ADMIN_KEY = "test-metrics-admin-key"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def mock_server():
+    server = MockAnthropicServer(port=_free_port())
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def gateway_url(mock_server):
+    port = _free_port()
+    tmp_dir = tempfile.mkdtemp(prefix="luthien_metrics_e2e_")
+    db_path = os.path.join(tmp_dir, "test.db")
+    db_pool = DatabasePool(f"sqlite:///{db_path}")
+
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(check_migrations(db_pool))
+
+    old_env = {}
+    for k, v in {
+        "ANTHROPIC_BASE_URL": f"http://127.0.0.1:{mock_server.port}",
+        "ANTHROPIC_API_KEY": "mock-key",
+    }.items():
+        old_env[k] = os.environ.get(k)
+        os.environ[k] = v
+
+    clear_settings_cache()
+    app = create_app(
+        api_key=_API_KEY,
+        admin_key=_ADMIN_KEY,
+        db_pool=db_pool,
+        redis_client=None,
+        startup_policy_path="config/policy_config.yaml",
+        policy_source="db-fallback-file",
+    )
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True, name="metrics-gateway")
+    thread.start()
+
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        raise RuntimeError("Metrics gateway did not start")
+
+    yield f"http://127.0.0.1:{port}"
+
+    server.should_exit = True
+    thread.join(timeout=5)
+    loop.run_until_complete(db_pool.close())
+    loop.close()
+    for k, v in old_env.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+async def test_metrics_returns_200_before_traffic(gateway_url):
+    """GET /metrics works even before any requests flow through."""
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(f"{gateway_url}/metrics")
+        assert resp.status_code == 200
+        assert "text/plain" in resp.headers["content-type"]
+
+
+async def test_metrics_contains_expected_families_after_request(gateway_url, mock_server):
+    """After a /v1/messages request, /metrics exposes all advertised metric families."""
+    mock_server.enqueue(text_response("metrics test"))
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.post(
+            f"{gateway_url}/v1/messages",
+            json={
+                "model": "claude-haiku-4-5",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 100,
+                "stream": False,
+            },
+            headers={
+                "Authorization": f"Bearer {_API_KEY}",
+                "Content-Type": "application/json",
+                "anthropic-version": "2023-06-01",
+            },
+        )
+        assert resp.status_code == 200, f"Gateway returned {resp.status_code}: {resp.text[:500]}"
+
+        metrics_resp = await client.get(f"{gateway_url}/metrics")
+        assert metrics_resp.status_code == 200
+        body = metrics_resp.text
+
+        assert "luthien_requests" in body, f"Missing luthien_requests in:\n{body[:500]}"
+        assert "luthien_tokens" in body, f"Missing luthien_tokens in:\n{body[:500]}"
+        assert "luthien_request_ttfb_seconds" in body, f"Missing luthien_request_ttfb_seconds in:\n{body[:500]}"
+        assert "luthien_active_requests" in body, f"Missing luthien_active_requests in:\n{body[:500]}"
+
+
+async def test_metrics_no_double_suffixes(gateway_url, mock_server):
+    """OTel Prometheus exporter should not mangle names with double suffixes.
+
+    Catches _total_total or _seconds_seconds from unit-appending behavior.
+    """
+    mock_server.enqueue(text_response("suffix test"))
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        await client.post(
+            f"{gateway_url}/v1/messages",
+            json={
+                "model": "claude-haiku-4-5",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 100,
+                "stream": False,
+            },
+            headers={
+                "Authorization": f"Bearer {_API_KEY}",
+                "Content-Type": "application/json",
+                "anthropic-version": "2023-06-01",
+            },
+        )
+
+        metrics_resp = await client.get(f"{gateway_url}/metrics")
+        body = metrics_resp.text
+
+        assert "luthien_requests_total_total" not in body, "Double _total suffix detected"
+        assert "luthien_tokens_total_total" not in body, "Double _total suffix detected"
+        assert "luthien_request_ttfb_seconds_seconds" not in body, "Double _seconds suffix detected"
+
+
+async def test_metrics_no_auth_required(gateway_url):
+    """GET /metrics should not require authentication (standard Prometheus convention)."""
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(f"{gateway_url}/metrics")
+        assert resp.status_code == 200

--- a/tests/luthien_proxy/e2e_tests/sqlite/test_metrics_endpoint.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/test_metrics_endpoint.py
@@ -1,118 +1,42 @@
 """sqlite_e2e tests for the /metrics Prometheus endpoint.
 
-Boots a self-contained SQLite gateway + mock Anthropic server and verifies:
-1. /metrics returns 200 with Prometheus content type
-2. After a request through the gateway, metric families appear in the output
-3. Metric names match what the changelog advertises (no OTel suffix mangling)
+Uses the shared sqlite gateway fixtures from conftest.py — no custom
+gateway or mock server setup needed.
 
 Run:  uv run pytest tests/luthien_proxy/e2e_tests/sqlite/test_metrics_endpoint.py -v --timeout=60
 """
 
-import asyncio
-import os
-import socket
-import tempfile
-import threading
-import time
-
 import httpx
 import pytest
-import uvicorn
+from prometheus_client.parser import text_string_to_metric_families
 from tests.luthien_proxy.e2e_tests.mock_anthropic.responses import text_response
-from tests.luthien_proxy.e2e_tests.mock_anthropic.server import MockAnthropicServer
-
-from luthien_proxy.main import create_app
-from luthien_proxy.settings import clear_settings_cache
-from luthien_proxy.utils.db import DatabasePool
-from luthien_proxy.utils.migration_check import check_migrations
 
 pytestmark = pytest.mark.sqlite_e2e
 
-_API_KEY = "test-metrics-key"
-_ADMIN_KEY = "test-metrics-admin-key"
+_EXPECTED_FAMILIES = {
+    "luthien_requests_completed",
+    "luthien_tokens",
+    "luthien_request_ttfb_seconds",
+    "luthien_active_requests",
+}
+
+_TTFB_BUCKET_BOUNDARIES = (0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0)
 
 
-def _free_port() -> int:
-    with socket.socket() as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
-@pytest.fixture(scope="module")
-def mock_server():
-    server = MockAnthropicServer(port=_free_port())
-    server.start()
-    yield server
-    server.stop()
-
-
-@pytest.fixture(scope="module")
-def gateway_url(mock_server):
-    port = _free_port()
-    tmp_dir = tempfile.mkdtemp(prefix="luthien_metrics_e2e_")
-    db_path = os.path.join(tmp_dir, "test.db")
-    db_pool = DatabasePool(f"sqlite:///{db_path}")
-
-    loop = asyncio.new_event_loop()
-    loop.run_until_complete(check_migrations(db_pool))
-
-    old_env = {}
-    for k, v in {
-        "ANTHROPIC_BASE_URL": f"http://127.0.0.1:{mock_server.port}",
-        "ANTHROPIC_API_KEY": "mock-key",
-    }.items():
-        old_env[k] = os.environ.get(k)
-        os.environ[k] = v
-
-    clear_settings_cache()
-    app = create_app(
-        api_key=_API_KEY,
-        admin_key=_ADMIN_KEY,
-        db_pool=db_pool,
-        redis_client=None,
-        startup_policy_path="config/policy_config.yaml",
-        policy_source="db-fallback-file",
-    )
-
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
-    server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, daemon=True, name="metrics-gateway")
-    thread.start()
-
-    deadline = time.monotonic() + 10
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-                break
-        except OSError:
-            time.sleep(0.1)
-    else:
-        raise RuntimeError("Metrics gateway did not start")
-
-    yield f"http://127.0.0.1:{port}"
-
-    server.should_exit = True
-    thread.join(timeout=5)
-    loop.run_until_complete(db_pool.close())
-    loop.close()
-    for k, v in old_env.items():
-        if v is None:
-            os.environ.pop(k, None)
-        else:
-            os.environ[k] = v
+def _parse_families(body: str) -> dict[str, object]:
+    """Parse Prometheus text format into {name: MetricFamily}."""
+    return {f.name: f for f in text_string_to_metric_families(body)}
 
 
 async def test_metrics_returns_200_before_traffic(gateway_url):
-    """GET /metrics works even before any requests flow through."""
     async with httpx.AsyncClient(timeout=10.0) as client:
         resp = await client.get(f"{gateway_url}/metrics")
         assert resp.status_code == 200
         assert "text/plain" in resp.headers["content-type"]
 
 
-async def test_metrics_contains_expected_families_after_request(gateway_url, mock_server):
-    """After a /v1/messages request, /metrics exposes all advertised metric families."""
-    mock_server.enqueue(text_response("metrics test"))
+async def test_metrics_contains_expected_families_after_request(gateway_url, api_key, mock_anthropic):
+    mock_anthropic.enqueue(text_response("metrics test"))
 
     async with httpx.AsyncClient(timeout=15.0) as client:
         resp = await client.post(
@@ -124,7 +48,7 @@ async def test_metrics_contains_expected_families_after_request(gateway_url, moc
                 "stream": False,
             },
             headers={
-                "Authorization": f"Bearer {_API_KEY}",
+                "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",
                 "anthropic-version": "2023-06-01",
             },
@@ -132,21 +56,14 @@ async def test_metrics_contains_expected_families_after_request(gateway_url, moc
         assert resp.status_code == 200, f"Gateway returned {resp.status_code}: {resp.text[:500]}"
 
         metrics_resp = await client.get(f"{gateway_url}/metrics")
-        assert metrics_resp.status_code == 200
-        body = metrics_resp.text
+        families = _parse_families(metrics_resp.text)
 
-        assert "luthien_requests_completed" in body, f"Missing luthien_requests_completed in:\n{body[:500]}"
-        assert "luthien_tokens" in body, f"Missing luthien_tokens in:\n{body[:500]}"
-        assert "luthien_request_ttfb_seconds" in body, f"Missing luthien_request_ttfb_seconds in:\n{body[:500]}"
-        assert "luthien_active_requests" in body, f"Missing luthien_active_requests in:\n{body[:500]}"
+        for name in _EXPECTED_FAMILIES:
+            assert name in families, f"Missing metric family {name!r}. Got: {sorted(families)}"
 
 
-async def test_metrics_no_double_suffixes(gateway_url, mock_server):
-    """OTel Prometheus exporter should not mangle names with double suffixes.
-
-    Catches _total_total or _seconds_seconds from unit-appending behavior.
-    """
-    mock_server.enqueue(text_response("suffix test"))
+async def test_metrics_no_double_suffixes(gateway_url, api_key, mock_anthropic):
+    mock_anthropic.enqueue(text_response("suffix test"))
 
     async with httpx.AsyncClient(timeout=15.0) as client:
         await client.post(
@@ -158,22 +75,51 @@ async def test_metrics_no_double_suffixes(gateway_url, mock_server):
                 "stream": False,
             },
             headers={
-                "Authorization": f"Bearer {_API_KEY}",
+                "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",
                 "anthropic-version": "2023-06-01",
             },
         )
 
-        metrics_resp = await client.get(f"{gateway_url}/metrics")
-        body = metrics_resp.text
+        families = _parse_families((await client.get(f"{gateway_url}/metrics")).text)
 
-        assert "luthien_requests_completed_total_total" not in body, "Double _total suffix detected"
-        assert "luthien_tokens_total_total" not in body, "Double _total suffix detected"
-        assert "luthien_request_ttfb_seconds_seconds" not in body, "Double _seconds suffix detected"
+        for name in families:
+            assert not name.endswith("_total_total"), f"Double _total suffix: {name}"
+            assert not name.endswith("_seconds_seconds"), f"Double _seconds suffix: {name}"
+
+
+async def test_metrics_histogram_buckets(gateway_url, api_key, mock_anthropic):
+    """Custom TTFB histogram buckets are applied (not OTel ms-oriented defaults)."""
+    mock_anthropic.enqueue(text_response("bucket test"))
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        await client.post(
+            f"{gateway_url}/v1/messages",
+            json={
+                "model": "claude-haiku-4-5",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 100,
+                "stream": False,
+            },
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "anthropic-version": "2023-06-01",
+            },
+        )
+
+        families = _parse_families((await client.get(f"{gateway_url}/metrics")).text)
+        ttfb = families.get("luthien_request_ttfb_seconds")
+        assert ttfb is not None, "Missing luthien_request_ttfb_seconds family"
+
+        bucket_les = sorted(
+            float(s.labels["le"]) for s in ttfb.samples if s.name.endswith("_bucket") and s.labels.get("le") != "+Inf"
+        )
+        expected = sorted(_TTFB_BUCKET_BOUNDARIES)
+        assert bucket_les == expected, f"Bucket boundaries mismatch: got {bucket_les}, expected {expected}"
 
 
 async def test_metrics_no_auth_required(gateway_url):
-    """GET /metrics should not require authentication (standard Prometheus convention)."""
     async with httpx.AsyncClient(timeout=10.0) as client:
         resp = await client.get(f"{gateway_url}/metrics")
         assert resp.status_code == 200

--- a/tests/luthien_proxy/unit_tests/test_metrics.py
+++ b/tests/luthien_proxy/unit_tests/test_metrics.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import luthien_proxy.telemetry as telemetry_mod
 from luthien_proxy.metrics import MetricsAwareUsageCollector
 
 
@@ -45,14 +46,24 @@ class TestMetricsAwareUsageCollector:
         assert snapshot["input_tokens"] == 10
         assert snapshot["output_tokens"] == 20
 
-    def test_record_tokens_zero_values_still_emitted(self):
+    def test_record_tokens_skips_zero_values(self):
         collector = MetricsAwareUsageCollector()
         mock_counter = MagicMock()
         with patch("luthien_proxy.metrics.token_counter", mock_counter):
             collector.record_tokens(input_tokens=0, output_tokens=0)
-        assert mock_counter.add.call_count == 2
-        mock_counter.add.assert_any_call(0, {"type": "input"})
-        mock_counter.add.assert_any_call(0, {"type": "output"})
+        mock_counter.add.assert_not_called()
+
+    def test_configure_metrics_idempotent(self):
+        with (
+            patch.object(telemetry_mod, "_metrics_configured", False),
+            patch.object(telemetry_mod, "_metrics_lock", telemetry_mod.threading.Lock()),
+            patch("luthien_proxy.telemetry.PrometheusMetricReader"),
+            patch("luthien_proxy.telemetry.MeterProvider"),
+            patch("luthien_proxy.telemetry.metrics"),
+            patch("luthien_proxy.telemetry._build_resource"),
+        ):
+            telemetry_mod.configure_metrics()
+            telemetry_mod.configure_metrics()
 
     def test_snapshot_and_reset_unaffected_by_metrics(self):
         collector = MetricsAwareUsageCollector()

--- a/tests/luthien_proxy/unit_tests/test_metrics.py
+++ b/tests/luthien_proxy/unit_tests/test_metrics.py
@@ -69,7 +69,7 @@ class TestMetricsAwareUsageCollector:
             assert reader_cls.call_count == 1
             assert provider_cls.call_count == 1
 
-    def test_snapshot_and_reset_unaffected_by_metrics(self):
+    def test_snapshot_and_reset_preserves_parent_counters(self):
         collector = MetricsAwareUsageCollector()
         with patch("luthien_proxy.metrics.request_counter"), patch("luthien_proxy.metrics.token_counter"):
             collector.record_completed(is_streaming=True)
@@ -115,9 +115,11 @@ class TestLatencyMiddleware:
         mock_active.add.assert_any_call(1)
         mock_active.add.assert_any_call(-1)
         mock_duration.record.assert_called_once()
-        assert mock_duration.record.call_args[0][1]["status"] == "error"
+        attrs = mock_duration.record.call_args[0][1]
+        assert attrs["status"] == "error"
+        assert attrs["streaming"] == "false"
 
-    def test_success_records_status_200(self):
+    def test_success_records_status_200_non_streaming(self):
         from starlette.responses import JSONResponse
 
         async def ok(request):
@@ -135,9 +137,33 @@ class TestLatencyMiddleware:
             resp = client.post("/v1/messages")
 
         assert resp.status_code == 200
-        mock_active.add.assert_any_call(1)
-        mock_active.add.assert_any_call(-1)
-        assert mock_duration.record.call_args[0][1]["status"] == "200"
+        attrs = mock_duration.record.call_args[0][1]
+        assert attrs["status"] == "200"
+        assert attrs["streaming"] == "false"
+
+    def test_streaming_response_labeled_as_streaming(self):
+        from starlette.responses import StreamingResponse
+
+        async def stream_gen():
+            yield b"data: hello\n\n"
+
+        async def sse(request):
+            return StreamingResponse(stream_gen(), media_type="text/event-stream")
+
+        app = self._build_app(sse)
+        mock_duration = MagicMock()
+        mock_active = MagicMock()
+
+        with (
+            patch("luthien_proxy.main.request_duration", mock_duration),
+            patch("luthien_proxy.main.active_requests", mock_active),
+        ):
+            client = TestClient(app)
+            resp = client.post("/v1/messages")
+
+        assert resp.status_code == 200
+        attrs = mock_duration.record.call_args[0][1]
+        assert attrs["streaming"] == "true"
 
     def test_non_messages_path_skips_metrics(self):
         from starlette.applications import Starlette

--- a/tests/luthien_proxy/unit_tests/test_metrics.py
+++ b/tests/luthien_proxy/unit_tests/test_metrics.py
@@ -1,6 +1,9 @@
 # ABOUTME: Unit tests for Prometheus metrics instruments and MetricsAwareUsageCollector
 
+import time
 from unittest.mock import MagicMock, patch
+
+from starlette.testclient import TestClient
 
 import luthien_proxy.telemetry as telemetry_mod
 from luthien_proxy.metrics import MetricsAwareUsageCollector
@@ -57,13 +60,15 @@ class TestMetricsAwareUsageCollector:
         with (
             patch.object(telemetry_mod, "_metrics_configured", False),
             patch.object(telemetry_mod, "_metrics_lock", telemetry_mod.threading.Lock()),
-            patch("luthien_proxy.telemetry.PrometheusMetricReader"),
-            patch("luthien_proxy.telemetry.MeterProvider"),
+            patch("luthien_proxy.telemetry.PrometheusMetricReader") as reader_cls,
+            patch("luthien_proxy.telemetry.MeterProvider") as provider_cls,
             patch("luthien_proxy.telemetry.metrics"),
             patch("luthien_proxy.telemetry._build_resource"),
         ):
             telemetry_mod.configure_metrics()
             telemetry_mod.configure_metrics()
+            assert reader_cls.call_count == 1
+            assert provider_cls.call_count == 1
 
     def test_snapshot_and_reset_unaffected_by_metrics(self):
         collector = MetricsAwareUsageCollector()
@@ -77,3 +82,47 @@ class TestMetricsAwareUsageCollector:
         assert snapshot["output_tokens"] == 3
         snapshot2 = collector.snapshot_and_reset()
         assert snapshot2["requests_completed"] == 0
+
+
+class TestLatencyMiddlewareErrorPath:
+    def test_error_status_when_call_next_raises(self):
+        from starlette.applications import Starlette
+        from starlette.middleware import Middleware
+        from starlette.middleware.base import BaseHTTPMiddleware
+        from starlette.routing import Route
+
+        mock_duration = MagicMock()
+        mock_active = MagicMock()
+
+        class _TestMiddleware(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                if request.url.path != "/v1/messages":
+                    return await call_next(request)
+                mock_active.add(1)
+                t0 = time.perf_counter()
+                response = None
+                try:
+                    response = await call_next(request)
+                    return response
+                finally:
+                    status = str(response.status_code) if response is not None else "error"
+                    mock_duration.record(time.perf_counter() - t0, {"status": status})
+                    mock_active.add(-1)
+
+        async def boom(request):
+            raise RuntimeError("boom")
+
+        app = Starlette(
+            routes=[Route("/v1/messages", boom, methods=["POST"])],
+            middleware=[Middleware(_TestMiddleware)],
+        )
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/v1/messages")
+        assert resp.status_code == 500
+
+        mock_active.add.assert_any_call(1)
+        mock_active.add.assert_any_call(-1)
+        mock_duration.record.assert_called_once()
+        recorded_attrs = mock_duration.record.call_args[0][1]
+        assert recorded_attrs["status"] == "error"

--- a/tests/luthien_proxy/unit_tests/test_metrics.py
+++ b/tests/luthien_proxy/unit_tests/test_metrics.py
@@ -1,6 +1,5 @@
 # ABOUTME: Unit tests for Prometheus metrics instruments and MetricsAwareUsageCollector
 
-import time
 from unittest.mock import MagicMock, patch
 
 from starlette.testclient import TestClient
@@ -84,45 +83,87 @@ class TestMetricsAwareUsageCollector:
         assert snapshot2["requests_completed"] == 0
 
 
-class TestLatencyMiddlewareErrorPath:
-    def test_error_status_when_call_next_raises(self):
+class TestLatencyMiddleware:
+    def _build_app(self, handler):
         from starlette.applications import Starlette
         from starlette.middleware import Middleware
-        from starlette.middleware.base import BaseHTTPMiddleware
         from starlette.routing import Route
 
-        mock_duration = MagicMock()
-        mock_active = MagicMock()
+        from luthien_proxy.main import LatencyMiddleware
 
-        class _TestMiddleware(BaseHTTPMiddleware):
-            async def dispatch(self, request, call_next):
-                if request.url.path != "/v1/messages":
-                    return await call_next(request)
-                mock_active.add(1)
-                t0 = time.perf_counter()
-                response = None
-                try:
-                    response = await call_next(request)
-                    return response
-                finally:
-                    status = str(response.status_code) if response is not None else "error"
-                    mock_duration.record(time.perf_counter() - t0, {"status": status})
-                    mock_active.add(-1)
+        return Starlette(
+            routes=[Route("/v1/messages", handler, methods=["POST"])],
+            middleware=[Middleware(LatencyMiddleware)],
+        )
 
+    def test_error_status_when_handler_raises(self):
         async def boom(request):
             raise RuntimeError("boom")
 
-        app = Starlette(
-            routes=[Route("/v1/messages", boom, methods=["POST"])],
-            middleware=[Middleware(_TestMiddleware)],
-        )
+        app = self._build_app(boom)
+        mock_duration = MagicMock()
+        mock_active = MagicMock()
 
-        client = TestClient(app, raise_server_exceptions=False)
-        resp = client.post("/v1/messages")
+        with (
+            patch("luthien_proxy.main.request_duration", mock_duration),
+            patch("luthien_proxy.main.active_requests", mock_active),
+        ):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post("/v1/messages")
+
         assert resp.status_code == 500
-
         mock_active.add.assert_any_call(1)
         mock_active.add.assert_any_call(-1)
         mock_duration.record.assert_called_once()
-        recorded_attrs = mock_duration.record.call_args[0][1]
-        assert recorded_attrs["status"] == "error"
+        assert mock_duration.record.call_args[0][1]["status"] == "error"
+
+    def test_success_records_status_200(self):
+        from starlette.responses import JSONResponse
+
+        async def ok(request):
+            return JSONResponse({"ok": True})
+
+        app = self._build_app(ok)
+        mock_duration = MagicMock()
+        mock_active = MagicMock()
+
+        with (
+            patch("luthien_proxy.main.request_duration", mock_duration),
+            patch("luthien_proxy.main.active_requests", mock_active),
+        ):
+            client = TestClient(app)
+            resp = client.post("/v1/messages")
+
+        assert resp.status_code == 200
+        mock_active.add.assert_any_call(1)
+        mock_active.add.assert_any_call(-1)
+        assert mock_duration.record.call_args[0][1]["status"] == "200"
+
+    def test_non_messages_path_skips_metrics(self):
+        from starlette.applications import Starlette
+        from starlette.middleware import Middleware
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+
+        from luthien_proxy.main import LatencyMiddleware
+
+        async def ok(request):
+            return JSONResponse({"ok": True})
+
+        app = Starlette(
+            routes=[Route("/health", ok, methods=["GET"])],
+            middleware=[Middleware(LatencyMiddleware)],
+        )
+        mock_duration = MagicMock()
+        mock_active = MagicMock()
+
+        with (
+            patch("luthien_proxy.main.request_duration", mock_duration),
+            patch("luthien_proxy.main.active_requests", mock_active),
+        ):
+            client = TestClient(app)
+            resp = client.get("/health")
+
+        assert resp.status_code == 200
+        mock_duration.record.assert_not_called()
+        mock_active.add.assert_not_called()

--- a/tests/luthien_proxy/unit_tests/test_metrics.py
+++ b/tests/luthien_proxy/unit_tests/test_metrics.py
@@ -1,5 +1,6 @@
 # ABOUTME: Unit tests for Prometheus metrics instruments and MetricsAwareUsageCollector
 
+import threading
 from unittest.mock import MagicMock, patch
 
 from starlette.testclient import TestClient
@@ -58,7 +59,7 @@ class TestMetricsAwareUsageCollector:
     def test_configure_metrics_idempotent(self):
         with (
             patch.object(telemetry_mod, "_metrics_configured", False),
-            patch.object(telemetry_mod, "_metrics_lock", telemetry_mod.threading.Lock()),
+            patch.object(telemetry_mod, "_metrics_lock", threading.Lock()),
             patch("luthien_proxy.telemetry.PrometheusMetricReader") as reader_cls,
             patch("luthien_proxy.telemetry.MeterProvider") as provider_cls,
             patch("luthien_proxy.telemetry.metrics"),
@@ -164,6 +165,27 @@ class TestLatencyMiddleware:
         assert resp.status_code == 200
         attrs = mock_duration.record.call_args[0][1]
         assert attrs["streaming"] == "true"
+
+    def test_response_without_content_type_is_non_streaming(self):
+        from starlette.responses import Response
+
+        async def bare(request):
+            return Response(content=b"ok", status_code=200)
+
+        app = self._build_app(bare)
+        mock_duration = MagicMock()
+        mock_active = MagicMock()
+
+        with (
+            patch("luthien_proxy.main.request_duration", mock_duration),
+            patch("luthien_proxy.main.active_requests", mock_active),
+        ):
+            client = TestClient(app)
+            resp = client.post("/v1/messages")
+
+        assert resp.status_code == 200
+        attrs = mock_duration.record.call_args[0][1]
+        assert attrs["streaming"] == "false"
 
     def test_non_messages_path_skips_metrics(self):
         from starlette.applications import Starlette

--- a/tests/luthien_proxy/unit_tests/test_metrics.py
+++ b/tests/luthien_proxy/unit_tests/test_metrics.py
@@ -1,0 +1,66 @@
+# ABOUTME: Unit tests for Prometheus metrics instruments and MetricsAwareUsageCollector
+
+from unittest.mock import MagicMock, patch
+
+from luthien_proxy.metrics import MetricsAwareUsageCollector
+
+
+class TestMetricsAwareUsageCollector:
+    def test_record_completed_increments_request_counter(self):
+        collector = MetricsAwareUsageCollector()
+        mock_counter = MagicMock()
+        with patch("luthien_proxy.metrics.request_counter", mock_counter):
+            collector.record_completed(is_streaming=False)
+        mock_counter.add.assert_called_once_with(1, {"streaming": "false"})
+
+    def test_record_completed_streaming_label(self):
+        collector = MetricsAwareUsageCollector()
+        mock_counter = MagicMock()
+        with patch("luthien_proxy.metrics.request_counter", mock_counter):
+            collector.record_completed(is_streaming=True)
+        mock_counter.add.assert_called_once_with(1, {"streaming": "true"})
+
+    def test_record_completed_also_updates_parent(self):
+        collector = MetricsAwareUsageCollector()
+        with patch("luthien_proxy.metrics.request_counter"):
+            collector.record_completed(is_streaming=False)
+        snapshot = collector.snapshot_and_reset()
+        assert snapshot["requests_completed"] == 1
+        assert snapshot["non_streaming_requests"] == 1
+
+    def test_record_tokens_increments_token_counter(self):
+        collector = MetricsAwareUsageCollector()
+        mock_counter = MagicMock()
+        with patch("luthien_proxy.metrics.token_counter", mock_counter):
+            collector.record_tokens(input_tokens=100, output_tokens=50)
+        assert mock_counter.add.call_count == 2
+        mock_counter.add.assert_any_call(100, {"type": "input"})
+        mock_counter.add.assert_any_call(50, {"type": "output"})
+
+    def test_record_tokens_also_updates_parent(self):
+        collector = MetricsAwareUsageCollector()
+        with patch("luthien_proxy.metrics.token_counter"):
+            collector.record_tokens(input_tokens=10, output_tokens=20)
+        snapshot = collector.snapshot_and_reset()
+        assert snapshot["input_tokens"] == 10
+        assert snapshot["output_tokens"] == 20
+
+    def test_record_tokens_skips_zero_values(self):
+        collector = MetricsAwareUsageCollector()
+        mock_counter = MagicMock()
+        with patch("luthien_proxy.metrics.token_counter", mock_counter):
+            collector.record_tokens(input_tokens=0, output_tokens=0)
+        mock_counter.add.assert_not_called()
+
+    def test_snapshot_and_reset_unaffected_by_metrics(self):
+        collector = MetricsAwareUsageCollector()
+        with patch("luthien_proxy.metrics.request_counter"), patch("luthien_proxy.metrics.token_counter"):
+            collector.record_completed(is_streaming=True)
+            collector.record_tokens(input_tokens=5, output_tokens=3)
+        snapshot = collector.snapshot_and_reset()
+        assert snapshot["requests_completed"] == 1
+        assert snapshot["streaming_requests"] == 1
+        assert snapshot["input_tokens"] == 5
+        assert snapshot["output_tokens"] == 3
+        snapshot2 = collector.snapshot_and_reset()
+        assert snapshot2["requests_completed"] == 0

--- a/tests/luthien_proxy/unit_tests/test_metrics.py
+++ b/tests/luthien_proxy/unit_tests/test_metrics.py
@@ -45,12 +45,14 @@ class TestMetricsAwareUsageCollector:
         assert snapshot["input_tokens"] == 10
         assert snapshot["output_tokens"] == 20
 
-    def test_record_tokens_skips_zero_values(self):
+    def test_record_tokens_zero_values_still_emitted(self):
         collector = MetricsAwareUsageCollector()
         mock_counter = MagicMock()
         with patch("luthien_proxy.metrics.token_counter", mock_counter):
             collector.record_tokens(input_tokens=0, output_tokens=0)
-        mock_counter.add.assert_not_called()
+        assert mock_counter.add.call_count == 2
+        mock_counter.add.assert_any_call(0, {"type": "input"})
+        mock_counter.add.assert_any_call(0, {"type": "output"})
 
     def test_snapshot_and_reset_unaffected_by_metrics(self):
         collector = MetricsAwareUsageCollector()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -1045,6 +1045,7 @@ dependencies = [
     { name = "litellm", extra = ["proxy"] },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-prometheus" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-redis" },
     { name = "opentelemetry-sdk" },
@@ -1085,6 +1086,7 @@ requires-dist = [
     { name = "litellm", extras = ["proxy"], specifier = ">=1.81.0,!=1.82.7,!=1.82.8" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-prometheus", specifier = ">=0.41b0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.41b0" },
     { name = "opentelemetry-instrumentation-redis", specifier = ">=0.41b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
@@ -1350,6 +1352,20 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-prometheus"
+version = "0.59b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/07/39370ec7eacfca10462121a0e036b66ccea3a616bf6ae6ea5fdb72e5009d/opentelemetry_exporter_prometheus-0.59b0.tar.gz", hash = "sha256:d64f23c49abb5a54e271c2fbc8feacea0c394a30ec29876ab5ef7379f08cf3d7", size = 14972, upload-time = "2025-10-16T08:35:55.973Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/ea/3005a732002242fd86203989520bdd5a752e1fd30dc225d5d45751ea19fb/opentelemetry_exporter_prometheus-0.59b0-py3-none-any.whl", hash = "sha256:71ced23207abd15b30d1fe4e7e910dcaa7c2ff1f24a6ffccbd4fdded676f541b", size = 13017, upload-time = "2025-10-16T08:35:37.253Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation"
 version = "0.59b0"
 source = { registry = "https://pypi.org/simple" }
@@ -1548,6 +1564,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a Prometheus-compatible `/metrics` endpoint using the OpenTelemetry Prometheus exporter — consistent with the existing OTel tracing setup, no second metrics library.

## Metrics exposed

| Metric | Labels | Description |
|--------|--------|-------------|
| `luthien_requests_completed_total` | `streaming` | Cumulative completed requests |
| `luthien_tokens_total` | `type` (input/output) | Cumulative token usage |
| `luthien_request_duration_seconds` | `status`, `streaming` | Latency histogram: full duration for non-streaming, TTFB for streaming (use `streaming` label to split) |
| `luthien_active_requests` | — | In-flight request gauge (TTFB-scoped for streaming) |

## Implementation

- **`opentelemetry-exporter-prometheus`** added as dependency (brings `prometheus-client`)
- **`telemetry.py`**: `configure_metrics()` creates `MeterProvider` + `PrometheusMetricReader` with custom histogram buckets for LLM latencies (0.1s–120s), called at startup alongside `configure_tracing()`. Thread-safe and idempotent.
- **`metrics.py`** (new): OTel instrument definitions + `MetricsAwareUsageCollector`
- **`MetricsAwareUsageCollector`**: drop-in replacement for `UsageCollector` — overrides `record_completed` and `record_tokens` to also increment OTel metrics. Always instantiated regardless of `USAGE_TELEMETRY` setting.
- **`main.py`**: `/metrics` endpoint (no auth, standard Prometheus convention), `LatencyMiddleware` for latency/active-requests on `/v1/messages` with `streaming` label, `/metrics` excluded from OTel FastAPI tracing, `generate_latest` wrapped in `run_in_threadpool`

## Tests

- 9 unit tests for `MetricsAwareUsageCollector` + `configure_metrics()` idempotency
- 5 `LatencyMiddleware` unit tests: error path, success, streaming label, missing content-type, non-messages skip
- 5 sqlite_e2e integration tests: endpoint 200, metric families parsed, no double suffixes, histogram buckets, no auth