### PR TITLE
refactor(policy_cache): drop unused updated_at column

### DIFF
--- a/changelog.d/policy-cache-drop-updated-at.md
+++ b/changelog.d/policy-cache-drop-updated-at.md
@@ -1,0 +1,5 @@
+---
+category: Refactors
+---
+
+**policy_cache: drop unused `updated_at` column**: The `updated_at` column on the `policy_cache` table was written by every upsert but never read by any code path. Dropped it from the migration files and the `put()` SQL to avoid write amplification and lock in the YAGNI decision. Added schema regression tests that will fail if the column (or a SQL statement referencing it) is reintroduced without a consumer.

--- a/migrations/postgres/012_add_policy_cache.sql
+++ b/migrations/postgres/012_add_policy_cache.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS policy_cache (
     value_json  JSONB NOT NULL,
     expires_at  TIMESTAMPTZ NOT NULL,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (policy_name, cache_key)
 );
 

--- a/migrations/sqlite/012_add_policy_cache.sql
+++ b/migrations/sqlite/012_add_policy_cache.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS policy_cache (
     value_json  TEXT NOT NULL,
     expires_at  TEXT NOT NULL,
     created_at  TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (policy_name, cache_key)
 );
 

--- a/src/luthien_proxy/utils/policy_cache.py
+++ b/src/luthien_proxy/utils/policy_cache.py
@@ -110,8 +110,7 @@ class PolicyCache:
             "VALUES ($1, $2, $3::jsonb, $4::timestamptz) "
             "ON CONFLICT (policy_name, cache_key) DO UPDATE SET "
             "value_json = EXCLUDED.value_json, "
-            "expires_at = EXCLUDED.expires_at, "
-            "updated_at = NOW()",
+            "expires_at = EXCLUDED.expires_at",
             self._policy_name,
             key,
             value_json,

--- a/src/luthien_proxy/utils/sqlite_migrations/012_add_policy_cache.sql
+++ b/src/luthien_proxy/utils/sqlite_migrations/012_add_policy_cache.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS policy_cache (
     value_json  TEXT NOT NULL,
     expires_at  TEXT NOT NULL,
     created_at  TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (policy_name, cache_key)
 );
 

--- a/tests/luthien_proxy/unit_tests/utils/test_policy_cache.py
+++ b/tests/luthien_proxy/unit_tests/utils/test_policy_cache.py
@@ -23,7 +23,6 @@ async def db_pool():
         "value_json TEXT NOT NULL, "
         "expires_at TEXT NOT NULL, "
         "created_at TEXT NOT NULL DEFAULT (datetime('now')), "
-        "updated_at TEXT NOT NULL DEFAULT (datetime('now')), "
         "PRIMARY KEY (policy_name, cache_key))"
     )
     yield pool
@@ -178,3 +177,38 @@ class TestPolicyCacheCleanup:
         # Valid entry should still be there
         result = await cache.get("valid")
         assert result == {"v": 3}
+
+
+class TestPolicyCacheSchema:
+    """Schema regression tests.
+
+    WHY: updated_at was originally added to the table but never read by any
+    code path (see Trello 69d8a429). It was dropped to keep the schema minimal
+    and avoid write amplification. These tests lock in that decision so a
+    future refactor doesn't silently reintroduce the column (or a SQL
+    statement referencing it) without an explicit consumer.
+    """
+
+    @pytest.mark.asyncio
+    async def test_table_has_no_updated_at_column(self, db_pool: SqlitePool):
+        """The policy_cache table must not have an updated_at column."""
+        rows = await db_pool.fetch("PRAGMA table_info(policy_cache)")
+        columns = {row["name"] for row in rows}
+        assert "updated_at" not in columns, (
+            "policy_cache.updated_at was reintroduced — if adding it back, "
+            "also add a read path or stats consumer (see Trello 69d8a429)"
+        )
+        # Sanity: the columns we do expect are still there.
+        assert {"policy_name", "cache_key", "value_json", "expires_at", "created_at"}.issubset(columns)
+
+    @pytest.mark.asyncio
+    async def test_put_sql_does_not_reference_updated_at(self, cache: PolicyCache):
+        """put() must succeed against a schema without updated_at.
+
+        This is an integration-level guard: if put()'s SQL is edited to
+        reference updated_at again, this test fails because the column does
+        not exist in the fixture's table.
+        """
+        await cache.put("probe", {"x": 1}, ttl_seconds=3600)
+        result = await cache.get("probe")
+        assert result == {"x": 1}


