### PR TITLE
test: document DatabasePool in-memory SQLite fixture pattern

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,150 @@
+# Luthien Proxy — Environment Configuration
+# Auto-generated from config field definitions (scripts/generate_env_example.py).
+# Copy to .env and edit as needed.
+
+# === SERVER ======================================================
+
+# Port the gateway listens on
+# GATEWAY_PORT=8000
+
+# Logging level (critical, error, warning, info, debug, trace)
+# (can also be set at runtime via admin API)
+# LOG_LEVEL=info
+
+# Include internal details in client-facing error responses
+# (can also be set at runtime via admin API)
+# VERBOSE_CLIENT_ERRORS=false
+
+
+# === AUTH ========================================================
+
+# API key clients must provide for proxy_key auth mode
+# (sensitive)
+# PROXY_API_KEY=
+
+# API key for admin endpoints
+# (sensitive)
+# ADMIN_API_KEY=
+
+# Authentication mode: proxy_key, passthrough, or both (managed via /api/admin/auth/config)
+# AUTH_MODE=AuthMode.BOTH
+
+# Skip authentication for requests from localhost
+# (can also be set at runtime via admin API)
+# LOCALHOST_AUTH_BYPASS=true
+
+
+# === POLICY ======================================================
+
+# Policy loading strategy: db, file, db-fallback-file, file-fallback-db
+# POLICY_SOURCE=db-fallback-file
+
+# Path to policy YAML file
+# POLICY_CONFIG=
+
+# Inject active policy names into the system message
+# (can also be set at runtime via admin API)
+# INJECT_POLICY_CONTEXT=true
+
+# Auto-compose DogfoodSafetyPolicy to prevent agents from killing the proxy
+# (can also be set at runtime via admin API)
+# DOGFOOD_MODE=false
+
+
+# === DATABASE ====================================================
+
+# Database connection URL (sqlite:/// or postgres://)
+# (sensitive)
+# DATABASE_URL=
+
+# Redis connection URL (optional; enables multi-instance pub/sub) — may contain credentials
+# (sensitive)
+# REDIS_URL=
+
+# Override path to migrations directory
+# MIGRATIONS_DIR=
+
+
+# === LLM =========================================================
+
+# Server-side Anthropic API key (optional; enables server-credential mode)
+# (sensitive)
+# ANTHROPIC_API_KEY=
+
+# LiteLLM master key for multi-tenant deployments
+# (sensitive)
+# LITELLM_MASTER_KEY=
+
+# Model ID for the LLM judge policy
+# LLM_JUDGE_MODEL=
+
+# Custom API base URL for the judge model
+# LLM_JUDGE_API_BASE=
+
+# API key for the judge model
+# (sensitive)
+# LLM_JUDGE_API_KEY=
+
+# Max number of cached Anthropic client instances for passthrough auth
+# ANTHROPIC_CLIENT_CACHE_SIZE=16
+
+
+# === SECURITY ====================================================
+
+# Fernet key for encrypting server credentials at rest
+# (sensitive)
+# CREDENTIAL_ENCRYPTION_KEY=
+
+
+# === OBSERVABILITY ===============================================
+
+# Enable OpenTelemetry distributed tracing
+# OTEL_ENABLED=false
+
+# OTLP exporter endpoint for traces
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
+
+# Tempo HTTP API URL for trace queries
+# TEMPO_URL=http://localhost:3200
+
+# Service name for distributed tracing
+# SERVICE_NAME=luthien-proxy
+
+# Service version for distributed tracing (derived from package metadata)
+# (default derived from PROXY_VERSION at startup)
+# SERVICE_VERSION=
+
+# Environment name (development, staging, production)
+# ENVIRONMENT=development
+
+# Railway service name (auto-sets environment if present)
+# RAILWAY_SERVICE_NAME=
+
+# Log full HTTP request and response bodies
+# ENABLE_REQUEST_LOGGING=false
+
+
+# === TELEMETRY ===================================================
+
+# Anonymous usage telemetry (None defers to DB config, True/False overrides)
+# (can also be set at runtime via admin API)
+# USAGE_TELEMETRY=
+
+# Endpoint for anonymous usage metrics
+# TELEMETRY_ENDPOINT=https://telemetry.luthien.cc/v1/events
+
+
+# === SENTRY ======================================================
+
+# Enable Sentry error tracking
+# SENTRY_ENABLED=false
+
+# Sentry project DSN
+# (sensitive)
+# SENTRY_DSN=
+
+# Sentry traces sampling rate (0.0 to 1.0)
+# SENTRY_TRACES_SAMPLE_RATE=0.0
+
+# Sentry server identifier
+# SENTRY_SERVER_NAME=

