### PR TITLE
docs: add policy authoring skill for Claude Code agents

### DIFF
--- a/.claude/skills/policy-authoring/SKILL.md
+++ b/.claude/skills/policy-authoring/SKILL.md
@@ -95,6 +95,7 @@ policy:
 3. **Thinking blocks first** — `thinking`/`redacted_thinking` blocks must come before `text` blocks.
 4. **Single finish_reason** — emit `finish_reason` once in the final chunk, not per tool call.
 5. **Preflight detection** — Claude Code sends probe requests (`max_tokens=1`) sharing `session_id`. Use `is_first_turn()` (re-evaluated per request), not session-level counters.
+6. **Override `short_policy_name`** — `BasePolicy.short_policy_name` returns the class name by default. Override it for a short human-readable identifier (e.g., `"NoOp"`, `"ToolJudge"`) used in logs and the admin UI.
 
 ## Streaming Event Types
 

--- a/.claude/skills/policy-authoring/SKILL.md
+++ b/.claude/skills/policy-authoring/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: Policy Authoring
+description: This skill should be used when the user needs to create, modify, or understand Luthien gateway policies — intercepting and transforming Anthropic API traffic. Covers "create a policy", "write a policy", "implement a policy", "modify a policy", "policy example", "how do policies work", "block a tool call", "filter streaming events", "transform responses", "intercept requests", or mentions PolicyContext, SimplePolicy, TextModifierPolicy, AnthropicHookPolicy, or policy hooks.
+version: 0.1.0
+---
+
+# Luthien Policy Authoring Guide
+
+Luthien policies intercept and transform Anthropic API traffic flowing through the gateway. Policies are singletons created once at startup, shared across all concurrent requests. They implement four lifecycle hooks called by the executor around backend I/O.
+
+## Policy Class Hierarchy — Pick the Right Base
+
+| Base class | Inherit when... | Override |
+|---|---|---|
+| `BasePolicy` + `AnthropicHookPolicy` | Full control over every hook | Any of the 4 hooks |
+| `TextModifierPolicy` | Transforming response text (streaming-aware) | `modify_text()`, optionally `extra_text()` |
+| `SimplePolicy` | Buffering is acceptable; transform complete content | `simple_on_response_content()`, `simple_on_request()`, `simple_on_anthropic_tool_call()` |
+| `NoOpPolicy` | Pass-through base for config-only demos | Nothing (inherits passthrough) |
+
+**Decision flowchart:**
+1. Only modifying text content? -> `TextModifierPolicy` (streaming-friendly, 1 method)
+2. Need complete content blocks (e.g., tool calls)? -> `SimplePolicy` (buffers, 3 methods)
+3. Need per-event streaming control? -> `BasePolicy` + `AnthropicHookPolicy` (4 hooks)
+
+## The Four Lifecycle Hooks
+
+```
+on_anthropic_request(request, context) -> request       # Transform before backend call
+      |
+[Backend call happens]
+      |
+on_anthropic_response(response, context) -> response    # Non-streaming only
+      |
+# Streaming path:
+on_anthropic_stream_event(event, context) -> list[event] # Per-event (filter=[], duplicate=multi)
+on_anthropic_stream_complete(context) -> list[emission]   # After stream ends, inject extras
+```
+
+`AnthropicHookPolicy` provides passthrough defaults for all four — override only what's needed.
+
+## Request-Scoped State via PolicyContext
+
+Policies are singletons. **Never store request data on `self`.**
+
+```python
+@dataclass
+class _MyState:
+    buffer: str = ""
+    count: int = 0
+
+class MyPolicy(BasePolicy, AnthropicHookPolicy):
+    async def on_anthropic_stream_event(self, event, context):
+        state = context.get_request_state(self, _MyState, _MyState)
+        state.buffer += "..."   # safe — isolated per request per policy
+        return [event]
+```
+
+Key `PolicyContext` facilities:
+- `get_request_state(owner, expected_type, factory)` — typed, collision-free per-policy state
+- `pop_request_state(owner, type)` — remove and return (cleanup)
+- `record_event(event_type, data)` — fire-and-forget observability
+- `span(name, attrs)` — OpenTelemetry context manager
+- `session_id` — conversation session identifier
+- `credential_manager` — resolve auth credentials
+- `for_testing(...)` — create test-friendly contexts
+
+## Configuration with Pydantic
+
+Define a Pydantic `BaseModel` for config. Use `_init_config()` to handle all input forms (None/dict/model):
+
+```python
+class MyConfig(BaseModel):
+    threshold: float = Field(default=0.5, ge=0.0, le=1.0)
+    api_key: str | None = Field(default=None, json_schema_extra={"format": "password"})
+
+class MyPolicy(BasePolicy, AnthropicHookPolicy):
+    def __init__(self, config: MyConfig | None = None):
+        self.config = self._init_config(config, MyConfig)
+        # Derived immutable state is fine on self:
+        self._threshold = self.config.threshold  # scalar — OK
+```
+
+YAML config:
+```yaml
+policy:
+  class: "luthien_proxy.policies.my_policy:MyPolicy"
+  config:
+    threshold: 0.8
+```
+
+## Critical Rules
+
+1. **No mutable containers on `self`** — `freeze_configured_state()` rejects `list`, `dict`, `set` on the policy instance. Use `tuple`/`frozenset` for config, `PolicyContext` for request state.
+2. **Content blocks before message_delta** — all `content_block_*` events must precede `RawMessageDeltaEvent` in streaming. Violating this corrupts sessions.
+3. **Thinking blocks first** — `thinking`/`redacted_thinking` blocks must come before `text` blocks.
+4. **Single finish_reason** — emit `finish_reason` once in the final chunk, not per tool call.
+5. **Preflight detection** — Claude Code sends probe requests (`max_tokens=1`) sharing `session_id`. Use `is_first_turn()` (re-evaluated per request), not session-level counters.
+
+## Streaming Event Types
+
+Events from `anthropic.types`:
+- `RawContentBlockStartEvent` — block begins (has `.content_block` with type info)
+- `RawContentBlockDeltaEvent` — content chunk (`.delta`: `TextDelta`, `InputJSONDelta`, etc.)
+- `RawContentBlockStopEvent` — block complete
+- `RawMessageDeltaEvent` — message-level metadata (stop_reason, usage)
+- `RawMessageStopEvent` — message complete
+
+Return values from `on_anthropic_stream_event`:
+- `[event]` — pass through
+- `[]` — filter/suppress (buffer it)
+- `[event1, event2]` — expand/inject
+
+## Testing Policies
+
+Mirror source path: `src/.../my_policy.py` -> `tests/.../unit_tests/policies/test_my_policy.py`
+
+```python
+from luthien_proxy.policy_core.policy_context import PolicyContext
+
+@pytest.fixture
+def policy():
+    return MyPolicy(config=MyConfig(threshold=0.5))
+
+class TestMyPolicyProtocol:
+    def test_implements_interface(self, policy):
+        assert isinstance(policy, AnthropicExecutionInterface)
+        assert isinstance(policy, BasePolicy)
+
+class TestMyPolicyResponse:
+    @pytest.mark.asyncio
+    async def test_transforms_content(self):
+        policy = MyPolicy()
+        ctx = PolicyContext.for_testing(transaction_id="test")
+        response: AnthropicResponse = {
+            "id": "msg_test", "type": "message", "role": "assistant",
+            "content": [{"type": "text", "text": "hello"}],
+            "model": "test", "stop_reason": "end_turn",
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+        result = await policy.on_anthropic_response(response, ctx)
+        assert result["content"][0]["text"] == "EXPECTED"
+```
+
+Run: `uv run pytest tests/luthien_proxy/unit_tests/policies/test_my_policy.py`
+
+## File Placement
+
+- Policy module: `src/luthien_proxy/policies/<name>_policy.py`
+- Tests: `tests/luthien_proxy/unit_tests/policies/test_<name>_policy.py`
+- Config: `config/policy_config.yaml` (uncomment/add entry)
+- Export: add to `src/luthien_proxy/policies/__init__.py` if needed
+
+## Additional Resources
+
+For detailed patterns, streaming internals, and gotchas, consult:
+- **`references/patterns.md`** — complete examples of each policy tier (passthrough, text modifier, buffered, streaming, judge-based)
+- **`references/gotchas.md`** — streaming protocol violations, mutable state bugs, event ordering, and preflight edge cases
+- **`references/uppercase_policy.py`** — simplest possible TextModifierPolicy (working example)
+- **`references/first_turn_banner_policy.py`** — SimplePolicy with request-scoped state and first-turn detection (working example)

