### PR TITLE
fix(docs): README troubleshooting no longer asks for PROXY_API_KEY onboarding never sets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,150 @@
+# Luthien Proxy — Environment Configuration
+# Auto-generated from config field definitions (scripts/generate_env_example.py).
+# Copy to .env and edit as needed.
+
+# === SERVER ======================================================
+
+# Port the gateway listens on
+# GATEWAY_PORT=8000
+
+# Logging level (critical, error, warning, info, debug, trace)
+# (can also be set at runtime via admin API)
+# LOG_LEVEL=info
+
+# Include internal details in client-facing error responses
+# (can also be set at runtime via admin API)
+# VERBOSE_CLIENT_ERRORS=false
+
+
+# === AUTH ========================================================
+
+# API key clients must provide for proxy_key auth mode
+# (sensitive)
+# PROXY_API_KEY=
+
+# API key for admin endpoints
+# (sensitive)
+# ADMIN_API_KEY=
+
+# Authentication mode: proxy_key, passthrough, or both (managed via /api/admin/auth/config)
+# AUTH_MODE=AuthMode.BOTH
+
+# Skip authentication for requests from localhost
+# (can also be set at runtime via admin API)
+# LOCALHOST_AUTH_BYPASS=true
+
+
+# === POLICY ======================================================
+
+# Policy loading strategy: db, file, db-fallback-file, file-fallback-db
+# POLICY_SOURCE=db-fallback-file
+
+# Path to policy YAML file
+# POLICY_CONFIG=
+
+# Inject active policy names into the system message
+# (can also be set at runtime via admin API)
+# INJECT_POLICY_CONTEXT=true
+
+# Auto-compose DogfoodSafetyPolicy to prevent agents from killing the proxy
+# (can also be set at runtime via admin API)
+# DOGFOOD_MODE=false
+
+
+# === DATABASE ====================================================
+
+# Database connection URL (sqlite:/// or postgres://)
+# (sensitive)
+# DATABASE_URL=
+
+# Redis connection URL (optional; enables multi-instance pub/sub) — may contain credentials
+# (sensitive)
+# REDIS_URL=
+
+# Override path to migrations directory
+# MIGRATIONS_DIR=
+
+
+# === LLM =========================================================
+
+# Server-side Anthropic API key (optional; enables server-credential mode)
+# (sensitive)
+# ANTHROPIC_API_KEY=
+
+# LiteLLM master key for multi-tenant deployments
+# (sensitive)
+# LITELLM_MASTER_KEY=
+
+# Model ID for the LLM judge policy
+# LLM_JUDGE_MODEL=
+
+# Custom API base URL for the judge model
+# LLM_JUDGE_API_BASE=
+
+# API key for the judge model
+# (sensitive)
+# LLM_JUDGE_API_KEY=
+
+# Max number of cached Anthropic client instances for passthrough auth
+# ANTHROPIC_CLIENT_CACHE_SIZE=16
+
+
+# === SECURITY ====================================================
+
+# Fernet key for encrypting server credentials at rest
+# (sensitive)
+# CREDENTIAL_ENCRYPTION_KEY=
+
+
+# === OBSERVABILITY ===============================================
+
+# Enable OpenTelemetry distributed tracing
+# OTEL_ENABLED=false
+
+# OTLP exporter endpoint for traces
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
+
+# Tempo HTTP API URL for trace queries
+# TEMPO_URL=http://localhost:3200
+
+# Service name for distributed tracing
+# SERVICE_NAME=luthien-proxy
+
+# Service version for distributed tracing (derived from package metadata)
+# (default derived from PROXY_VERSION at startup)
+# SERVICE_VERSION=
+
+# Environment name (development, staging, production)
+# ENVIRONMENT=development
+
+# Railway service name (auto-sets environment if present)
+# RAILWAY_SERVICE_NAME=
+
+# Log full HTTP request and response bodies
+# ENABLE_REQUEST_LOGGING=false
+
+
+# === TELEMETRY ===================================================
+
+# Anonymous usage telemetry (None defers to DB config, True/False overrides)
+# (can also be set at runtime via admin API)
+# USAGE_TELEMETRY=
+
+# Endpoint for anonymous usage metrics
+# TELEMETRY_ENDPOINT=https://telemetry.luthien.cc/v1/events
+
+
+# === SENTRY ======================================================
+
+# Enable Sentry error tracking
+# SENTRY_ENABLED=false
+
+# Sentry project DSN
+# (sensitive)
+# SENTRY_DSN=
+
+# Sentry traces sampling rate (0.0 to 1.0)
+# SENTRY_TRACES_SAMPLE_RATE=0.0
+
+# Sentry server identifier
+# SENTRY_SERVER_NAME=

--- a/README.md
+++ b/README.md
@@ -287,11 +287,17 @@ docker compose down && ./scripts/quick_start.sh
 
 ### API requests failing
 
-1. **Check gateway key**: Ensure `Authorization: Bearer <PROXY_API_KEY>` header is set
-2. **Check upstream credentials**:
+`luthien onboard` sets `AUTH_MODE=both` and does **not** set a `PROXY_API_KEY` — clients
+authenticate by forwarding their upstream credential (Claude Pro/Max OAuth session or
+`ANTHROPIC_API_KEY`). Start with the credential path:
+
+1. **Check upstream credentials**:
    - *OAuth passthrough (default)*: Run `claude auth login` to ensure your Claude Pro/Max session is active
    - *API key mode*: Verify `ANTHROPIC_API_KEY` starts with `sk-ant-api` in `.env`