### PR DESCRIPTION
## Summary

Drops the unused `updated_at` column from the `policy_cache` table introduced in #521.

## Concern boundary

- This PR touches the `updated_at` column decision only.
- Sibling Trello cards cover adjacent concerns: size cap/eviction (69d8a425) and round-trip coverage (69d8a432). Out of scope here.

## Decision: drop, not expose

PR #521 review comment [#8](https://github.com/LuthienResearch/luthien-proxy/pull/521#issuecomment-4221340187) flagged that `policy_cache.updated_at` is written by every `put()` upsert but never read. This PR drops the column.

**Verified unused:** Exhaustive grep across `src/` (admin, debug, ui, static, pipeline, credentials), `tests/`, and the `PolicyCache` class itself shows zero read paths. The only reference was the write site in `put()`.

**Why drop over expose:**
- No consumer exists and none was proposed on the original PR
- `created_at` remains as minimal provenance; `updated_at` is redundant with `expires_at` (which encodes `write_time + ttl`, so callers who care about freshness can derive it)
- Sibling card 69d8a425 (size cap / eviction): if it ends up needing LRU, it will need a dedicated `last_access_at` field populated on `get()`, not an `updated_at` populated on `put()` — so this column wouldn't serve that use case anyway
- YAGNI: every `put()` pays a write-amplification cost for a column no one reads

## What changed

- `migrations/postgres/012_add_policy_cache.sql`: remove `updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
- `migrations/sqlite/012_add_policy_cache.sql`: remove `updated_at TEXT NOT NULL DEFAULT (datetime('now'))`
- `src/luthien_proxy/utils/sqlite_migrations/012_add_policy_cache.sql`: same (in-process runner copy)
- `src/luthien_proxy/utils/policy_cache.py`: drop `updated_at = NOW()` from the `put()` upsert
- `tests/luthien_proxy/unit_tests/utils/test_policy_cache.py`:
  - Remove `updated_at` from the fixture's `CREATE TABLE`
  - Add `TestPolicyCacheSchema` class with two regression tests:
    - `test_table_has_no_updated_at_column`: asserts `PRAGMA table_info(policy_cache)` has no `updated_at` column — fails loudly if the column is reintroduced
    - `test_put_sql_does_not_reference_updated_at`: integration-level guard — `put()` must succeed against the column-free schema, so any SQL edit that re-references `updated_at` will fail the test
- `changelog.d/policy-cache-drop-updated-at.md`: changelog fragment

## Migration / rollback story

PR #521 has merged; this PR is rebased on `main` as a single `refactor(policy_cache): drop unused updated_at column` commit that edits the existing `012_add_policy_cache.sql` files in place.

Any dev environment that has already applied the old `012_add_policy_cache.sql` (i.e. pulled main after #521 merged and ran the gateway) will hit a migration hash mismatch on startup after pulling this PR. Remediation: drop the local SQLite DB (`rm ~/.luthien/local.db`) or `DELETE FROM _migrations WHERE filename='012_add_policy_cache.sql'` + `DROP TABLE policy_cache` before pulling. The cache has no persistent data anyone would want to preserve.

No production deployment has applied `012_add_policy_cache.sql` yet, so no prod-side rollback is needed.

## Devil review findings

Self-critique performed (devil skill):
1. "Unused" verified by grep, not assumption — checked all of `src/`, `tests/`, admin/debug/ui/static directories. The `updated_at` hits in grep are all for unrelated tables (`auth_config`, `telemetry_config`, `gateway_config`, `server_credentials`).
2. No admin/debug/UI tool reads `policy_cache.updated_at` — the only `policy_cache` references in the entire repo are the migration files, the `PolicyCache` class, the test file, the `PolicyContext.policy_cache()` accessor, and one factory site in `anthropic_processor.py`. None read `updated_at`.

## Test plan

- [x] `uv run pytest tests/luthien_proxy/unit_tests/utils/test_policy_cache.py` — 11 passed (including 2 new regression tests)
- [x] `uv run pytest tests/luthien_proxy/unit_tests` — 1865 passed
- [x] `uv run pytest --no-cov` (full non-e2e suite) — 2085 passed, 352 deselected
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — 340 files already formatted
- [x] `uv run pyright` — 0 errors, 0 warnings

Trello: https://trello.com/c/wJYrPRon

🤖 Generated with [Claude Code](https://claude.com/claude-code)