### PR TITLE
fix: restore .env.example and add drift regression test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,150 @@
+# Luthien Proxy — Environment Configuration
+# Auto-generated from config field definitions (scripts/generate_env_example.py).
+# Copy to .env and edit as needed.
+
+# === SERVER ======================================================
+
+# Port the gateway listens on
+# GATEWAY_PORT=8000
+
+# Logging level (critical, error, warning, info, debug, trace)
+# (can also be set at runtime via admin API)
+# LOG_LEVEL=info
+
+# Include internal details in client-facing error responses
+# (can also be set at runtime via admin API)
+# VERBOSE_CLIENT_ERRORS=false
+
+
+# === AUTH ========================================================
+
+# API key clients must provide for proxy_key auth mode
+# (sensitive)
+# PROXY_API_KEY=
+
+# API key for admin endpoints
+# (sensitive)
+# ADMIN_API_KEY=
+
+# Authentication mode: proxy_key, passthrough, or both (managed via /api/admin/auth/config)
+# AUTH_MODE=AuthMode.BOTH
+
+# Skip authentication for requests from localhost
+# (can also be set at runtime via admin API)
+# LOCALHOST_AUTH_BYPASS=true
+
+
+# === POLICY ======================================================
+
+# Policy loading strategy: db, file, db-fallback-file, file-fallback-db
+# POLICY_SOURCE=db-fallback-file
+
+# Path to policy YAML file
+# POLICY_CONFIG=
+
+# Inject active policy names into the system message
+# (can also be set at runtime via admin API)
+# INJECT_POLICY_CONTEXT=true
+
+# Auto-compose DogfoodSafetyPolicy to prevent agents from killing the proxy
+# (can also be set at runtime via admin API)
+# DOGFOOD_MODE=false
+
+
+# === DATABASE ====================================================
+
+# Database connection URL (sqlite:/// or postgres://)
+# (sensitive)
+# DATABASE_URL=
+
+# Redis connection URL (optional; enables multi-instance pub/sub) — may contain credentials
+# (sensitive)
+# REDIS_URL=
+
+# Override path to migrations directory
+# MIGRATIONS_DIR=
+
+
+# === LLM =========================================================
+
+# Server-side Anthropic API key (optional; enables server-credential mode)
+# (sensitive)
+# ANTHROPIC_API_KEY=
+
+# LiteLLM master key for multi-tenant deployments
+# (sensitive)
+# LITELLM_MASTER_KEY=
+
+# Model ID for the LLM judge policy
+# LLM_JUDGE_MODEL=
+
+# Custom API base URL for the judge model
+# LLM_JUDGE_API_BASE=
+
+# API key for the judge model
+# (sensitive)
+# LLM_JUDGE_API_KEY=
+
+# Max number of cached Anthropic client instances for passthrough auth
+# ANTHROPIC_CLIENT_CACHE_SIZE=16
+
+
+# === SECURITY ====================================================
+
+# Fernet key for encrypting server credentials at rest
+# (sensitive)
+# CREDENTIAL_ENCRYPTION_KEY=
+
+
+# === OBSERVABILITY ===============================================
+
+# Enable OpenTelemetry distributed tracing
+# OTEL_ENABLED=false
+
+# OTLP exporter endpoint for traces
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
+
+# Tempo HTTP API URL for trace queries
+# TEMPO_URL=http://localhost:3200
+
+# Service name for distributed tracing
+# SERVICE_NAME=luthien-proxy
+
+# Service version for distributed tracing (derived from package metadata)
+# (default derived from PROXY_VERSION at startup)
+# SERVICE_VERSION=
+
+# Environment name (development, staging, production)
+# ENVIRONMENT=development
+
+# Railway service name (auto-sets environment if present)
+# RAILWAY_SERVICE_NAME=
+
+# Log full HTTP request and response bodies
+# ENABLE_REQUEST_LOGGING=false
+
+
+# === TELEMETRY ===================================================
+
+# Anonymous usage telemetry (None defers to DB config, True/False overrides)
+# (can also be set at runtime via admin API)
+# USAGE_TELEMETRY=
+
+# Endpoint for anonymous usage metrics
+# TELEMETRY_ENDPOINT=https://telemetry.luthien.cc/v1/events
+
+
+# === SENTRY ======================================================
+
+# Enable Sentry error tracking
+# SENTRY_ENABLED=false
+
+# Sentry project DSN
+# (sensitive)
+# SENTRY_DSN=
+
+# Sentry traces sampling rate (0.0 to 1.0)
+# SENTRY_TRACES_SAMPLE_RATE=0.0
+
+# Sentry server identifier
+# SENTRY_SERVER_NAME=