--- a/.claude/skills/policy-authoring/references/first_turn_banner_policy.py
+++ b/.claude/skills/policy-authoring/references/first_turn_banner_policy.py
@@ -1,5 +1,8 @@
 """FirstTurnBannerPolicy — SimplePolicy with request-scoped state.
 
+REFERENCE EXAMPLE — this file lives under `.claude/skills/` and imports
+from `luthien_proxy.*`. To use, copy to `src/luthien_proxy/policies/`.
+
 Prepends a welcome banner to the first response in each conversation.
 Demonstrates: SimplePolicy subclassing, PolicyContext state, first-turn detection.
 

--- a/.claude/skills/policy-authoring/references/first_turn_banner_policy.py
+++ b/.claude/skills/policy-authoring/references/first_turn_banner_policy.py
@@ -1,0 +1,66 @@
+"""FirstTurnBannerPolicy — SimplePolicy with request-scoped state.
+
+Prepends a welcome banner to the first response in each conversation.
+Demonstrates: SimplePolicy subclassing, PolicyContext state, first-turn detection.
+
+Example config:
+    policy:
+      class: "luthien_proxy.policies.first_turn_banner_policy:FirstTurnBannerPolicy"
+      config:
+        banner: "Welcome to the Luthien-powered assistant!"
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from luthien_proxy.policies.onboarding_policy import is_first_turn
+from luthien_proxy.policies.simple_policy import SimplePolicy
+
+if TYPE_CHECKING:
+    from luthien_proxy.llm.types.anthropic import AnthropicRequest
+    from luthien_proxy.policy_core.policy_context import PolicyContext
+
+
+class FirstTurnBannerConfig(BaseModel):
+    banner: str = Field(
+        default="Welcome! This conversation is monitored by Luthien.",
+        description="Text to prepend to the first response",
+    )
+
+
+@dataclass
+class _BannerState:
+    """Request-scoped state: tracks first-turn detection."""
+
+    is_first_turn: bool = field(default=False)
+
+
+class FirstTurnBannerPolicy(SimplePolicy):
+    """Prepend a banner to the first response in a conversation."""
+
+    def __init__(self, config: FirstTurnBannerConfig | None = None):
+        self.config = self._init_config(config, FirstTurnBannerConfig)
+
+    @property
+    def short_policy_name(self) -> str:
+        return "FirstTurnBanner"
+
+    def _state(self, context: PolicyContext) -> _BannerState:
+        return context.get_request_state(self, _BannerState, _BannerState)
+
+    async def on_anthropic_request(
+        self, request: AnthropicRequest, context: PolicyContext
+    ) -> AnthropicRequest:
+        self._state(context).is_first_turn = is_first_turn(request)
+        return await super().on_anthropic_request(request, context)
+
+    async def simple_on_response_content(
+        self, content: str, context: PolicyContext
+    ) -> str:
+        if not self._state(context).is_first_turn:
+            return content
+        return f"[{self.config.banner}]\n\n{content}"