--- a/changelog.d/database-pool-test-construction.md
+++ b/changelog.d/database-pool-test-construction.md
@@ -1,0 +1,5 @@
+---
+category: Chores & Docs
+---
+
+**DatabasePool test construction idiom**: Documented the canonical pattern for tests that need an in-memory SQLite `DatabasePool` with pre-populated schema (construct via the public constructor, prime with `get_pool()`, seed schema on the returned pool). Added a regression test in `tests/luthien_proxy/unit_tests/utils/test_db.py` that pins the pattern so downstream tests don't reach for `DatabasePool.__new__(...)` + private-attribute pokes.

--- a/src/luthien_proxy/utils/db.py
+++ b/src/luthien_proxy/utils/db.py
@@ -89,7 +89,24 @@ class DatabasePool:
         factory: PoolFactory | None = None,
         **pool_kwargs: object,
     ) -> None:
-        """Initialize the database connection pool."""
+        """Initialize the database connection pool.
+
+        Tests that need an in-memory SQLite DatabasePool with schema set up
+        ahead of time should construct it directly and prime the cached pool
+        via the public API:
+
+            db = DatabasePool("sqlite://:memory:")
+            pool = await db.get_pool()
+            await pool.execute("CREATE TABLE ...")
+
+        The returned `db` can then be passed anywhere a `DatabasePool` is
+        expected — subsequent `get_pool()` calls return the same cached pool,
+        so schema set up above is visible to later callers. This avoids the
+        temptation to `DatabasePool.__new__(...)` and poke private attributes,
+        which silently breaks when the initializer grows new required fields.
+        See `tests/luthien_proxy/unit_tests/utils/test_db.py::
+        test_database_pool_in_memory_sqlite_fixture_pattern` for the idiom.
+        """
         if not url:
             raise RuntimeError("Database URL must be provided")
         self._url = url

--- a/tests/luthien_proxy/unit_tests/utils/test_db.py
+++ b/tests/luthien_proxy/unit_tests/utils/test_db.py
@@ -79,6 +79,47 @@ async def test_database_pool_connection_context():
 
 
 @pytest.mark.asyncio
+async def test_database_pool_in_memory_sqlite_fixture_pattern():
+    """Canonical pattern for tests that need a DatabasePool with pre-populated schema.
+
+    This exists as the documented replacement for the `DatabasePool.__new__(...)
+    + private-attribute poke` hack. Tests that previously constructed a
+    `SqlitePool` directly and wrapped it should use this pattern instead:
+
+      1. Construct a DatabasePool via its public constructor.
+      2. Prime it once via `get_pool()` and do schema/fixture setup on the
+         returned pool.
+      3. Pass the DatabasePool anywhere a real one is expected — `get_pool()`
+         returns the same cached instance, so schema set up in step 2 is
+         visible throughout.
+
+    If this test ever breaks because `DatabasePool.__init__` grows a new
+    required field, that's the signal for downstream tests: they need to
+    update along with it — there is no hidden bypass.
+    """
+    pool = db.DatabasePool("sqlite://:memory:")
+    try:
+        backing_pool = await pool.get_pool()
+        await backing_pool.execute("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)")
+        await backing_pool.execute("INSERT INTO widgets (id, name) VALUES ($1, $2)", 1, "sprocket")
+
+        # Subsequent get_pool() calls return the same cached instance so the
+        # schema and rows seeded above are visible.
+        again = await pool.get_pool()
+        assert again is backing_pool
+
+        # Reading through the public `connection()` context manager sees the
+        # seeded row, proving downstream consumers don't need any back-door
+        # access to the underlying SqlitePool.
+        async with pool.connection() as conn:
+            row = await conn.fetchrow("SELECT name FROM widgets WHERE id = $1", 1)
+        assert row is not None
+        assert row["name"] == "sprocket"
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
 async def test_database_pool_close_resets():
     pools = [DummyPool(name="first"), DummyPool(name="second")]
 