--- a/changelog.d/fix-service-version-env-example-drift.md
+++ b/changelog.d/fix-service-version-env-example-drift.md
@@ -1,5 +1,6 @@
 ---
 category: Fixes
+pr: 527
 ---
 
 **Restore `.env.example` and add regression guard**: The file was accidentally wiped to zero lines in PR #519 (commit `1b28e4d5`), leaving main's CI dev_checks job red because the clean-tree gate caught the generator producing 150 lines of output on every run. Regenerated the committed copy from `scripts/generate_env_example.py` and added a unit test (`test_env_example_matches_generator`) that asserts the committed file matches the generator's output. This test runs in the fast unit tier and also guards against the original "hardcoded SERVICE_VERSION=2.0.0" class of bug — any config field whose committed default drifts from `config_fields.py` will now be caught before CI.

--- a/changelog.d/fix-service-version-env-example-drift.md
+++ b/changelog.d/fix-service-version-env-example-drift.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**Restore `.env.example` and add regression guard**: The file was accidentally wiped to zero lines in PR #519 (commit `1b28e4d5`), leaving main's CI dev_checks job red because the clean-tree gate caught the generator producing 150 lines of output on every run. Regenerated the committed copy from `scripts/generate_env_example.py` and added a unit test (`test_env_example_matches_generator`) that asserts the committed file matches the generator's output. This test runs in the fast unit tier and also guards against the original "hardcoded SERVICE_VERSION=2.0.0" class of bug — any config field whose committed default drifts from `config_fields.py` will now be caught before CI.

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -8,8 +8,9 @@ Usage:
 import sys
 from pathlib import Path
 
-# Add src to path so we can import config_fields when run as a script.
-# When imported as a module (from tests), the package is already installed.
+# Add src to path so we can import config_fields when run as a script
+# (the insert is harmless when imported from tests because the installed
+# package is already on sys.path — we just end up with an extra entry).
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from luthien_proxy.config_fields import CONFIG_CATEGORIES, CONFIG_FIELDS

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -8,13 +8,19 @@ Usage:
 import sys
 from pathlib import Path
 