--- a/.claude/skills/policy-authoring/references/gotchas.md
+++ b/.claude/skills/policy-authoring/references/gotchas.md
@@ -1,0 +1,223 @@
+# Policy Gotchas Reference
+
+Non-obvious behaviors, edge cases, and common mistakes when writing Luthien policies.
+
+## Mutable State on Policy Instances
+
+**Problem:** Policies are singletons shared across all concurrent requests. Mutable containers on `self` would be shared state.
+
+**Guard:** `freeze_configured_state()` runs at load time and rejects `list`, `dict`, `set`, `bytearray` on the instance.
+
+```python
+# WRONG — freeze_configured_state() will raise TypeError
+class BadPolicy(BasePolicy, AnthropicHookPolicy):
+    def __init__(self):
+        self.cache = {}            # MutableMapping
+        self.patterns = ["a", "b"] # MutableSequence
+
+# RIGHT — use immutable types for config state
+class GoodPolicy(BasePolicy, AnthropicHookPolicy):
+    def __init__(self):
+        self._patterns = ("a", "b")          # tuple
+        self._names = frozenset({"x", "y"})  # frozenset
+
+# RIGHT — use PolicyContext for request-scoped mutable state
+@dataclass
+class _RequestState:
+    buffer: dict[int, str] = field(default_factory=dict)
+
+class GoodPolicy2(BasePolicy, AnthropicHookPolicy):
+    async def on_anthropic_stream_event(self, event, context):
+        state = context.get_request_state(self, _RequestState, _RequestState)
+        state.buffer[0] = "safe"  # isolated per request
+```
+
+Note: `freeze_configured_state()` only checks at load time. It does not prevent runtime attribute assignment. But any runtime mutation on the singleton is a concurrency bug.
+
+**Exception:** Pydantic `BaseModel` instances assigned to `self.config` are allowed because they're not `MutableMapping`/`MutableSequence`/`MutableSet` — but treat them as immutable anyway.
+
+---
+
+## Streaming Event Ordering
+
+### Content Blocks Must Precede message_delta
+
+**Problem:** If a policy emits `content_block_*` events after `RawMessageDeltaEvent`, the Anthropic client session is corrupted.
+
+**Fix:** Flush all held-back content events before message_delta arrives.
+
+```python
+# In on_anthropic_stream_event:
+if isinstance(event, RawMessageDeltaEvent):
+    flush_events = self._flush_buffer(state)  # emit pending content
+    flush_events.append(event)
+    return flush_events
+```
+
+This is why `TextModifierPolicy._flush_before_message_delta()` and `StringReplacementPolicy`'s buffer flush both trigger on `RawMessageDeltaEvent`.
+
+### Thinking Blocks Must Come First
+
+Anthropic API requires `thinking`/`redacted_thinking` blocks BEFORE `text` blocks in response content. Reordering blocks to put text first causes: `Expected 'thinking' or 'redacted_thinking', but found 'text'`.
+
+### Single finish_reason in Final Chunk
+
+**Problem:** Setting `finish_reason` on each tool call chunk causes clients to interpret them as separate responses.
+
+**Fix:** Emit `finish_reason` only once, in the final chunk after all tool calls.
+
+---
+
+## Content + finish_reason in Same Chunk
+
+**Problem:** When a streaming chunk contains both content text AND a `finish_reason`, some clients ignore the `finish_reason` — the content takes priority and the stop signal is lost.
+
+**Fix:** Emit content as one chunk, then emit a separate chunk with only the `finish_reason`.
+
+---
+
+## Preflight Requests (Claude Code Probes)
+
+**Problem:** Claude Code sends preflight/probe requests with `max_tokens=1` that share the same `session_id` as the real request. If a policy uses session-level state to track "first turn", the preflight consumes it.
+
+**Fix:** Use `is_first_turn(request)` which checks message count (re-evaluated per request), not session-level counters. Each request gets its own `PolicyContext`, so any state set during preflight is scoped to that request's context.
+
+---
+
+## SimplePolicy: Thinking Deltas Pass Through
+
+`SimplePolicy` only buffers `TextDelta` and `InputJSONDelta`. Other delta types (thinking blocks, etc.) pass through unchanged. This is by design — `simple_on_response_content()` only sees complete text, not thinking content.
+
+---
+
+## Tool Call Replacement: Stop Reason
+
+When blocking a tool_use and replacing it with text, also update `stop_reason`:
+
+```python
+# Non-streaming: check if all tool_use blocks were blocked
+has_tool_use = any(b.get("type") == "tool_use" for b in new_content)
+if not has_tool_use and response.get("stop_reason") == "tool_use":
+    response["stop_reason"] = "end_turn"
+```
+
+Without this, the client thinks it should submit tool results but has no tool calls to respond to.
+
+---
+
+## model_construct vs Regular Construction
+
+For performance in hot paths (streaming), use `model_construct` to skip Pydantic validation:
+
+```python
+# Fast — no validation (use in streaming hot path)
+text_delta = TextDelta.model_construct(type="text_delta", text=transformed)
+delta_event = RawContentBlockDeltaEvent.model_construct(
+    type="content_block_delta", index=index, delta=text_delta,
+)
+
+# Normal — with validation (use when correctness matters more than speed)
+delta_event = RawContentBlockDeltaEvent(
+    type="content_block_delta", index=index, delta=text_delta,
+)
+```
+
+`SimplePolicy` and `StringReplacementPolicy` use `model_construct` in their streaming paths.
+`TextModifierPolicy` uses regular constructors for suffix injection (less frequent, correctness matters).
+
+---
+
+## model_copy for Event Modification
+
+To modify an existing event without mutation, use `model_copy`:
+
+```python
+# Modify a text delta in an existing event
+new_delta = event.delta.model_copy(update={"text": transformed_text})
+return [event.model_copy(update={"delta": new_delta})]
+```
+
+This preserves all other fields and creates a new object (no shared state).
+
+---
+
+## Buffer Cleanup
+
+Always clean up request-scoped state when streaming completes:
+
+```python
+async def on_anthropic_streaming_policy_complete(self, context):
+    context.pop_request_state(self, _MyState)
+```
+
+Or implement cleanup in `on_anthropic_stream_complete`:
+
+```python
+async def on_anthropic_stream_complete(self, context):
+    state = context.pop_request_state(self, _MyState)
+    if state and state.buffer:
+        return self._flush(state)  # emit remaining buffered content
+    return []
+```
+
+---
+
+## Config Instantiation Patterns
+
+The `_instantiate_policy()` function in `config.py` tries two patterns:
+
+1. **Spread pattern:** `policy_class(**config_dict)` — when config keys match constructor param names
+2. **Model pattern:** `policy_class(param_name=config_dict)` — when config keys match Pydantic model fields
+
+If a policy has `def __init__(self, config: MyConfig | None = None)`, the YAML `config:` section is passed as the `config` parameter. If it has `def __init__(self, threshold: float = 0.5, model: str = "...")`, the YAML keys are spread as keyword arguments.
+
+**Recommendation:** Use the single-parameter Pydantic model pattern (`config: MyConfig | None = None`) for consistency and auto-serialization via `get_config()`.
+
+---
+
+## Observability Best Practices
+
+Use `context.record_event()` for policy-specific telemetry:
+
+```python
+context.record_event(
+    "policy.my_policy.blocked",
+    {
+        "summary": f"Blocked tool call: {name}",  # human-readable
+        "tool_name": name,
+        "reason": "matched pattern",
+    },
+)
+```
+
+Conventions:
+- Event type: `policy.<policy_name>.<action>` (e.g., `policy.judge.evaluation_complete`)
+- Include a `summary` field for UI display
+- Include a `severity` field for warnings/errors: `"warning"`, `"error"`
+- Truncate large values (tool arguments → first 500 chars)
+
+Use `context.span(name, attrs)` for timed operations:
+
+```python
+with context.span("judge_evaluation", {"tool_name": name}):
+    result = await self._call_judge(...)
+```
+
+---
+
+## cast() for MessageStreamEvent
+
+When constructing `RawContentBlock*` events manually, they need to be cast to `MessageStreamEvent` for the return type:
+
+```python
+from typing import cast
+from anthropic.lib.streaming import MessageStreamEvent
+
+return [
+    cast(MessageStreamEvent, start_event),
+    cast(MessageStreamEvent, delta_event),
+    cast(MessageStreamEvent, stop_event),
+]
+```
+
+This is a type-checker appeasement — the runtime types are correct.