### PR DESCRIPTION
## Summary

Tests that need a `DatabasePool` with pre-populated schema should construct it via the public constructor and prime it with `get_pool()` — not via `DatabasePool.__new__(...)` + private-attribute pokes, which silently break when `__init__` grows new required fields.

This was flagged as review item #10 on #521 (policy cache infra), where `tests/.../test_policy_cache.py` used the `__new__` hack. This PR lands the clean idiom on `main` so #521 can adopt it on rebase and future test authors have an obvious, discoverable pattern.

## Design rationale

I considered adding a `DatabasePool.from_sqlite_pool(pool)` classmethod (the first option from the Trello card). After a devil's-advocate pass, the simpler option won:

- `DatabasePool(\"sqlite://:memory:\")` + `await db.get_pool()` already caches the SqlitePool, so schema set up in the fixture is visible to all downstream callers — no wrapping needed.
- Adding `from_sqlite_pool` would still have required poking `wrapper._sqlite_pool = pool`, just moved inside the class. That's a rename of the hack, not encapsulation.
- The classmethod would have permanently added API surface specifically to accommodate a test-fixture structure that was wrong in the first place. `SqlitePool` would have leaked into the public interface of `DatabasePool`.
- If `__init__` ever grows new required fields, the documented pattern picks them up automatically (it uses the real constructor); the classmethod would silently skip any field whose value depends on the wrapped pool.

## Changes

- `src/luthien_proxy/utils/db.py` — docstring on `DatabasePool.__init__` documenting the in-memory SQLite test idiom and pointing at the pinned regression test.
- `tests/luthien_proxy/unit_tests/utils/test_db.py` — new `test_database_pool_in_memory_sqlite_fixture_pattern` that pins the pattern end-to-end (construct → prime → seed schema → share through `connection()` context manager). If `__init__` grows a new required field, this test breaks first, giving a clear signal to update downstream tests.
- `changelog.d/database-pool-test-construction.md` — changelog fragment under \"Chores & Docs\".
- `.env.example` — regenerated from `config_fields.py`. **This is pre-existing drift on `main`** (the file was empty on HEAD but `scripts/generate_env_example.py` produces 150 lines). `dev_checks.sh` and CI both gate on a clean tree post-regen, so this PR couldn't pass checks without including it. Unrelated to the core concern but unavoidable — flagging for visibility. A separate follow-up should figure out which recent merge dropped the generated content.

## Test plan

- [x] `uv run pytest tests/luthien_proxy/unit_tests/utils/test_db.py` — 5 passing
- [x] `uv run pytest tests/luthien_proxy/unit_tests/utils/` — 77 passing
- [x] `./scripts/dev_checks.sh` — format, lint, pyright, full unit suite clean
- [ ] CI green

## Follow-ups for #521 / #522

When PR #521 rebases onto this, the fix in `tests/.../test_policy_cache.py` is:

\`\`\`python
@pytest.fixture
async def db_pool():
    pool = DatabasePool(\"sqlite://:memory:\")
    backing = await pool.get_pool()
    await backing.execute(\"CREATE TABLE IF NOT EXISTS policy_cache (...)\")
    yield pool
    await pool.close()

@pytest.fixture
def cache(db_pool: DatabasePool):
    return PolicyCache(db_pool, \"test_policy\")
\`\`\`

No `__new__` hack, no `_wrap_sqlite_pool` helper, no private-attribute pokes. PR #522 should adopt the same pattern if it carries a similar hack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)