-# Add src to path so we can import config_fields
+# Add src to path so we can import config_fields when run as a script.
+# When imported as a module (from tests), the package is already installed.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from luthien_proxy.config_fields import CONFIG_CATEGORIES, CONFIG_FIELDS
 
 
-def main() -> None:
+def build_env_example_text() -> str:
+    """Return the full generated .env.example text.
+
+    Exposed separately from `main()` so tests and other tooling can compare
+    against the canonical output without spawning a subprocess.
+    """
     lines = [
         "# Luthien Proxy — Environment Configuration",
         "# Auto-generated from config field definitions (scripts/generate_env_example.py).",
@@ -61,8 +67,11 @@ def main() -> None:
                 lines.append(f"# {meta.env_var}={default_str}")
             lines.append("")
 
-    output = "\n".join(lines)
-    print(output, end="")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    print(build_env_example_text(), end="")
 
 
 if __name__ == "__main__":

--- a/tests/luthien_proxy/unit_tests/test_config_registry.py
+++ b/tests/luthien_proxy/unit_tests/test_config_registry.py
@@ -449,41 +449,20 @@ class TestConfigFieldsCompleteness:
     def test_env_example_matches_generator(self):
         """The .env.example about to land in a commit must match the generator.
 
-        Regression guard for PR #519: commit 1b28e4d5 accidentally wiped
-        .env.example (150 lines -> 0), which broke CI clean-tree checks on main
-        until it was spotted. The dev_checks.sh clean-tree check catches drift
-        at pipeline end; this test adds a fast pytest-level guard and also
-        catches the original "hardcoded SERVICE_VERSION=2.0.0" class of bug:
-        any config field whose default drifts from config_fields.py fails here.
+        Regression guard for PR #519 (commit 1b28e4d5 accidentally wiped
+        .env.example from 150 lines to 0, turning main CI red). Also catches
+        the original "hardcoded SERVICE_VERSION=2.0.0" class of bug: any
+        ConfigFieldMeta default that drifts from the committed .env.example
+        fails this test.
 
-        Reads from the git index (`git show :.env.example`), NOT the working
-        tree, for several reasons:
-
-        - In CI and on a clean checkout, the index mirrors HEAD — the
-          committed state we want to validate.
-        - In dev_checks.sh, the pipeline regenerates .env.example into the
-          working tree BEFORE the auto-stage step (which only stages files
-          dirtied by `ruff format`/`ruff check --fix`). So the index is not
-          updated and still reflects the committed state — a stale committed
-          copy fails this test earlier than the end-of-pipeline clean-tree
-          gate, giving the developer faster feedback.
-        - In a pre-commit TDD workflow (dev edits config_fields.py,
-          regenerates, stages, runs pytest), the index shows the staged
-          version, avoiding a false-positive from comparing against stale HEAD.
-        - Reading the raw working tree would miss the dev_checks.sh case
-          because `dev_checks.sh` rewrites the working tree before pytest
-          runs, making the comparison tautological.
-
-        Note: reading the index isolates unstaged edits to `.env.example`
-        itself, but NOT unstaged edits to `config_fields.py` — the generator
-        imports the live module, so an unstaged config edit will still
-        propagate through and the test will compare generator(working-tree
-        config) vs index(.env.example). That's intentional: `config_fields.py`
-        is the input under test.
-
-        The generator intentionally omits dynamic_default values (like
-        SERVICE_VERSION resolved from PROXY_VERSION) so its output is stable
-        across build environments.
+        Reads from the git index (`git show :.env.example`), not the working
+        tree, so that (a) dev_checks.sh regenerating the working tree before
+        pytest doesn't make the comparison tautological, (b) pre-commit TDD
+        workflows don't false-positive against a stale HEAD, and (c) unstaged
+        .env.example edits don't pollute the check. Unstaged config_fields.py
+        edits DO propagate (intentionally — that module is the input under
+        test). The generator skips dynamic_default fields like SERVICE_VERSION
+        so its output is stable across build environments.
         """
         repo_root = Path(__file__).resolve().parents[3]
         generator_path = repo_root / "scripts" / "generate_env_example.py"
@@ -498,23 +477,19 @@ class TestConfigFieldsCompleteness:
         spec.loader.exec_module(generator)
         expected = generator.build_env_example_text()
 
-        # Read from the git index (`git show :path`), NOT the working tree.
-        # For tracked unmodified files the index mirrors HEAD, so in CI and
-        # clean checkouts this equals the committed state — the thing we want
-        # to validate. For a dev mid-commit who has staged a regenerated copy,
-        # it equals what's about to land. For a dev with unstaged working-tree
-        # edits to .env.example, the index still reflects the last staged
-        # state, so uncommitted WIP doesn't false-positive or false-negative
-        # the test. This sidesteps the dev_checks.sh trap: dev_checks
-        # regenerates the working tree then auto-stages it before pytest runs,
-        # so the index is exactly the state that will be committed.
-        result = subprocess.run(
-            ["git", "show", ":.env.example"],
-            capture_output=True,
-            text=True,
-            cwd=repo_root,
-            check=True,
-        )
+        # See docstring for why we read the index instead of the working tree.
+        try:
+            result = subprocess.run(
+                ["git", "show", ":.env.example"],
+                capture_output=True,
+                text=True,
+                cwd=repo_root,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            pytest.fail(
+                f".env.example is not in the git index (cwd={repo_root}). git stderr: {exc.stderr.strip() or '<empty>'}"
+            )
         actual = result.stdout
 
         if actual != expected:

--- a/tests/luthien_proxy/unit_tests/test_config_registry.py
+++ b/tests/luthien_proxy/unit_tests/test_config_registry.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import difflib
 import importlib.util
+import subprocess
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -449,12 +451,18 @@ class TestConfigFieldsCompleteness:
 
         Regression guard for PR #519: commit 1b28e4d5 accidentally wiped
         .env.example (150 lines -> 0), which broke CI clean-tree checks on main
-        until it was spotted. The dev_checks.sh clean-tree check catches drift,
-        but only after running the full pipeline. This test gives fast pytest-level
-        feedback (runs in unit test tier) and also catches the case where a
-        config field change doesn't make it into the committed .env.example —
-        e.g. the original "hardcoded SERVICE_VERSION=2.0.0" scenario this ticket
-        was opened to prevent.
+        until it was spotted. The dev_checks.sh clean-tree check catches drift
+        at pipeline end. This test adds a fast pytest-level guard and also
+        catches the original "hardcoded SERVICE_VERSION=2.0.0" class of bug:
+        any config field whose committed default drifts from config_fields.py
+        fails this test.
+
+        Critical detail: we read the committed copy via `git show HEAD:.env.example`
+        rather than the on-disk file. dev_checks.sh regenerates the on-disk
+        .env.example *before* running pytest, so reading the working tree would
+        always see the generator's current output and the test would trivially
+        pass in CI. Reading from git HEAD catches drift even when dev_checks
+        has already rewritten the working file.
 
         The generator intentionally omits dynamic_default values (like
         SERVICE_VERSION resolved from PROXY_VERSION) so its output is stable
@@ -462,22 +470,41 @@ class TestConfigFieldsCompleteness:
         """
         repo_root = Path(__file__).resolve().parents[3]
         generator_path = repo_root / "scripts" / "generate_env_example.py"
-        env_example = repo_root / ".env.example"
 
         assert generator_path.exists(), f"Generator missing at {generator_path}"
-        assert env_example.exists(), f".env.example missing at {env_example}"
 
-        # Load the script as a module without running it as a subprocess —
-        # faster and produces real tracebacks on failure.
+        # Load the script as a module to call build_env_example_text() in-process.
+        # Faster than shelling out and produces real tracebacks on generator errors.
         spec = importlib.util.spec_from_file_location("_generate_env_example", generator_path)
         assert spec is not None and spec.loader is not None
         generator = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(generator)
-
         expected = generator.build_env_example_text()
-        actual = env_example.read_text()
 
-        assert actual == expected, (
-            ".env.example is out of sync with scripts/generate_env_example.py. "
-            "Run: uv run python scripts/generate_env_example.py > .env.example"
+        # Read the committed copy from git HEAD — NOT from the working tree —
+        # so the test catches drift even after dev_checks.sh has regenerated
+        # the on-disk file. See class docstring for why.
+        result = subprocess.run(
+            ["git", "show", "HEAD:.env.example"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            check=True,
         )
+        actual = result.stdout
+
+        if actual != expected:
+            diff = "\n".join(
+                difflib.unified_diff(
+                    expected.splitlines(),
+                    actual.splitlines(),
+                    fromfile="expected (generator output)",
+                    tofile="actual (committed .env.example)",
+                    lineterm="",
+                )
+            )
+            pytest.fail(
+                "Committed .env.example is out of sync with scripts/generate_env_example.py.\n"
+                "Run: uv run python scripts/generate_env_example.py > .env.example && git add .env.example\n\n"
+                f"{diff}"
+            )

--- a/tests/luthien_proxy/unit_tests/test_config_registry.py
+++ b/tests/luthien_proxy/unit_tests/test_config_registry.py
@@ -447,22 +447,30 @@ class TestConfigFieldsCompleteness:
         )
 
     def test_env_example_matches_generator(self):
-        """Committed .env.example must match scripts/generate_env_example.py output.
+        """The .env.example about to land in a commit must match the generator.
 
         Regression guard for PR #519: commit 1b28e4d5 accidentally wiped
         .env.example (150 lines -> 0), which broke CI clean-tree checks on main
         until it was spotted. The dev_checks.sh clean-tree check catches drift
-        at pipeline end. This test adds a fast pytest-level guard and also
+        at pipeline end; this test adds a fast pytest-level guard and also
         catches the original "hardcoded SERVICE_VERSION=2.0.0" class of bug:
-        any config field whose committed default drifts from config_fields.py
-        fails this test.
+        any config field whose default drifts from config_fields.py fails here.
 
-        Critical detail: we read the committed copy via `git show HEAD:.env.example`
-        rather than the on-disk file. dev_checks.sh regenerates the on-disk
-        .env.example *before* running pytest, so reading the working tree would
-        always see the generator's current output and the test would trivially
-        pass in CI. Reading from git HEAD catches drift even when dev_checks
-        has already rewritten the working file.
+        Reads from the git index (`git show :.env.example`), NOT the working
+        tree, for several reasons:
+
+        - In CI and on a clean checkout, the index mirrors HEAD — the
+          committed state we want to validate.
+        - In dev_checks.sh, the pipeline regenerates .env.example into the
+          working tree and auto-stages it before pytest runs, so the index
+          reflects exactly what's about to be committed.
+        - In a pre-commit TDD workflow (dev edits config_fields.py,
+          regenerates, stages, runs pytest), the index shows the staged
+          version, avoiding a false-positive from comparing against stale HEAD.
+        - Reading the raw working tree would miss the dev_checks.sh case
+          (working tree gets rewritten before pytest runs, so the comparison
+          becomes tautological) and would false-positive on WIP edits the
+          developer hasn't staged yet.
 
         The generator intentionally omits dynamic_default values (like
         SERVICE_VERSION resolved from PROXY_VERSION) so its output is stable
@@ -481,11 +489,18 @@ class TestConfigFieldsCompleteness:
         spec.loader.exec_module(generator)
         expected = generator.build_env_example_text()
 
-        # Read the committed copy from git HEAD — NOT from the working tree —
-        # so the test catches drift even after dev_checks.sh has regenerated
-        # the on-disk file. See class docstring for why.
+        # Read from the git index (`git show :path`), NOT the working tree.
+        # For tracked unmodified files the index mirrors HEAD, so in CI and
+        # clean checkouts this equals the committed state — the thing we want
+        # to validate. For a dev mid-commit who has staged a regenerated copy,
+        # it equals what's about to land. For a dev with unstaged working-tree
+        # edits to .env.example, the index still reflects the last staged
+        # state, so uncommitted WIP doesn't false-positive or false-negative
+        # the test. This sidesteps the dev_checks.sh trap: dev_checks
+        # regenerates the working tree then auto-stages it before pytest runs,
+        # so the index is exactly the state that will be committed.
         result = subprocess.run(
-            ["git", "show", "HEAD:.env.example"],
+            ["git", "show", ":.env.example"],
             capture_output=True,
             text=True,
             cwd=repo_root,
@@ -499,12 +514,14 @@ class TestConfigFieldsCompleteness:
                     expected.splitlines(),
                     actual.splitlines(),
                     fromfile="expected (generator output)",
-                    tofile="actual (committed .env.example)",
+                    tofile="actual (git index)",
                     lineterm="",
                 )
             )
             pytest.fail(
-                "Committed .env.example is out of sync with scripts/generate_env_example.py.\n"
-                "Run: uv run python scripts/generate_env_example.py > .env.example && git add .env.example\n\n"
+                "Staged/committed .env.example is out of sync with "
+                "scripts/generate_env_example.py.\n"
+                "Run: uv run python scripts/generate_env_example.py > .env.example "
+                "&& git add .env.example\n\n"
                 f"{diff}"
             )

--- a/tests/luthien_proxy/unit_tests/test_config_registry.py
+++ b/tests/luthien_proxy/unit_tests/test_config_registry.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -440,4 +443,42 @@ class TestConfigFieldsCompleteness:
         env_vars = [f.env_var for f in CONFIG_FIELDS]
         assert len(env_vars) == len(set(env_vars)), (
             f"Duplicate env vars: {[v for v in env_vars if env_vars.count(v) > 1]}"
+        )
+
+    def test_env_example_matches_generator(self):
+        """Committed .env.example must match scripts/generate_env_example.py output.
+
+        Regression guard for PR #519: commit 1b28e4d5 accidentally wiped
+        .env.example (150 lines -> 0), which broke CI clean-tree checks on main
+        until it was spotted. The dev_checks.sh clean-tree check catches drift,
+        but only after running the full pipeline. This test gives fast pytest-level
+        feedback (runs in unit test tier) and also catches the case where a
+        config field change doesn't make it into the committed .env.example —
+        e.g. the original "hardcoded SERVICE_VERSION=2.0.0" scenario this ticket
+        was opened to prevent.
+
+        The generator intentionally omits dynamic_default values (like
+        SERVICE_VERSION resolved from PROXY_VERSION) so its output is stable
+        across build environments.
+        """
+        repo_root = Path(__file__).resolve().parents[3]
+        generator = repo_root / "scripts" / "generate_env_example.py"
+        env_example = repo_root / ".env.example"
+
+        assert generator.exists(), f"Generator missing at {generator}"
+        assert env_example.exists(), f".env.example missing at {env_example}"
+
+        result = subprocess.run(
+            [sys.executable, str(generator)],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            check=True,
+        )
+        expected = result.stdout
+        actual = env_example.read_text()
+
+        assert actual == expected, (
+            ".env.example is out of sync with scripts/generate_env_example.py. "
+            "Run: uv run python scripts/generate_env_example.py > .env.example"
         )

--- a/tests/luthien_proxy/unit_tests/test_config_registry.py
+++ b/tests/luthien_proxy/unit_tests/test_config_registry.py
@@ -462,15 +462,24 @@ class TestConfigFieldsCompleteness:
         - In CI and on a clean checkout, the index mirrors HEAD — the
           committed state we want to validate.
         - In dev_checks.sh, the pipeline regenerates .env.example into the
-          working tree and auto-stages it before pytest runs, so the index
-          reflects exactly what's about to be committed.
+          working tree BEFORE the auto-stage step (which only stages files
+          dirtied by `ruff format`/`ruff check --fix`). So the index is not
+          updated and still reflects the committed state — a stale committed
+          copy fails this test earlier than the end-of-pipeline clean-tree
+          gate, giving the developer faster feedback.
         - In a pre-commit TDD workflow (dev edits config_fields.py,
           regenerates, stages, runs pytest), the index shows the staged
           version, avoiding a false-positive from comparing against stale HEAD.
         - Reading the raw working tree would miss the dev_checks.sh case
-          (working tree gets rewritten before pytest runs, so the comparison
-          becomes tautological) and would false-positive on WIP edits the
-          developer hasn't staged yet.
+          because `dev_checks.sh` rewrites the working tree before pytest
+          runs, making the comparison tautological.
+
+        Note: reading the index isolates unstaged edits to `.env.example`
+        itself, but NOT unstaged edits to `config_fields.py` — the generator
+        imports the live module, so an unstaged config edit will still
+        propagate through and the test will compare generator(working-tree
+        config) vs index(.env.example). That's intentional: `config_fields.py`
+        is the input under test.
 
         The generator intentionally omits dynamic_default values (like
         SERVICE_VERSION resolved from PROXY_VERSION) so its output is stable

--- a/tests/luthien_proxy/unit_tests/test_config_registry.py
+++ b/tests/luthien_proxy/unit_tests/test_config_registry.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import subprocess
-import sys
+import importlib.util
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -462,20 +461,20 @@ class TestConfigFieldsCompleteness:
         across build environments.
         """
         repo_root = Path(__file__).resolve().parents[3]
-        generator = repo_root / "scripts" / "generate_env_example.py"
+        generator_path = repo_root / "scripts" / "generate_env_example.py"
         env_example = repo_root / ".env.example"
 
-        assert generator.exists(), f"Generator missing at {generator}"
+        assert generator_path.exists(), f"Generator missing at {generator_path}"
         assert env_example.exists(), f".env.example missing at {env_example}"
 
-        result = subprocess.run(
-            [sys.executable, str(generator)],
-            capture_output=True,
-            text=True,
-            cwd=repo_root,
-            check=True,
-        )
-        expected = result.stdout
+        # Load the script as a module without running it as a subprocess —
+        # faster and produces real tracebacks on failure.
+        spec = importlib.util.spec_from_file_location("_generate_env_example", generator_path)
+        assert spec is not None and spec.loader is not None
+        generator = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(generator)
+
+        expected = generator.build_env_example_text()
         actual = env_example.read_text()
 
         assert actual == expected, (


### PR DESCRIPTION
## Summary

- Restore `.env.example` to the generator's output (was accidentally wiped to 0 lines in PR #519, commit `1b28e4d5`)
- Add `test_env_example_matches_generator` — a fast pytest-level guard that diffs the committed `.env.example` against `scripts/generate_env_example.py` output
- Closes Trello card [69d89705 "Fix stale SERVICE_VERSION default"](https://trello.com/c/LqYVqdkP) — the literal "hardcoded 2.0.0" concern was already fixed in `04870adf`/`3c79bc0b`; this PR adds the regression guard that would have caught it and fixes the closely-related drift bug on main

## Why

Main CI has been **red on every push** since PR #519 merged at `2026-04-10T07:12:41Z`. That PR's commit message ("fix: propagate CLI overrides to env so startup fields honor them") didn't mention `.env.example`, yet the diff deleted 150 lines from it (0 added). The dev_checks.sh clean-tree gate catches the drift every run, but only after the full pipeline completes.

Repro on main: `./scripts/dev_checks.sh` → passes every phase, then fails at `== Clean tree check (post) ==` with 150 lines of `.env.example` drift.

## Correction of Errors (COE)

### What happened
PR #519 ("propagate CLI overrides to env") landed a commit that deleted the entire `.env.example` content as a side effect, with no mention in the commit message. CI ran and reported `FAILURE` on `dev-checks` 20 seconds *after* the merge. Main has been red ever since — every subsequent push has shown the same drift failure in CI.

### Root cause
Two contributing failures, in order of leverage:

1. **Primary:** `main` has no branch protection. `gh api repos/LuthienResearch/luthien-proxy/branches/main/protection` returns 404 "Branch not protected". There is no required status check, so a PR can be merged while its CI is still pending — which is exactly what happened here. PR #519 merged at 07:12:41Z; dev-checks completed (FAILURE) at 07:13:01Z.
2. **Secondary:** The drift detection in `dev_checks.sh` runs at the very end of the pipeline (the clean-tree gate after lint/type/test). A developer running `dev_checks.sh` locally and hitting the late failure has no fast signal — they may mistake the regenerated file for cruft and `git commit -a` the wrong state. There was also no pytest-level assertion catching drift, so `uv run pytest` alone could not detect the problem.

### Systemic fix in this PR
- **Regression test** (`test_env_example_matches_generator`): runs in the fast unit tier (<1s), produces a direct "run this command" error on drift. This lifts the detection earlier in the pipeline and makes it visible to anyone running pytest — not just those running the full `dev_checks.sh`. It also forward-protects against the original "hardcoded SERVICE_VERSION=2.0.0" class of bug the Trello ticket described: any config field whose committed default drifts from `config_fields.py` will now fail unit tests.

### Follow-up (separate card, separate PR)
- [Trello: Enable branch protection on main (required Dev Checks)](https://trello.com/c/5S2GLjPT) — the real leverage fix. Until this lands, a sufficiently confident developer can still merge a PR with red CI and break main the same way. Per repo convention (one PR = one concern), branch protection is out of scope here.

### Honest scoping note
Trello card 69d89705's literal description asked for deriving `service_version` from `PROXY_VERSION` and removing the hardcoded value from `.env.example`. Both were already done on main before this PR started (commits `04870adf` and `3c79bc0b`). This PR fixes a *related* bug (the wiped `.env.example`) discovered while investigating the card, and adds the regression test the card was really about. The card can be closed as "done" after this merges because the actual live manifestation of "stale SERVICE_VERSION default" — drift between committed `.env.example` and the generator — is now tested for.

## Test plan

- [x] `uv run pytest tests/luthien_proxy/unit_tests/test_config_registry.py::TestConfigFieldsCompleteness -v` — 5/5 pass including the new test
- [x] `./scripts/dev_checks.sh` — full pipeline clean, clean-tree gate green
- [x] Verified the test fails on the broken main state (empty `.env.example`) before the fix
- [x] Verified the test fails if a `ConfigFieldMeta` default is changed without regenerating

🤖 Generated with [Claude Code](https://claude.com/claude-code)