--- a/.claude/skills/policy-authoring/references/gotchas.md
+++ b/.claude/skills/policy-authoring/references/gotchas.md
@@ -143,14 +143,11 @@ This preserves all other fields and creates a new object (no shared state).
 
 ## Buffer Cleanup
 
-Always clean up request-scoped state when streaming completes:
+Always clean up request-scoped state when streaming completes. There are two options:
 
-```python
-async def on_anthropic_streaming_policy_complete(self, context):
-    context.pop_request_state(self, _MyState)
-```
+### Option A: `on_anthropic_stream_complete` (standard protocol hook)
 
-Or implement cleanup in `on_anthropic_stream_complete`:
+This is the fourth lifecycle hook defined on `AnthropicExecutionInterface`/`AnthropicHookPolicy`. The executor always calls it after the upstream stream ends. Use this as the primary cleanup path:
 
 ```python
 async def on_anthropic_stream_complete(self, context):
@@ -159,6 +156,12 @@ async def on_anthropic_stream_complete(self, context):
         return self._flush(state)  # emit remaining buffered content
     return []
 ```
+
+### Option B: `on_anthropic_streaming_policy_complete` (convention method, MultiSerialPolicy only)
+
+Several built-in policies (`SimplePolicy`, `ToolCallJudgePolicy`, `DogfoodSafetyPolicy`) define an `on_anthropic_streaming_policy_complete` cleanup method. **This is not part of any protocol** — it's a convention method discovered via `getattr` in `MultiSerialPolicy.on_anthropic_streaming_policy_complete()` (see `src/luthien_proxy/policies/multi_serial_policy.py:170-175`).
+
+It is **only called when policies are composed via `MultiSerialPolicy`**. If the policy runs standalone (the default), this method will never fire. Do not rely on it for correctness-critical cleanup — use `on_anthropic_stream_complete` instead. Only define it if the policy will specifically be used as a sub-policy in a chain and needs a cleanup hook that doesn't return events.
 
 ---
 