-3. **Check logs**: `luthien logs` (local mode) or `docker compose logs -f gateway` (Docker mode)
+2. **Check logs**: `luthien logs` (local mode) or `docker compose logs -f gateway` (Docker mode)
+3. **Only if you explicitly configured `PROXY_API_KEY`**: ensure clients send it via
+   `Authorization: Bearer <PROXY_API_KEY>` or `x-api-key: <PROXY_API_KEY>`. Onboarding does
+   not set this, so skip this step unless you added one manually.
 
 ### Database connection issues
 

--- a/changelog.d/fix-readme-troubleshooting-proxy-api-key.md
+++ b/changelog.d/fix-readme-troubleshooting-proxy-api-key.md
@@ -1,0 +1,11 @@
+---
+category: Fixes
+---
+
+**README troubleshooting no longer assumes a proxy key that onboarding never sets**: The
+"API requests failing" steps used to tell users to check their `Authorization: Bearer
+<PROXY_API_KEY>` header first, but `luthien onboard` runs in `AUTH_MODE=both` and never
+writes a `PROXY_API_KEY` — clients authenticate via their passthrough upstream credential
+(OAuth session or `ANTHROPIC_API_KEY`). The troubleshooting list now leads with upstream
+credentials and treats `PROXY_API_KEY` as an opt-in that can be skipped if you didn't set
+one.


### PR DESCRIPTION
## Summary

- README \"API requests failing\" section told users to verify `Authorization: Bearer <PROXY_API_KEY>` as step 1, but `luthien onboard` sets `AUTH_MODE=both` without a `PROXY_API_KEY` — so clients authenticate via their upstream credential (Claude Pro/Max OAuth or `ANTHROPIC_API_KEY`). Users hitting API errors were being told to check a key that was never configured.
- Rewrite the section to lead with the upstream-credential path, move logs into step 2, and demote `PROXY_API_KEY` verification to a final step applicable only if the user added one manually.
- Restore `.env.example` contents (unrelated, details in COE below).

## COE (Correction of Errors)

### What went wrong
Troubleshooting doc (`README.md` line ~290) gave the first-action advice \"Check gateway key: Ensure `Authorization: Bearer <PROXY_API_KEY>` header is set\" for a scenario that the default onboarding flow never produces. A user following `luthien onboard` has no `PROXY_API_KEY` in their `.env` (`src/luthien_cli/src/luthien_cli/commands/onboard.py::_write_local_env` and `_ensure_docker_env` both write only `ADMIN_API_KEY` + `AUTH_MODE=both`). With `AUTH_MODE=both`, `gateway_routes.verify_token` accepts passthrough upstream credentials, so there's nothing for the user to verify at the gateway-key layer.

### Root cause
The troubleshooting section was written for the `AUTH_MODE=proxy_key` model where a gateway-level key is mandatory, and was not updated when `AUTH_MODE=both` became the onboarding default (2026-03-17, see `dev/context/authentication.md`). Classic \"docs drift after default change.\"

### Related areas checked
- **`dev-README.md` Troubleshooting** (line 213+): minimal, doesn't mention `PROXY_API_KEY`. No change needed.
- **`dev/context/authentication.md`**: accurately describes `AUTH_MODE=both` — used to validate the fix.
- **README `Gateway Keys` section** (lines 155-163): still presents `PROXY_API_KEY` as \"API key for clients to access the proxy\" without noting it's optional under `AUTH_MODE=both`. This contradicts the troubleshooting fix. **Intentionally NOT touched** in this PR (one PR = one concern). Commented on Trello card [0uZIQlD2 \"Clean up PROXY_API_KEY vs ANTHROPIC_API_KEY auth docs\"](https://trello.com/c/0uZIQlD2) to flag the increased urgency.
- **`.env.example`**: was emptied by PR #519 (commit `1b28e4d5`). Not related to this bug, but `scripts/dev_checks.sh` regenerates it from `config_fields.py` and trips the clean-tree gate, so every PR branched off main hits the drift. Restored in this PR as the minimum needed to make CI green. Filed a separate Trello card for the main-branch fix so it gets its own dedicated PR.

### What would have caught this
A doc-level integration test that, for each default onboarding mode, walks the README happy-path + troubleshooting instructions against the actual env file written by `luthien onboard`. Out of scope for this PR.

## Devil review (self-administered)
Adversarial pass confirmed the prose was initially too verbose and would push actionable steps below the fold for skim-readers. Tightened from a 5-line intro + 3 numbered steps to a 3-line intro + 3 tighter steps with `PROXY_API_KEY` as the final \"only if you configured one\" step. Also flagged the still-contradictory `Gateway Keys` section above the troubleshooting — left in scope of the separate audit card by design.

## Test plan

- [x] `./scripts/dev_checks.sh` — passes locally (2068 tests, 0 failures; only drift is `.env.example` regeneration, now committed)
- [x] Traced `_write_local_env` and `_ensure_docker_env` in `src/luthien_cli/src/luthien_cli/commands/onboard.py` to confirm neither sets `PROXY_API_KEY`
- [x] Confirmed `gateway_routes.verify_token` and `dev/context/authentication.md` match the new troubleshooting guidance for `AUTH_MODE=both`

## Follow-ups filed

- [Trello Q9BlY7N4](https://trello.com/c/Q9BlY7N4): PR #519 emptied `.env.example` — main dev_checks broken (needs dedicated restoration PR)
- [Trello 0uZIQlD2](https://trello.com/c/0uZIQlD2) (existing): added comment noting the `Gateway Keys` README section still contradicts the new troubleshooting wording

Closes trello card [oVAy0f5O](https://trello.com/c/oVAy0f5O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)