### PR TITLE
fix(cli): filter git describe to cli-v* tags for hatch-vcs

### DIFF
--- a/changelog.d/fix-cli-hatch-vcs.md
+++ b/changelog.d/fix-cli-hatch-vcs.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**luthien-cli build failure on recent checkouts**: Filter `git describe` to only consider `cli-v*` tags when resolving the CLI version. Previously, after the proxy's `v3.0.0` tag landed, any fresh checkout or worktree would fail to build with `UserWarning: tag 'v3.0.0' no version found` because hatch-vcs picked the nearest tag (`v3.0.0`) before the cli-specific `tag_regex` could filter it.

--- a/changelog.d/fix-cli-hatch-vcs.md
+++ b/changelog.d/fix-cli-hatch-vcs.md
@@ -1,5 +1,6 @@
 ---
 category: Fixes
+pr: 520
 ---
 
 **luthien-cli build failure on recent checkouts**: Filter `git describe` to only consider `cli-v*` tags when resolving the CLI version. Previously, after the proxy's `v3.0.0` tag landed, any fresh checkout or worktree would fail to build with `UserWarning: tag 'v3.0.0' no version found` because hatch-vcs picked the nearest tag (`v3.0.0`) before the cli-specific `tag_regex` could filter it.

--- a/src/luthien_cli/pyproject.toml
+++ b/src/luthien_cli/pyproject.toml
@@ -25,6 +25,12 @@ packages = ["src/luthien_cli"]
 source = "vcs"
 raw-options.root = "../.."
 raw-options.tag_regex = "^cli-v(?P<version>\\d+(?:\\.\\d+)*)$"
+# Filter git describe to only cli-v* tags — otherwise the proxy's v3.0.0 tag
+# (newer than any cli-v*) trips tag_regex parsing and builds fail with:
+#   UserWarning: tag 'v3.0.0' no version found
+raw-options.git_describe_command = [
+    "git", "describe", "--dirty", "--tags", "--long", "--match", "cli-v*",
+]
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/luthien_cli/_version.py"


### PR DESCRIPTION
## Summary

Fresh checkouts and worktrees fail to build `luthien-cli` since the proxy's `v3.0.0` tag landed:

\`\`\`
UserWarning: tag 'v3.0.0' no version found
AssertionError: Error getting the version from source \`vcs\`
\`\`\`

**Root cause:** `tag_regex` in hatch-vcs only parses the version out of a tag name — it runs *after* `git describe` has already picked a tag. Without a `--match` filter, `git describe --tags` returns `v3.0.0` (the proxy tag, which is now newer than any `cli-v*` tag). hatch-vcs then tries to parse `v3.0.0` with the cli-specific regex, fails, and errors.

**Fix:** pass `--match 'cli-v*'` to `git describe` via `raw-options.git_describe_command` so the proxy tag is never considered when resolving the CLI version.

## Test plan

- [x] `uv sync --dev` succeeds in a fresh worktree off `main`
- [x] `uv run python -c 'from luthien_cli._version import version; print(version)'` returns a valid cli version (e.g. `0.1.21.dev24+g3e356750`)
- [ ] CI passes

---
*Posted by Claude Code (claude-opus-4-6)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## RCA/COE

### Bug: luthien-cli build fails on any fresh checkout with tags after `v3.0.0` landed

**Impact:** Every contributor doing a fresh clone (or `git fetch --tags` in an existing worktree) since 2026-04-09 hits `AssertionError: Error getting the version from source 'vcs'` when running `uv sync`, `uv build`, or any command that triggers an editable install of `luthien-cli`. That includes `./scripts/dev_checks.sh`, making pre-PR validation impossible without either working around the failure or manually resolving the git state. Blast radius is any new contributor setup + every new worktree. No production impact (the proxy still runs), but dogfooding is broken for anyone who fetches tags.

**Repro Steps (before this fix):**
1. Check out commit `3e356750` (main HEAD before this PR) or later
2. `git fetch --tags` (any workflow that materialises tags locally)
3. `uv sync --dev`
4. Observe: build fails with `UserWarning: tag 'v3.0.0' no version found` followed by `AssertionError: Error getting the version from source 'vcs'`, from hatchling trying to resolve `luthien-cli`'s version.

**Timeline:**

| Date | Event |
|------|-------|
| 2025-10 or earlier | `tag_regex = "^cli-v(?P<version>...)$"` added to `src/luthien_cli/pyproject.toml` under the (incorrect) assumption it filtered which tags `git describe` considers |
| 2026-04-08 | Auto-tag-proxy workflow added (`b39e28b6`, `de29ecbd`) — introduces the possibility of `v*` tags appearing on main |
| 2026-04-09 11:02 PDT | First proxy auto-tag fires: `v3.0.0` committed by the auto-tag workflow (`5f87db68`, `[skip auto-tag-proxy]` in the message) |
| 2026-04-09 19:06 PDT | Bug discovered in `velvety-fluttering-ritchie` worktree during a routine `dev_checks.sh` run; initially assumed to be worktree-specific flakiness |
| 2026-04-09 19:56 PDT | Root cause identified: `tag_regex` parses, doesn't filter |
| 2026-04-09 22:45 PDT | Fix shipped (this PR) |

**5 Whys:**
1. Why did it break? → hatch-vcs tried to parse `v3.0.0` with the cli regex `^cli-v(?P<version>...)$`, failed, and errored out.
2. Why did it try `v3.0.0`? → `git describe --tags` was called with no `--match` filter, so it returned the nearest reachable tag — `v3.0.0`, which is newer on `main` than any `cli-v*` tag.
3. Why wasn't `git_describe_command` overridden? → When `tag_regex` was added, it was assumed to act as a filter. It only *parses* an already-selected tag name; the actual filter is `git_describe_command`'s `--match` flag. The naming is misleading — `tag_regex` sounds like tag selection but isn't.
4. Why wasn't the misunderstanding caught in review or CI? → CI runs `uv sync` with `actions/checkout@v4`'s default `fetch-depth: 1`, which clones a single commit *without tags*. With no tags visible, `git describe` falls back silently and hatch-vcs uses a dev version — the failing parse path is never exercised. Release-cli's `fetch-depth: 0` would hit it, but it only fires on `cli-v*` pushes, which resolve directly against a cli tag without climbing the history.
5. Why did a version-resolution config go untested in a realistic environment? → The repo has no CI step that mirrors a contributor's local experience (full clone, tags fetched, `uv sync` from scratch). The dev_checks workflow was designed around unit/integration/type checks, not against environment-setup failure modes. Version resolution is treated as infrastructure that "just works" until it doesn't.

**The Pattern:**

| PR | Date | What went wrong | How discovered |
|----|------|----------------|----------------|
| This PR (#520) | 2026-04-09 | Tag-namespace collision between `cli-v*` and `v*`; hatch-vcs filter misconfigured | Local `dev_checks.sh` in a worktree |
| #497 (one-click Railway) | 2026-04-08 | Adjacent — introduced the auto-tag-proxy workflow that made `v*` tags exist on main | n/a (feature PR) |

New class of bug for this repo: **version-resolution configs silently validated only in unrealistic CI environments**. Not a recurrence of a prior COE.

**Detection gap:**
1. **How discovered:** A contributor (me) ran `./scripts/dev_checks.sh` in a worktree where tags had been fetched for another investigation, saw the hatchling failure, and traced it to `tag_regex` vs. `--match`. If I hadn't explicitly fetched tags in that worktree, I would not have seen it either — it was a side-effect of unrelated investigation.
2. **How it should have been discovered:** CI should run a build of `src/luthien_cli` in a job that mirrors a realistic contributor environment (`fetch-depth: 0`, all tags available). That job would have failed immediately on the first PR after `v3.0.0` landed. Alternative: a test that exercises `Hatch().version.cached` resolution directly.

**What else could break? (Sweep)**

| Search | Files checked | Result |
|--------|--------------|--------|
| Other `tool.hatch.version` / `hatch-vcs` configs in the repo | `find . -name "pyproject.toml"` → `./pyproject.toml`, `./src/luthien_cli/pyproject.toml` | `luthien-proxy`'s root `pyproject.toml` uses `tag_regex = "^v(?P<version>...)$"` which *does* match `v3.0.0`, so it resolves correctly. Only `luthien_cli` has the collision. |
| Other uses of `git describe` in CI workflows | `.github/workflows/*.yml` grep `git describe` | Only used implicitly by hatch-vcs at build time. No direct calls that would collide. |
| Other places that might parse tag names with wrong assumptions | `grep -r "cli-v" .github/` | `auto-tag-cli.yml` uses `git tag -l 'cli-v*'` with an explicit glob — correct. No analogous bug. |
| Any workflow pinning to `fetch-depth: 0` that would have hit this earlier | `.github/workflows/*.yml` grep `fetch-depth` | `auto-tag-proxy.yml` and `release-cli.yml` use `fetch-depth: 0` but don't run `uv sync` against `luthien-cli` in a way that exercises version parsing on the failing path. |

**Class-level analysis:**

Failure class: **"silent degradation in environment-setup paths that CI doesn't mirror."** Specifically — version resolution is one of several environment-setup concerns (dependency resolution, lockfile enforcement, migration application, secret loading) where CI and local environments diverge.

Other instances (not fixed in this PR, logged as action items):
- **Lockfile drift**: `uv sync --locked` in CI vs `uv sync` locally. Covered; CI catches it.
- **Tag-dependent version**: This bug. Fixed here.
- **Untagged / shallow clones**: Unknown whether other build steps silently degrade. Should be audited.

The fix in this PR only addresses the `luthien-cli` config. The broader gap — that no CI job mirrors a full-clone contributor environment — remains and is the real root cause.

**Fixes Applied:**

| Issue | Fix | File |
|-------|-----|------|
| `tag_regex` doesn't filter which tags `git describe` considers | Added `raw-options.git_describe_command` with explicit `--match cli-v*` | `src/luthien_cli/pyproject.toml` |
| No explanation of *why* the filter is needed | Inline comment citing the exact `UserWarning` | `src/luthien_cli/pyproject.toml` |
| No user-visible record of the regression | Added changelog fragment | `changelog.d/fix-cli-hatch-vcs.md` |

**Action items:**

| Action | Owner | Due date | Type |
|--------|-------|----------|------|
| Add a CI job that does a full clone (`fetch-depth: 0`) + `uv build src/luthien_cli` + `uv sync --dev`, to catch version-resolution bugs before they reach contributors | @jai | 2026-04-16 | Detection |
| Audit other environment-setup paths (migrations, secret loading) for the same "CI doesn't mirror reality" failure mode; write up findings in `dev/context/gotchas.md` | @jai | 2026-04-23 | Architectural |
| Document the `tag_regex` vs. `--match` distinction in `src/luthien_cli/CLAUDE.md` so this specific misreading doesn't happen again if the config is ever touched | @jai | 2026-04-16 | Process |

**Completeness gate:**

> "If a similar but slightly different version of this bug appeared tomorrow in an adjacent area, would this fix prevent it?"

**No** — the fix is local to `luthien-cli`'s `pyproject.toml`. If `luthien-proxy`'s root version config were ever misconfigured similarly, or if a new package were added to `src/` with its own version resolution, this fix wouldn't catch it. The **detection action item** (CI job with full clone) is what provides the class-level protection. The local fix is necessary but not sufficient; merging this PR without also landing the CI guard leaves the class open.