--- a/.claude/skills/policy-authoring/references/patterns.md
+++ b/.claude/skills/policy-authoring/references/patterns.md
@@ -278,6 +278,7 @@ class MyPolicy(SimplePolicy):
 For policies that call a separate LLM to evaluate content:
 
 ```python
+from luthien_proxy.credentials import parse_auth_provider
 from luthien_proxy.llm.judge_client import judge_completion
 
 class MyJudge(BasePolicy, AnthropicHookPolicy):
@@ -307,7 +308,7 @@ class MyJudge(BasePolicy, AnthropicHookPolicy):
 Policies can be chained via `MultiSerialPolicy`:
 
 ```python
-from luthien_proxy.policies.policy_composition import compose_policy
+from luthien_proxy.policy_composition import compose_policy
 
 # At runtime (e.g., via admin API):
 combined = compose_policy(current_policy, additional_policy)

--- a/.claude/skills/policy-authoring/references/patterns.md
+++ b/.claude/skills/policy-authoring/references/patterns.md
@@ -1,0 +1,335 @@
+# Policy Patterns Reference
+
+Detailed examples of each policy authoring tier, from simplest to most complex.
+
+## Pattern 1: Passthrough (NoOpPolicy)
+
+The absolute minimum — inherit `BasePolicy` + `AnthropicHookPolicy`, all hooks pass through by default.
+
+```python
+from luthien_proxy.policy_core import AnthropicHookPolicy, BasePolicy
+
+class NoOpPolicy(BasePolicy, AnthropicHookPolicy):
+    @property
+    def short_policy_name(self) -> str:
+        return "NoOp"
+
+    def active_policy_names(self) -> list[str]:
+        return []  # doesn't modify anything
+```
+
+Use case: placeholder, config-only demo base.
+
+---
+
+## Pattern 2: TextModifierPolicy — Modify Response Text
+
+Override `modify_text()` for in-stream text transformation. Handles both streaming and non-streaming automatically.
+
+```python
+from luthien_proxy.policy_core import TextModifierPolicy
+
+class AllCapsPolicy(TextModifierPolicy):
+    def modify_text(self, text: str) -> str:
+        return text.upper()
+```
+
+### With Extra Text (Suffix Injection)
+
+Override `extra_text()` to append content to the last text block. The base class handles the streaming protocol complexity — flushing before `message_delta`, handling tool_use blocks that follow text, etc.
+
+```python
+class OnboardingPolicy(TextModifierPolicy):
+    def __init__(self, gateway_url: str = "http://localhost:8000"):
+        self._gateway_url = gateway_url
+
+    def extra_text(self) -> str | None:
+        return f"\n\n---\nGateway: {self._gateway_url}"
+```
+
+**How TextModifierPolicy handles streaming internally:**
+- Text deltas are modified in-flight (`model_copy(update=...)`)
+- `extra_text()` suffix is injected before `RawMessageDeltaEvent` (content blocks must precede it)
+- If a `ToolUseBlock` starts after text, the held-back text stop event is flushed with the suffix first
+- Safety net in `on_anthropic_stream_complete` handles abrupt stream endings
+
+---
+
+## Pattern 3: SimplePolicy — Buffered Content Transformation
+
+Trades streaming responsiveness for simpler authoring. Buffers all content, applies transformation on `content_block_stop`, emits as a single delta.
+
+### Response Content Transformation
+
+```python
+from luthien_proxy.policies.simple_policy import SimplePolicy
+
+class CensorPolicy(SimplePolicy):
+    async def simple_on_response_content(self, content: str, context) -> str:
+        return content.replace("secret", "[REDACTED]")
+```
+
+### Request Transformation
+
+```python
+class SystemPromptInjector(SimplePolicy):
+    async def simple_on_request(self, request_str: str, context) -> str:
+        return f"[IMPORTANT: Always be helpful]\n{request_str}"
+```
+
+### Tool Call Transformation
+
+```python
+from luthien_proxy.llm.types.anthropic import AnthropicToolUseBlock
+
+class ToolCallLogger(SimplePolicy):
+    async def simple_on_anthropic_tool_call(
+        self, tool_call: AnthropicToolUseBlock, context
+    ) -> AnthropicToolUseBlock:
+        context.record_event("tool_called", {"name": tool_call["name"]})
+        return tool_call  # pass through unchanged
+```
+
+### How SimplePolicy Buffering Works
+
+1. `content_block_start` → initialize buffer for this block index
+2. `content_block_delta` (TextDelta) → accumulate in buffer, return `[]` (suppress)
+3. `content_block_delta` (InputJSONDelta) → accumulate in tool buffer, return `[]`
+4. `content_block_stop` → call `simple_on_response_content()` or `simple_on_anthropic_tool_call()`, emit transformed content as single delta + stop event
+5. Other events (thinking deltas, message events) → pass through unchanged
+
+**Request-scoped state** is managed via `_SimplePolicyAnthropicState` using `context.get_request_state()`.
+
+---
+
+## Pattern 4: Full Hook Policy — Streaming Control
+
+For policies that need per-event streaming decisions (filter events, inject events, buffer across chunks).
+
+### Tool Call Buffering and Evaluation (Judge Pattern)
+
+The `ToolCallJudgePolicy` pattern: buffer tool_use events, evaluate on completion, either replay or replace.
+
+```python
+@dataclass
+class _BufferedToolUse:
+    id: str
+    name: str
+    input_json: str = ""
+
+@dataclass
+class _JudgeState:
+    buffered: dict[int, _BufferedToolUse] = field(default_factory=dict)
+
+class MyJudgePolicy(BasePolicy, AnthropicHookPolicy):
+    def _state(self, ctx):
+        return ctx.get_request_state(self, _JudgeState, _JudgeState)
+
+    async def on_anthropic_stream_event(self, event, context):
+        state = self._state(context)
+
+        # Buffer tool_use starts
+        if isinstance(event, RawContentBlockStartEvent):
+            if isinstance(event.content_block, ToolUseBlock):
+                state.buffered[event.index] = _BufferedToolUse(
+                    id=event.content_block.id,
+                    name=event.content_block.name,
+                )
+                return []  # suppress until judged
+            return [event]
+
+        # Accumulate JSON deltas
+        if isinstance(event, RawContentBlockDeltaEvent):
+            if event.index in state.buffered and isinstance(event.delta, InputJSONDelta):
+                state.buffered[event.index].input_json += event.delta.partial_json
+                return []
+            return [event]
+
+        # Judge on block completion
+        if isinstance(event, RawContentBlockStopEvent):
+            if event.index in state.buffered:
+                buf = state.buffered.pop(event.index)
+                if self._should_block(buf):
+                    return self._build_blocked_events(event.index, buf, event)
+                return self._rebuild_allowed_events(event.index, buf, event)
+            return [event]
+
+        return [event]
+```
+
+### Rebuilding Allowed Events
+
+When a buffered tool call is allowed, reconstruct the full event sequence:
+
+```python
+def _rebuild_allowed_events(self, index, buf, stop_event):
+    start = RawContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=ToolUseBlock(type="tool_use", id=buf.id, name=buf.name, input={}),
+    )
+    delta = RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=InputJSONDelta(type="input_json_delta", partial_json=buf.input_json or "{}"),
+    )
+    return [cast(MessageStreamEvent, start), cast(MessageStreamEvent, delta), cast(MessageStreamEvent, stop_event)]
+```
+
+### Replacing Blocked Tool Calls with Text
+
+```python
+def _build_blocked_events(self, index, buf, stop_event):
+    start = RawContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=TextBlock(type="text", text=""),
+    )
+    delta = RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=TextDelta(type="text_delta", text=f"Blocked: {buf.name}"),
+    )
+    return [cast(MessageStreamEvent, start), cast(MessageStreamEvent, delta), cast(MessageStreamEvent, stop_event)]
+```
+
+---
+
+## Pattern 5: Cross-Chunk Streaming (Sliding Buffer)
+
+`StringReplacementPolicy` demonstrates handling replacements that span chunk boundaries using a sliding buffer.
+
+**Core idea:** Hold back `buffer_size` characters (longest source - 1) from each chunk. On the next chunk, prepend the buffer, apply replacements to the combined string, emit the safe prefix, hold back the new tail.
+
+```python
+# Simplified version of the sliding buffer pattern
+async def on_anthropic_stream_event(self, event, context):
+    if isinstance(event, RawContentBlockDeltaEvent) and isinstance(event.delta, TextDelta):
+        state = self._get_buffer_state(context)
+        combined = state.buffer + event.delta.text
+        replaced = self._apply_replacements(combined)
+
+        if len(replaced) <= self._buffer_size:
+            state.buffer = replaced
+            return []  # not enough to emit safely
+
+        emit_text = replaced[:-self._buffer_size]
+        state.buffer = replaced[-self._buffer_size:]
+        new_delta = event.delta.model_copy(update={"text": emit_text})
+        return [event.model_copy(update={"delta": new_delta})]
+
+    # Flush buffer before message_delta and content_block_stop
+    if isinstance(event, (RawMessageDeltaEvent, RawContentBlockStopEvent)):
+        flush_events = self._flush_buffer(state)
+        flush_events.append(event)
+        return flush_events
+```
+
+**Critical:** Always flush before `RawMessageDeltaEvent` and `RawContentBlockStopEvent`.
+
+---
+
+## Pattern 6: Pydantic Config with Immutable Derived State
+
+```python
+class MyConfig(BaseModel):
+    replacements: list[list[str]] = Field(default_factory=list)
+    match_capitalization: bool = False
+
+class MyPolicy(BasePolicy, AnthropicHookPolicy):
+    def __init__(self, config: MyConfig | None = None):
+        self.config = self._init_config(config, MyConfig)
+        # Derived state MUST be immutable (freeze_configured_state enforces this)
+        self._replacements: tuple[tuple[str, str], ...] = tuple(
+            (pair[0], pair[1]) for pair in self.config.replacements
+        )
+        self._buffer_size: int = max(
+            (len(s) for s, _ in self._replacements), default=0
+        ) - 1
+```
+
+---
+
+## Pattern 7: First-Turn Detection
+
+Detect whether this is the first message in a conversation:
+
+```python
+from luthien_proxy.policies.onboarding_policy import is_first_turn
+
+class MyPolicy(SimplePolicy):
+    async def on_anthropic_request(self, request, context):
+        state = self._state(context)
+        state.first_turn = is_first_turn(request)
+        return await super().on_anthropic_request(request, context)
+
+    async def simple_on_response_content(self, content, context):
+        if not self._state(context).first_turn:
+            return content
+        return f"[Welcome banner]\n\n{content}"
+```
+
+`is_first_turn()` checks if the request has only a single user message (no prior exchanges).
+
+---
+
+## Pattern 8: External LLM Calls (Judge)
+
+For policies that call a separate LLM to evaluate content:
+
+```python
+from luthien_proxy.llm.judge_client import judge_completion
+
+class MyJudge(BasePolicy, AnthropicHookPolicy):
+    def __init__(self, config=None):
+        self.config = self._init_config(config, MyJudgeConfig)
+        self._auth_provider = parse_auth_provider(self.config.auth_provider)
+
+    async def _call_judge(self, name, arguments, context):
+        credential = await context.credential_manager.resolve(self._auth_provider, context)
+        response_text = await judge_completion(
+            credential,
+            model=self.config.model,
+            messages=prompt,
+            temperature=0.0,
+            max_tokens=256,
+            api_base=self.config.api_base,
+        )
+        return parse_result(response_text)
+```
+
+**Fail-secure:** Always wrap judge calls in try/except. Default to blocking on failure.
+
+---
+
+## Policy Composition
+
+Policies can be chained via `MultiSerialPolicy`:
+
+```python
+from luthien_proxy.policies.policy_composition import compose_policy
+
+# At runtime (e.g., via admin API):
+combined = compose_policy(current_policy, additional_policy)
+# Request hooks run in order: policy1 -> policy2
+# Each policy's output feeds the next
+```
+
+`DogfoodSafetyPolicy` auto-composes via `DOGFOOD_MODE=true` — wraps whatever policy is configured.
+
+---
+
+## Admin API Hot-Swap
+
+Policies can be changed at runtime via the admin API:
+
+```
+POST /api/admin/policy
+{
+    "class_ref": "luthien_proxy.policies.all_caps_policy:AllCapsPolicy",
+    "config": {},
+    "enabled_by": "admin"
+}
+```
+
+The policy manager validates the class, instantiates it, and swaps atomically.

--- a/.claude/skills/policy-authoring/references/uppercase_policy.py
+++ b/.claude/skills/policy-authoring/references/uppercase_policy.py
@@ -1,0 +1,21 @@
+"""UppercasePolicy — Simplest possible TextModifierPolicy.
+
+Converts all text content in responses to uppercase.
+Tool calls, thinking blocks, and images pass through unchanged.
+
+Example config:
+    policy:
+      class: "luthien_proxy.policies.uppercase_policy:UppercasePolicy"
+      config: {}
+"""
+
+from __future__ import annotations
+
+from luthien_proxy.policy_core import TextModifierPolicy
+
+
+class UppercasePolicy(TextModifierPolicy):
+    """Convert all response text to uppercase."""
+
+    def modify_text(self, text: str) -> str:
+        return text.upper()

--- a/.claude/skills/policy-authoring/references/uppercase_policy.py
+++ b/.claude/skills/policy-authoring/references/uppercase_policy.py
@@ -1,5 +1,8 @@
 """UppercasePolicy — Simplest possible TextModifierPolicy.
 
+REFERENCE EXAMPLE — this file lives under `.claude/skills/` and imports
+from `luthien_proxy.*`. To use, copy to `src/luthien_proxy/policies/`.
+
 Converts all text content in responses to uppercase.
 Tool calls, thinking blocks, and images pass through unchanged.
 

--- a/changelog.d/policy-authoring-skill.md
+++ b/changelog.d/policy-authoring-skill.md
@@ -1,0 +1,6 @@
+---
+category: Chores & Docs
+pr: 518
+---
+
+**Policy authoring skill**: Added a Claude Code skill at `.claude/skills/policy-authoring/` with a comprehensive guide to writing Luthien policies — base class selection, lifecycle hooks, streaming gotchas, request-scoped state, and working examples.

--- a/dev-README.md
+++ b/dev-README.md
@@ -156,6 +156,8 @@ The gateway uses an event-driven policy architecture with streaming support.
 
 Subclass `SimplePolicy` for basic request/response transformations. See `src/luthien_proxy/policies/` for examples.
 
+For a comprehensive authoring guide — choosing the right base class, lifecycle hooks, streaming gotchas, request-scoped state, and working examples — see the **[Policy Authoring skill](.claude/skills/policy-authoring/SKILL.md)**.
+
 ## Troubleshooting
 
 ### Tests failing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ packages = ["src/luthien_proxy"]
 target-version = "py313"
 src = ["src", "tests", "saas_infra"]
 line-length = 120
+extend-exclude = [".claude/skills"]  # Documentation fragments, not source code
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Summary

- Adds a Claude Code skill at `.claude/skills/policy-authoring/` with a comprehensive guide to writing Luthien policies
- Covers base class selection, lifecycle hooks, request-scoped state, Pydantic config, streaming event types, testing patterns, and file placement
- Reference files cover 8 detailed patterns (passthrough through judge-based) and 12 gotchas with fixes
- Includes two working example policies as reference material
- Links from `dev-README.md` "Creating Custom Policies" section

## Test plan

- [x] Verify all referenced source modules exist in the codebase
- [x] Skill reviewer pass (description quality, progressive disclosure, writing style)
- [ ] Manually trigger skill with "how do I create a policy" and verify it loads

---
*Posted by Claude Code (claude-opus-4-6)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)