### PR TITLE
docs: clean stale LiteLLM content from dev/context/

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,150 @@
+# Luthien Proxy — Environment Configuration
+# Auto-generated from config field definitions (scripts/generate_env_example.py).
+# Copy to .env and edit as needed.
+
+# === SERVER ======================================================
+
+# Port the gateway listens on
+# GATEWAY_PORT=8000
+
+# Logging level (critical, error, warning, info, debug, trace)
+# (can also be set at runtime via admin API)
+# LOG_LEVEL=info
+
+# Include internal details in client-facing error responses
+# (can also be set at runtime via admin API)
+# VERBOSE_CLIENT_ERRORS=false
+
+
+# === AUTH ========================================================
+
+# API key clients must provide for proxy_key auth mode
+# (sensitive)
+# PROXY_API_KEY=
+
+# API key for admin endpoints
+# (sensitive)
+# ADMIN_API_KEY=
+
+# Authentication mode: proxy_key, passthrough, or both (managed via /api/admin/auth/config)
+# AUTH_MODE=AuthMode.BOTH
+
+# Skip authentication for requests from localhost
+# (can also be set at runtime via admin API)
+# LOCALHOST_AUTH_BYPASS=true
+
+
+# === POLICY ======================================================
+
+# Policy loading strategy: db, file, db-fallback-file, file-fallback-db
+# POLICY_SOURCE=db-fallback-file
+
+# Path to policy YAML file
+# POLICY_CONFIG=
+
+# Inject active policy names into the system message
+# (can also be set at runtime via admin API)
+# INJECT_POLICY_CONTEXT=true
+
+# Auto-compose DogfoodSafetyPolicy to prevent agents from killing the proxy
+# (can also be set at runtime via admin API)
+# DOGFOOD_MODE=false
+
+
+# === DATABASE ====================================================
+
+# Database connection URL (sqlite:/// or postgres://)
+# (sensitive)
+# DATABASE_URL=
+
+# Redis connection URL (optional; enables multi-instance pub/sub) — may contain credentials
+# (sensitive)
+# REDIS_URL=
+
+# Override path to migrations directory
+# MIGRATIONS_DIR=
+
+
+# === LLM =========================================================
+
+# Server-side Anthropic API key (optional; enables server-credential mode)
+# (sensitive)
+# ANTHROPIC_API_KEY=
+
+# LiteLLM master key for multi-tenant deployments
+# (sensitive)
+# LITELLM_MASTER_KEY=
+
+# Model ID for the LLM judge policy
+# LLM_JUDGE_MODEL=
+
+# Custom API base URL for the judge model
+# LLM_JUDGE_API_BASE=
+
+# API key for the judge model
+# (sensitive)
+# LLM_JUDGE_API_KEY=
+
+# Max number of cached Anthropic client instances for passthrough auth
+# ANTHROPIC_CLIENT_CACHE_SIZE=16
+
+
+# === SECURITY ====================================================
+
+# Fernet key for encrypting server credentials at rest
+# (sensitive)
+# CREDENTIAL_ENCRYPTION_KEY=
+
+
+# === OBSERVABILITY ===============================================
+
+# Enable OpenTelemetry distributed tracing
+# OTEL_ENABLED=false
+
+# OTLP exporter endpoint for traces
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
+
+# Tempo HTTP API URL for trace queries
+# TEMPO_URL=http://localhost:3200
+
+# Service name for distributed tracing
+# SERVICE_NAME=luthien-proxy
+
+# Service version for distributed tracing (derived from package metadata)
+# (default derived from PROXY_VERSION at startup)
+# SERVICE_VERSION=
+
+# Environment name (development, staging, production)
+# ENVIRONMENT=development
+
+# Railway service name (auto-sets environment if present)
+# RAILWAY_SERVICE_NAME=
+
+# Log full HTTP request and response bodies
+# ENABLE_REQUEST_LOGGING=false
+
+
+# === TELEMETRY ===================================================
+
+# Anonymous usage telemetry (None defers to DB config, True/False overrides)
+# (can also be set at runtime via admin API)
+# USAGE_TELEMETRY=
+
+# Endpoint for anonymous usage metrics
+# TELEMETRY_ENDPOINT=https://telemetry.luthien.cc/v1/events
+
+
+# === SENTRY ======================================================
+
+# Enable Sentry error tracking
+# SENTRY_ENABLED=false
+
+# Sentry project DSN
+# (sensitive)
+# SENTRY_DSN=
+
+# Sentry traces sampling rate (0.0 to 1.0)
+# SENTRY_TRACES_SAMPLE_RATE=0.0
+
+# Sentry server identifier
+# SENTRY_SERVER_NAME=

--- a/changelog.d/cleanup-stale-litellm-context.md
+++ b/changelog.d/cleanup-stale-litellm-context.md
@@ -1,0 +1,5 @@
+---
+category: Chores & Docs
+---
+
+**Cleanup stale LiteLLM content in dev/context/ and dev/REQUEST_PROCESSING_ARCHITECTURE.md**: the agent-facing context docs still described a LiteLLM-backed gateway path that was replaced by direct Anthropic SDK usage. Rewrote the architecture overview, streaming-pipeline notes, and thinking-block gotchas to reflect the current `pipeline/anthropic_processor.py` + `AnthropicClient` path, and scoped the remaining LiteLLM references to the judge-LLM path (`llm/judge_client.py`, `simple_llm_utils.py`, `tool_call_judge_utils.py`) where it is still used.

--- a/changelog.d/cleanup-stale-litellm-context.md
+++ b/changelog.d/cleanup-stale-litellm-context.md
@@ -1,5 +1,7 @@
 ---
 category: Chores & Docs
+pr: 532
 ---
 
 **Cleanup stale LiteLLM content in dev/context/ and dev/REQUEST_PROCESSING_ARCHITECTURE.md**: the agent-facing context docs still described a LiteLLM-backed gateway path that was replaced by direct Anthropic SDK usage. Rewrote the architecture overview, streaming-pipeline notes, and thinking-block gotchas to reflect the current `pipeline/anthropic_processor.py` + `AnthropicClient` path, and scoped the remaining LiteLLM references to the judge-LLM path (`llm/judge_client.py`, `simple_llm_utils.py`, `tool_call_judge_utils.py`) where it is still used.
+  - Also regenerated `.env.example` as a bootstrap fix: commit 1b28e4d5 had truncated it to 0 bytes, which broke the `dev_checks.sh` clean-tree gate on every branch off main. Included here so this docs PR could pass its own CI.

--- a/dev/REQUEST_PROCESSING_ARCHITECTURE.md
+++ b/dev/REQUEST_PROCESSING_ARCHITECTURE.md
@@ -83,14 +83,15 @@ Mid-stream errors after headers have been sent produce an in-stream Anthropic er
 
 LiteLLM is **not** on the main `/v1/messages` path. Backend calls are always `AnthropicClient` -> Anthropic SDK. `pipeline/anthropic_processor.py` does not import `litellm` at all.
 
-LiteLLM only appears in:
+Direct `litellm` imports in `src/luthien_proxy/` are limited to:
 
 - **Judge-LLM calls** — `llm/judge_client.py`, `policies/simple_llm_utils.py`, `policies/tool_call_judge_utils.py` call `litellm.acompletion` to ask a judge model for a decision. `judge_client.judge_completion` is the common wrapper.
 - **Startup config** — `main.py` sets `litellm.drop_params = True` once so judge calls tolerate unknown kwargs.
 - **Admin model listing** — `admin/routes.py` reads `litellm.anthropic_models` for the admin UI model dropdown.
-- **Error mapping** — `exceptions.map_litellm_error_type()` translates litellm error classes to `BackendAPIError` codes on the judge path.
 
-See `dev/context/codebase_learnings.md` (LiteLLM Usage Boundaries) for the complete list of supported import sites.
+Indirect references (no import, still tied to the judge path): `exceptions.map_litellm_error_type()` maps LiteLLM exception class names to `BackendAPIError` codes via string lookup, and `settings.litellm_master_key` is retained as a legacy judge-key fallback.
+
+See `dev/context/codebase_learnings.md` (LiteLLM Usage Boundaries) for the complete list.
 
 ## Troubleshooting
 

--- a/dev/REQUEST_PROCESSING_ARCHITECTURE.md
+++ b/dev/REQUEST_PROCESSING_ARCHITECTURE.md
@@ -1,377 +1,107 @@
 # Request Processing & Streaming Pipeline Architecture
 
-**Last Updated**: 2026-02-27
+**Last Updated**: 2026-04-10
 
-This document provides an overview of request flow through the current gateway (`src/luthien_proxy/`), focusing on Anthropic endpoints.
+This document describes how Anthropic `/v1/messages` requests flow through the gateway in the current code (`src/luthien_proxy/`). The authoritative source is `src/luthien_proxy/pipeline/anthropic_processor.py` — read that file if anything here disagrees.
 
----
-
-## Conceptual Overview
-
-The gateway processes requests via the Anthropic path:
-
-**Anthropic path** (`/v1/messages`): native Anthropic processing via `process_anthropic_request()` and `AnthropicExecutionInterface.run_anthropic()`.
-
-The path supports streaming and non-streaming responses using an execution-oriented runtime where policies emit final responses/events and may make zero or more backend calls.
+> **Historical note**: Earlier revisions of this document described a short-lived queue-based pipeline (`PolicyOrchestrator` + `PolicyExecutor` + `ClientFormatter` + `Queue[ModelResponse]`) built around LiteLLM's `ModelResponse` type. Those modules no longer exist. The gateway now talks to Anthropic through the Anthropic SDK directly and runs policies via a hook-based execution interface.
 
 ---
 
-## Non-Streaming Pipeline
+## Endpoint Scope
 
-**The Journey of a Simple Chat Completion (OpenAI path)**:
+The gateway exposes the Anthropic Messages API at `/v1/messages`. Requests are handled natively, so features like extended thinking, tool use, and prompt caching pass through without format conversion. Non-Anthropic clients are out of scope in this document.
 
-### 1. Client sends request
+## Request Lifecycle
 
-Request arrives at `/v1/messages` (Anthropic format)
+Every request passes through four phases, wrapped in an OpenTelemetry span hierarchy rooted at `anthropic_transaction_processing`:
 
-### 2. Gateway receives request
-
-([gateway_routes.py](../src/luthien_proxy/gateway_routes.py))
-
-- Creates request-scoped context (`PolicyContext`, tracing span data)
-- Validates authentication (API key check)
-
-### 3. Request processing
-
-Via `PolicyOrchestrator.process_request()`
-
-- Policy can modify request, add metadata, or reject
-
-### 4. Backend call
-
-- Request sent to configured backend via LiteLLM client
-- Backend returns complete response
-
-### 5. Response processing
-
-- Policy processes complete response
-- Policy can inspect, modify, or reject response
-
-### 6. Response returned to client
-
-- Format converted to client's expected format (OpenAI or Anthropic)
-- Events recorded to database (`conversation_calls`, `conversation_events`)
-- Published to Redis for activity monitoring
-
-**Total time**: ~1-5 seconds depending on LLM latency
-
-### Anthropic non-streaming note
-
-Anthropic non-streaming requests are handled separately by `process_anthropic_request()` in
-`src/luthien_proxy/pipeline/anthropic_processor.py`, where policies implement `run_anthropic()` and emit response objects.
-
----
-
-## Streaming Pipeline
-
-The streaming pipeline handles requests where the backend returns response chunks incrementally. The request phase is identical to non-streaming; the response handling differs.
-
-### How Streaming Differs from Non-Streaming
-
-Instead of receiving a complete response at once, the backend returns an `AsyncIterator[ModelResponse]`. This requires a two-stage processing pipeline:
-
-1. **Stage 1 (PolicyExecutor)**: Consume raw chunks from backend, assemble complete blocks, invoke policy hooks, put processed chunks in `policy_out_queue`
-2. **Stage 2 (ClientFormatter)**: Consume processed chunks from `policy_out_queue`, convert to client format (SSE), put strings in `sse_queue`
-3. **Stage 3 (Gateway)**: Drain `sse_queue` and yield to client
-
-This approach gives policies visibility into complete blocks (not just raw chunks) while maintaining streaming semantics to the client.
-
-### Quick Reference Diagram
-
-```mermaid
-graph TD
-    A["Backend LLM via LiteLLM"] -->|"AsyncIter[ModelResponse]"| B["PolicyExecutor - Stage 1"]
-    B -->|"Block assembly + hooks"| C["policy_out_queue<br/>Queue[ModelResponse]"]
-    C --> D["ClientFormatter - Stage 2"]
-    D -->|"SSE conversion"| E["sse_queue<br/>Queue[str]"]
-    E --> F["Gateway yields to client"]
+```
+anthropic_transaction_processing
+  +-- process_request
+  +-- process_response
+  |   +-- policy_execute
+  |   +-- send_upstream  (zero or more backend calls)
+  +-- send_to_client     (non-streaming only)
 ```
 
-**Key Components**:
+### 1. Ingest & Authenticate
 
-- **PolicyExecutor**: Assembles blocks from chunks, invokes policy hooks (55 unit tests)
-- **ClientFormatter**: Converts ModelResponse → SSE strings (12 unit tests)
-- **Queues**: Bounded (maxsize=10000) with 30s timeout on put operations
+`gateway_routes.py` validates the credential via `CredentialManager`, resolves the backend `AnthropicClient` (proxy-key vs passthrough vs explicit `x-anthropic-api-key`), and dispatches to `process_anthropic_request()`.
 
-### Detailed Flow
+### 2. Build PolicyContext
 
-**The Journey of a Streaming Chat Completion**:
+`process_anthropic_request()` (in `pipeline/anthropic_processor.py`) creates a `PolicyContext` for the call:
 
-### 1. Client sends streaming request
+- `transaction_id` (a new `call_id`)
+- `raw_http_request` snapshot (headers, body)
+- `session_id` (extracted from the request body / headers)
+- `user_credential` and `credential_manager` for auth-provider resolution
+- `emitter` for observability events
 
-Request includes `"stream": true`
+If `inject_policy_context` is enabled and the policy derives from `BasePolicy`, a small system-prompt addition listing the active policy names is injected into the request.
 
-### 2. Gateway receives request
+### 3. Run the Execution Policy
 
-(Same as non-streaming)
+Policies implement `AnthropicExecutionInterface` (in `policy_core/anthropic_execution_interface.py`) — a hook-based protocol. The processor's `_run_policy_hooks()` function owns the backend call and stream iteration, invoking four hooks in sequence:
 
-- Creates contexts (`ObservabilityContext`, `PolicyContext`)
-- Validates authentication
-- Processes request through policy hooks
+- `on_anthropic_request(request, context) -> AnthropicRequest` — transform the request before it is sent to the backend.
+- `on_anthropic_response(response, context) -> AnthropicResponse` — transform a non-streaming backend response.
+- `on_anthropic_stream_event(event, context) -> list[MessageStreamEvent]` — transform or replace each backend stream event (each call may emit zero or many events).
+- `on_anthropic_stream_complete(context) -> list[MessageStreamEvent]` — emit any tail events after the backend stream finishes (e.g. injected blocks).
 
-### 3. LiteLLM streams from backend
+Policies never see the IO layer directly. The executor wraps the backend in an `_AnthropicPolicyIO` helper (implementing `AnthropicPolicyIOProtocol`) that holds the current request and exposes `io.stream(...)` / `io.complete(...)`. The executor calls `io.stream(request)` or `io.complete(request)` exactly once per request — based on the incoming `stream: true/false` flag — and runs each hook around that call. Each backend call executes under a `send_upstream` child span.
 
-- Returns `AsyncIterator[ModelResponse]` - chunks arrive incrementally
-- LiteLLM already normalized chunks to common format
-- **Key insight**: No ingress formatting needed!
+`_execute_anthropic_policy()` dispatches the resulting emissions to either `_handle_execution_non_streaming` (single `AnthropicResponse` → `JSONResponse`) or `_handle_execution_streaming` (sequence of `MessageStreamEvent` → SSE).
 
-### 4. Streaming Pipeline - Stage 1: PolicyExecutor
+### 4. Emit to Client and Record
 
-- Consumes `AsyncIterator[ModelResponse]` from backend
-- **Block Assembly**: Uses `StreamingChunkAssembler` to build complete blocks
-  - Detects when content blocks complete
-  - Detects when tool calls complete
-  - Tracks finish_reason
-- **Policy Hooks**: Invokes policy at key moments
-  - `on_content_delta(delta, ...)` - each content chunk
-  - `on_tool_call_delta(delta, ...)` - each tool call chunk
-  - `on_block_complete(block, ...)` - when block finishes
-  - `on_stream_complete(...)` - when stream ends
-- **Timeout Monitoring**: Calls `keepalive()` on each chunk to prevent hangs
-- **Outputs**: Puts processed `ModelResponse` chunks into `policy_out_queue`
+**Non-streaming** (`_handle_execution_non_streaming`): the processor captures the original backend response (before policy mutation) and the final emitted response, records a `transaction.response_recorded` event, and returns a `JSONResponse`.
 
-### 5. Queue Handoff: policy_out_queue
+**Streaming** (`_handle_execution_streaming`): the processor iterates the policy emissions, serializes each event with `_format_sse_event`, and yields them to the client as `text/event-stream`. In the `finally` block it:
 
-- Typed as `Queue[ModelResponse]`
-- Bounded queue (maxsize=10000)
-- 30s timeout on put() to prevent deadlock
+- Validates the accumulated event sequence against `validate_anthropic_event_ordering` (log-and-warn only — violations are recorded as `streaming.protocol_violation` events).
+- Reconstructs an `AnthropicResponse` from the accumulated stream events.
+- Records `transaction.streaming_response_recorded` with both the raw and final responses.
+- Flushes request-log records and records usage telemetry (input/output tokens) when the stream completed normally.
 
-### 6. Streaming Pipeline - Stage 2: ClientFormatter
+Mid-stream errors after headers have been sent produce an in-stream Anthropic error event (`_build_error_event`) so the client sees a structured failure instead of a silent truncation.
 
-- Consumes `ModelResponse` chunks from `policy_out_queue`
-- **OpenAI Client**: Converts to OpenAI SSE format
-  - `data: {"id": "...", "choices": [{"delta": {...}}]}\n\n`
-- **Anthropic Client**: Converts to Anthropic SSE format with event lifecycle
-  - `event: message_start\ndata: {...}\n\n`
-  - `event: content_block_delta\ndata: {...}\n\n`
-  - `event: message_stop\ndata: {...}\n\n`
-- **Outputs**: Puts SSE strings into `sse_queue`
+## Key Abstractions
 
-### 7. Queue Handoff: sse_queue
+| Abstraction | Location | Role |
+|-------------|----------|------|
+| `process_anthropic_request` | `pipeline/anthropic_processor.py` | Top-level phase 1–4 orchestration for Anthropic requests |
+| `AnthropicExecutionInterface` | `policy_core/anthropic_execution_interface.py` | Hook-based contract for Anthropic policies (`on_anthropic_request`, `on_anthropic_response`, `on_anthropic_stream_event`, `on_anthropic_stream_complete`) |
+| `AnthropicPolicyIOProtocol` | `policy_core/anthropic_execution_interface.py` | Executor-only I/O surface (`complete`, `stream`, current request) — policies do not see this directly |
+| `AnthropicClient` | `llm/anthropic_client.py` | Async Anthropic SDK wrapper (api_key vs bearer-token auth) |
+| `PolicyContext` | `policy_core/policy_context.py` | Per-request state — transaction id, emitter, typed request-state slots |
+| `EventEmitterProtocol` | `observability/emitter.py` | Records transaction + policy events to storage and Redis |
+| `validate_anthropic_event_ordering` | `pipeline/stream_protocol_validator.py` | Post-stream protocol-ordering check |
 
-- Typed as `Queue[str]`
-- Bounded queue (maxsize=10000)
-- 30s timeout on put()
+## LiteLLM Scope
 
-### 8. Gateway yields to client
+LiteLLM is **not** on the main `/v1/messages` path. Backend calls are always `AnthropicClient` -> Anthropic SDK. `pipeline/anthropic_processor.py` does not import `litellm` at all.
 
-- Drains `sse_queue` with `async for sse_string in ...: yield sse_string`
-- Client receives Server-Sent Events incrementally
-- Events recorded and published (same as non-streaming)
+LiteLLM only appears in:
 
-**Total time**: Streaming duration + policy overhead (typically milliseconds per chunk)
+- **Judge-LLM calls** — `llm/judge_client.py`, `policies/simple_llm_utils.py`, `policies/tool_call_judge_utils.py` call `litellm.acompletion` to ask a judge model for a decision. `judge_client.judge_completion` is the common wrapper.
+- **Startup config** — `main.py` sets `litellm.drop_params = True` once so judge calls tolerate unknown kwargs.
+- **Admin model listing** — `admin/routes.py` reads `litellm.anthropic_models` for the admin UI model dropdown.
+- **Error mapping** — `exceptions.map_litellm_error_type()` translates litellm error classes to `BackendAPIError` codes on the judge path.
 
----
-
-## Key Design Principles
-
-### 1. Dependency Injection
-
-Gateway creates pipeline components and injects them:
-
-```python
-# In gateway_routes.py
-policy_executor = DefaultPolicyExecutor(timeout_seconds=30.0)
-client_formatter = AnthropicClientFormatter(model_name=request.model)
-
-orchestrator = PolicyOrchestrator(
-    policy=policy,
-    policy_executor=policy_executor,
-    client_formatter=client_formatter,
-
-)
-```
-
-**Why**: Clear dependencies, easy to test, explicit over implicit.
-
-### 2. Context Threading
-
-`ObservabilityContext` and `PolicyContext` created at gateway, passed through entire lifecycle:
-
-```python
-# Created once
-obs_ctx = ObservabilityContext(trace_id=..., span=...)
-policy_ctx = PolicyContext(transaction_id=call_id)
-
-# Threaded through all operations
-orchestrator.process_request(request, obs_ctx, policy_ctx)
-orchestrator.process_streaming_response(stream, obs_ctx, policy_ctx)
-```
-
-**Why**: Consistent tracing, no globals, clear lifecycle ownership.
-
-### 3. Typed Queues
-
-Explicit types at queue boundaries catch errors early:
-
-```python
-policy_out_queue: asyncio.Queue[ModelResponse] = asyncio.Queue(maxsize=10000)
-sse_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=10000)
-```
-
-**Why**: Type safety, clear contracts, self-documenting code.
-
-### 4. Bounded Queues with Circuit Breaker
-
-Large but bounded queues prevent memory exhaustion:
-
-- maxsize=10000 (handles bursts)
-- 30s timeout on put() (prevents deadlock)
-- Raises `QueueFullError` if overwhelmed
-
-**Why**: Fail fast under load rather than OOM.
-
-### 5. Separation of Concerns
-
-- **PolicyExecutor**: Stream mechanics (chunking, timeout, assembly)
-- **Policy**: Business logic (allow/block decisions, transformations)
-- **ClientFormatter**: Output format conversion
-- **PolicyOrchestrator**: Coordinates pipeline, doesn't implement logic
-
-**Why**: Each component has single responsibility, easy to test and maintain.
-
----
-
-## Policy Hook Points
-
-Policies can intercept at these points:
-
-### Request Lifecycle
-
-- `on_request_started(request, policy_ctx, obs_ctx)` - Before LLM call
-- `on_request_completed(request, policy_ctx, obs_ctx)` - After modification
-
-### Streaming Response Lifecycle
-
-- `on_response_started(policy_ctx, obs_ctx)` - Stream begins
-- `on_content_delta(delta, policy_ctx, obs_ctx)` - Each content chunk
-- `on_tool_call_delta(delta, policy_ctx, obs_ctx)` - Each tool call chunk
-- `on_block_complete(block, policy_ctx, obs_ctx)` - Block finished
-- `on_stream_complete(policy_ctx, obs_ctx)` - Stream finished
-
-### Non-Streaming Response Lifecycle
-
-**Status**: Not yet fully integrated with orchestrator
-
-- `process_full_response(response, policy_ctx)` - Process complete response (currently the only hook)
-
-**Example Policy**: ToolCallJudgePolicy buffers tool calls, sends them to judge LLM, blocks if unsafe.
-
----
-
-## Component Locations
-
-### Core Pipeline
-
-- **Gateway Routes**: `src/luthien_proxy/gateway_routes.py`
-- **PolicyOrchestrator**: `src/luthien_proxy/orchestration/policy_orchestrator.py`
-- **PolicyExecutor**: `src/luthien_proxy/streaming/policy_executor/executor.py`
-- **ClientFormatter**: `src/luthien_proxy/streaming/client_formatter/openai.py`
-
-### Supporting Components
-
-- **StreamingChunkAssembler**: `src/luthien_proxy/streaming/streaming_chunk_assembler.py`
-- **PolicyContext**: `src/luthien_proxy/policy_core/policy_context.py`
-
-
-### Policies
-
-- **Policy Protocol**: `src/luthien_proxy/policy_core/policy_protocol.py`
-- **Example Policies**: `src/luthien_proxy/policies/{noop,simple,debug_logging,tool_call_judge}_policy.py`
-
-### Tests
-
-- **PolicyExecutor tests**: `tests/luthien_proxy/unit_tests/streaming/policy_executor/` (55 tests)
-- **ClientFormatter tests**: `tests/luthien_proxy/unit_tests/streaming/client_formatter/` (12 tests)
-- **E2E tests**: `tests/luthien_proxy/e2e_tests/test_api_compatibility.py`
-
----
-
-## Common Questions
-
-### Q: Why not just use callbacks like before?
-
-**A**: Explicit queues make data flow visible, enable recording at boundaries, and make testing easier. Can inspect queue states during debugging.
-
-### Q: Why remove CommonFormatter?
-
-**A**: Discovered LiteLLM already normalizes backend responses to ModelResponse. Having a formatter that did `ModelResponse → ModelResponse` was unnecessary complexity (~200 lines removed).
-
-### Q: What if a policy is slow?
-
-**A**: Bounded queues prevent unbounded memory growth. If `policy_out_queue` fills up, the system fails fast with `QueueFullError` rather than consuming all memory.
-
-### Q: How does timeout monitoring work?
-
-**A**: PolicyExecutor calls `self.keepalive()` on each chunk. If no chunks arrive for 30s, timeout triggers. This prevents hanging on slow/stuck LLM connections.
-
-### Q: Can policies modify streaming chunks?
-
-**A**: Yes! Policies can inject new chunks, block chunks, or transform them. For example, ToolCallJudgePolicy blocks tool calls by injecting error content chunks.
-
-### Q: How do I add a new policy?
-
-**A**: Implement `PolicyProtocol` with your hook logic. See `dev/event_driven_policy_guide.md` for examples. NoOpPolicy is the simplest reference implementation.
-
----
-
-## Performance Characteristics
-
-### Latency Overhead
-
-- **Non-streaming**: ~1-5ms (policy hook invocations)
-- **Streaming**: ~1-2ms per chunk (assembly + policy hooks)
-- **Queue operations**: Sub-millisecond (asyncio queues are fast)
-
-### Memory Usage
-
-- **Bounded queues**: Max 10000 items per queue
-- **ModelResponse size**: ~1-5KB per chunk typically
-- **Worst case**: ~50MB per active stream (policy_out_queue + sse_queue full)
-
-### Throughput
-
-- **Concurrent streams**: Limited by asyncio TaskGroup overhead (minimal)
-- **Bottleneck**: Usually backend LLM latency, not proxy
-- **Queue saturation**: Needs sustained 300+ chunks/sec to fill queues
-
----
+See `dev/context/codebase_learnings.md` (LiteLLM Usage Boundaries) for the complete list of supported import sites.
 
 ## Troubleshooting
 
-### Streaming hangs
-
-- Check PolicyExecutor timeout (default 30s)
-- Look for policy hooks that don't complete
-- Verify backend LLM is actually streaming
-
-### Queue full errors
-
-- Policy is too slow (buffering/judging taking too long)
-- Backend producing chunks faster than client consuming
-- Consider increasing queue size or optimizing policy
-
-### Missing chunks in output
-
-- Policy may not be forwarding chunks (check `on_content_delta` implementation)
-- ClientFormatter may have bug (check unit tests)
-- Verify chunks in `policy_out_queue` before formatter
-
-### Type errors
-
-- Ensure using proper LiteLLM types (`StreamingChoices`, `Delta`, not dicts)
-- Check queue type annotations match what's being put/get
-- Use test fixtures as reference for proper types
-
----
+- **Stream hangs or truncates**: inspect `pipeline/anthropic_processor.py` `_handle_execution_streaming` and the policy's `run_anthropic` implementation — the SSE iterator pulls directly from whatever the policy yields.
+- **Protocol-ordering violations in logs**: `streaming.protocol_violation` events indicate the policy emitted events out of Anthropic's required order (all `content_block_*` must precede `message_delta`). See `gotchas.md` under "Anthropic Streaming: All Content Blocks Must Precede message_delta".
+- **Empty stream 500**: the policy returned without yielding any events; `_handle_execution_streaming` converts that into an explicit Anthropic error event and logs `policy.execution.empty_stream`.
+- **Judge LLM call failures**: these come from `judge_client.judge_completion`, not the main request path; check `LLM_JUDGE_API_KEY`, per-policy `api_key`, and the upstream LiteLLM configuration.
 
 ## Related Documentation
 
-- **Context Files**:
-  - [codebase_learnings.md](context/codebase_learnings.md#streaming-pipeline-architecture-2025-11-05) - Architecture patterns
-  - [decisions.md](context/decisions.md#streaming-pipeline-queue-based-architecture-2025-11-05) - Why this approach
-  - [gotchas.md](context/gotchas.md#queue-shutdown-for-stream-termination-2025-01-20-updated-2025-10-20) - Queue patterns
-
-- **Observability**:
-  - [observability.md](observability.md) - Tracing and monitoring
-  - [VIEWING_TRACES_GUIDE.md](VIEWING_TRACES_GUIDE.md) - Using Tempo
+- `ARCHITECTURE.md` — broader module map (note: known staleness tracked separately on Trello; prefer the source code when in doubt).
+- `dev/context/codebase_learnings.md` — architectural patterns.
+- `dev/context/gotchas.md` — streaming protocol invariants and common debugging pitfalls.
+- `dev/observability.md` — tracing, event recording, and Tempo integration.

--- a/dev/REQUEST_PROCESSING_ARCHITECTURE.md
+++ b/dev/REQUEST_PROCESSING_ARCHITECTURE.md
@@ -48,7 +48,7 @@ Policies implement `AnthropicExecutionInterface` (in `policy_core/anthropic_exec
 - `on_anthropic_request(request, context) -> AnthropicRequest` — transform the request before it is sent to the backend.
 - `on_anthropic_response(response, context) -> AnthropicResponse` — transform a non-streaming backend response.
 - `on_anthropic_stream_event(event, context) -> list[MessageStreamEvent]` — transform or replace each backend stream event (each call may emit zero or many events).
-- `on_anthropic_stream_complete(context) -> list[MessageStreamEvent]` — emit any tail events after the backend stream finishes (e.g. injected blocks).
+- `on_anthropic_stream_complete(context) -> list[AnthropicPolicyEmission]` — emit any tail emissions after the backend stream finishes (e.g. injected blocks). `AnthropicPolicyEmission = AnthropicResponse | MessageStreamEvent`, so a tail emission can in principle be a full non-streaming response as well as a stream event.
 
 Policies never see the IO layer directly. The executor wraps the backend in an `_AnthropicPolicyIO` helper (implementing `AnthropicPolicyIOProtocol`) that holds the current request and exposes `io.stream(...)` / `io.complete(...)`. The executor calls `io.stream(request)` or `io.complete(request)` exactly once per request — based on the incoming `stream: true/false` flag — and runs each hook around that call. Each backend call executes under a `send_upstream` child span.
 

--- a/dev/REQUEST_PROCESSING_ARCHITECTURE.md
+++ b/dev/REQUEST_PROCESSING_ARCHITECTURE.md
@@ -95,7 +95,7 @@ See `dev/context/codebase_learnings.md` (LiteLLM Usage Boundaries) for the compl
 
 ## Troubleshooting
 
-- **Stream hangs or truncates**: inspect `pipeline/anthropic_processor.py` `_handle_execution_streaming` and the policy's `run_anthropic` implementation — the SSE iterator pulls directly from whatever the policy yields.
+- **Stream hangs or truncates**: inspect `pipeline/anthropic_processor.py` `_handle_execution_streaming` and the policy's `on_anthropic_stream_event` / `on_anthropic_stream_complete` hooks — the SSE iterator pulls directly from whatever those hooks yield.
 - **Protocol-ordering violations in logs**: `streaming.protocol_violation` events indicate the policy emitted events out of Anthropic's required order (all `content_block_*` must precede `message_delta`). See `gotchas.md` under "Anthropic Streaming: All Content Blocks Must Precede message_delta".
 - **Empty stream 500**: the policy returned without yielding any events; `_handle_execution_streaming` converts that into an explicit Anthropic error event and logs `policy.execution.empty_stream`.
 - **Judge LLM call failures**: these come from `judge_client.judge_completion`, not the main request path; check `LLM_JUDGE_API_KEY`, per-policy `api_key`, and the upstream LiteLLM configuration.

--- a/dev/REQUEST_PROCESSING_ARCHITECTURE.md
+++ b/dev/REQUEST_PROCESSING_ARCHITECTURE.md
@@ -48,7 +48,7 @@ Policies implement `AnthropicExecutionInterface` (in `policy_core/anthropic_exec
 - `on_anthropic_request(request, context) -> AnthropicRequest` — transform the request before it is sent to the backend.
 - `on_anthropic_response(response, context) -> AnthropicResponse` — transform a non-streaming backend response.
 - `on_anthropic_stream_event(event, context) -> list[MessageStreamEvent]` — transform or replace each backend stream event (each call may emit zero or many events).
-- `on_anthropic_stream_complete(context) -> list[AnthropicPolicyEmission]` — emit any tail emissions after the backend stream finishes (e.g. injected blocks). `AnthropicPolicyEmission = AnthropicResponse | MessageStreamEvent`, so a tail emission can in principle be a full non-streaming response as well as a stream event.
+- `on_anthropic_stream_complete(context) -> list[AnthropicPolicyEmission]` — emit any tail emissions after the backend stream finishes (e.g. injected blocks). `AnthropicPolicyEmission = AnthropicResponse | MessageStreamEvent`, but `_handle_execution_streaming` enforces a single shape per request: on the streaming path it raises `TypeError` if a policy tries to emit an `AnthropicResponse`, and `_handle_execution_non_streaming` symmetrically rejects `MessageStreamEvent`s on the non-streaming path. In practice, `on_anthropic_stream_complete` should only yield `MessageStreamEvent`s.
 
 Policies never see the IO layer directly. The executor wraps the backend in an `_AnthropicPolicyIO` helper (implementing `AnthropicPolicyIOProtocol`) that holds the current request and exposes `io.stream(...)` / `io.complete(...)`. The executor calls `io.stream(request)` or `io.complete(request)` exactly once per request — based on the incoming `stream: true/false` flag — and runs each hook around that call. Each backend call executes under a `send_upstream` child span.
 
@@ -56,7 +56,7 @@ Policies never see the IO layer directly. The executor wraps the backend in an `
 
 ### 4. Emit to Client and Record
 
-**Non-streaming** (`_handle_execution_non_streaming`): the processor captures the original backend response (before policy mutation) and the final emitted response, records a `transaction.response_recorded` event, and returns a `JSONResponse`.
+**Non-streaming** (`_handle_execution_non_streaming`): the processor captures the original backend response (before policy mutation) and the final emitted response, records a `transaction.non_streaming_response_recorded` event, and returns a `JSONResponse`.
 
 **Streaming** (`_handle_execution_streaming`): the processor iterates the policy emissions, serializes each event with `_format_sse_event`, and yields them to the client as `text/event-stream`. In the `finally` block it:
 

--- a/dev/context/authentication.md
+++ b/dev/context/authentication.md
@@ -32,8 +32,6 @@ Token is extracted from, in order:
    - Received via `Authorization: Bearer` → `AnthropicClient(auth_token=token)` (OAuth token)
    - Received via `x-api-key` → `AnthropicClient(api_key=token)` (API key)
 
-**For Anthropic (`/v1/messages`)**: `verify_token()` validates but the token is NOT forwarded to LiteLLM — LiteLLM uses env vars (`ANTHROPIC_API_KEY`, etc.) or per-request `api_key` kwargs.
-
 ---
 
 ## Passthrough Key in PolicyContext (2026-03-17)
@@ -49,14 +47,16 @@ Headers are stored lowercase. `BasePolicy._extract_passthrough_key(raw_http_requ
 
 ---
 
-## Judge LLM Key Resolution (2026-03-17)
+## Judge LLM Key Resolution (2026-03-17, updated 2026-04-10)
 
-Both `SimpleLLMPolicy` and `ToolCallJudgePolicy` make separate LiteLLM calls to a judge model. Key priority (resolved per-request at call time):
+Both `SimpleLLMPolicy` and `ToolCallJudgePolicy` issue a separate judge-model call per decision. Judge calls are routed through `luthien_proxy.llm.judge_client.judge_completion`, which wraps `litellm.acompletion` — LiteLLM is intentionally scoped to this judge path only and is not on the main request pipeline.
+
+Key priority (resolved per-request at call time):
 
 1. **Explicit policy config `api_key`** — set by admin in the policy config. Highest priority, overrides everything.
 2. **Passthrough key** — the client's incoming API key from `context.raw_http_request.headers`. Default behavior: the client's key is used for judge calls too.
 3. **`LLM_JUDGE_API_KEY` env var** — server-configured key specifically for judge calls.
-4. **`LITELLM_MASTER_KEY` env var** — legacy catch-all fallback.
+4. **`LITELLM_MASTER_KEY` env var** — legacy catch-all fallback (still read by the settings object).
 5. **None** — LiteLLM resolves via its own env var chain (`ANTHROPIC_API_KEY`, etc.).
 
 This is implemented in `_resolve_api_key(context)` on each policy class (backed by `BasePolicy._extract_passthrough_key()`). The resolved key is passed as `api_key=` kwarg to `call_simple_llm_judge()` / `call_judge()`.

--- a/dev/context/codebase_learnings.md
+++ b/dev/context/codebase_learnings.md
@@ -7,28 +7,30 @@ If updating existing content significantly, note it: `## Topic (2025-10-08, upda
 
 ---
 
-## V2 Architecture Overview (2025-10-24, updated 2025-12-04)
+## Architecture Overview (2025-10-24, updated 2026-04-10)
 
-- **Gateway** (`src/luthien_proxy/`): Integrated FastAPI + LiteLLM application with built-in policy enforcement
-- **Orchestration** (`src/luthien_proxy/orchestration/`): PolicyOrchestrator coordinates streaming pipeline
-- **Policies** (`src/luthien_proxy/policies/`): Event-driven policy implementations
-- **Policy Core** (`src/luthien_proxy/policy_core/`): Policy protocol, contexts, and chunk builders
-- **Storage** (`src/luthien_proxy/storage/`): Conversation event persistence with background queue
-- **Streaming** (`src/luthien_proxy/streaming/`): Policy executor and client formatters
-- **Observability** (`src/luthien_proxy/observability/`): OpenTelemetry integration, transaction recording
-- **Admin** (`src/luthien_proxy/admin/`): Runtime policy management API
-- **Debug** (`src/luthien_proxy/debug/`): Debug endpoints for inspecting conversation events
-- **UI** (`src/luthien_proxy/ui/`): Activity monitoring and diff viewer interfaces
-- **LLM** (`src/luthien_proxy/llm/`): LiteLLM client wrapper and format converters
+Integrated single-process gateway. Authoritative module map and request lifecycle live in `ARCHITECTURE.md`. Summary of directories referenced from these context notes:
 
-Integrated architecture - everything runs in single gateway process.
+- **Gateway** (`src/luthien_proxy/`): FastAPI app with built-in policy enforcement; Anthropic requests flow through `pipeline/anthropic_processor.py` and use `AnthropicClient` (wraps the Anthropic SDK) to talk to the backend.
+- **Pipeline** (`src/luthien_proxy/pipeline/`): Request processors for the Anthropic path, including streaming execution.
+- **Policies** (`src/luthien_proxy/policies/`): Concrete policy implementations (noop, simple, tool-call judge, etc.).
+- **Policy Core** (`src/luthien_proxy/policy_core/`): Policy base classes, protocols, per-request `PolicyContext`, Anthropic execution interface.
+- **Storage** (`src/luthien_proxy/storage/`): Conversation event persistence with a background queue.
+- **Observability** (`src/luthien_proxy/observability/`): OpenTelemetry integration and structured transaction recording.
+- **Admin** (`src/luthien_proxy/admin/`): Runtime policy management API.
+- **Debug** (`src/luthien_proxy/debug/`): Endpoints for inspecting conversation events.
+- **UI** (`src/luthien_proxy/ui/`): Activity monitoring and diff viewer interfaces.
+- **LLM** (`src/luthien_proxy/llm/`): `AnthropicClient` (Anthropic SDK wrapper) plus a LiteLLM-backed `judge_client` used by judge-driven policies. The main request path does not go through LiteLLM.
 
-## Anthropic Runtime Model (2026-02-27)
+## Anthropic Runtime Model (2026-02-27, updated 2026-04-10)
 
-- Anthropic request handling is execution-oriented, not hook-oriented.
-- Policies on `/v1/messages` implement `AnthropicExecutionInterface.run_anthropic(io, context)` and emit responses/events.
-- Policy runtime is backend-call agnostic: policies may make zero, one, or many backend calls via `io.complete()` / `io.stream()`.
-- Legacy Anthropic compatibility helpers (`_handle_streaming`, `_handle_non_streaming` in `anthropic_processor.py`) were removed from production code.
+- Anthropic request handling is hook-based. The executor (`_run_policy_hooks` in `pipeline/anthropic_processor.py`) owns the backend call and stream iteration.
+- Policies implement `AnthropicExecutionInterface` (`policy_core/anthropic_execution_interface.py`) with four hooks:
+  - `on_anthropic_request(request, context) -> AnthropicRequest`
+  - `on_anthropic_response(response, context) -> AnthropicResponse`
+  - `on_anthropic_stream_event(event, context) -> list[MessageStreamEvent]`
+  - `on_anthropic_stream_complete(context) -> list[MessageStreamEvent]`
+- Policies never see the IO layer directly. The executor wraps the backend in `_AnthropicPolicyIO` (implementing `AnthropicPolicyIOProtocol`) and calls `io.stream(request)` or `io.complete(request)` exactly once per request based on the incoming `stream` flag.
 
 ## Key Patterns (2025-10-24)
 
@@ -37,22 +39,20 @@ Integrated architecture - everything runs in single gateway process.
 - **Background persistence**: `SequentialTaskQueue` ensures non-blocking event emission to database
 - **OpenTelemetry**: Distributed tracing with automatic span creation and log correlation
 
-## LiteLLM Role in V2 Architecture (2025-10-17)
+## LiteLLM Usage Boundaries (2025-10-17, updated 2026-04-10)
 
-**Key insight**: LiteLLM should ONLY be used for API format conversion, not parameter validation.
+LiteLLM is NOT on the main request path. Anthropic `/v1/messages` traffic is handled by `AnthropicClient` (Anthropic SDK) in `pipeline/anthropic_processor.py`, and the processor never imports `litellm`.
 
-**Problem**: When passing model-specific parameters (e.g., provider-specific options), litellm's `acompletion()` rejects them with "Unknown parameter" errors.
+Current imports of `litellm` in `src/luthien_proxy/`:
 
-**Solution**: Use litellm's `allowed_openai_params` mechanism:
-```python
-# Identify model-specific parameters to forward
-known_params = {"verbosity"}  # Add more as needed
-model_specific_params = [p for p in data.keys() if p in known_params]
-if model_specific_params:
-    data["allowed_openai_params"] = model_specific_params
-```
+- `llm/judge_client.py` — wraps `litellm.acompletion` for judge-LLM calls.
+- `policies/simple_llm_utils.py` and `policies/tool_call_judge_utils.py` — call `acompletion` directly for judge decisions (these are the underlying utilities for `SimpleLLMPolicy` and `ToolCallJudgePolicy`).
+- `main.py` — sets `litellm.drop_params = True` once at startup so judge calls tolerate unknown kwargs.
+- `admin/routes.py` — reads `litellm.anthropic_models` to list available Claude models in the admin UI.
+- `exceptions.py` — `map_litellm_error_type()` maps litellm exception classes onto `BackendAPIError` codes for judge-path errors.
+- `config_fields.py` / `settings.py` — retain `litellm_master_key` as a legacy fallback when resolving judge API keys.
 
-**Key principle**: We want litellm to do format conversion (OpenAI ↔ Anthropic) but NOT validate parameters. Each provider knows what it supports.
+**Key rule**: Do not introduce new LiteLLM imports from gateway request processing, streaming, or the `pipeline/` package. Judge-LLM calls (and the startup/admin touches listed above) are the only supported entry points today.
 
 ## E2E Test Infrastructure (2025-10-17, updated 2026-03-25)
 
@@ -80,57 +80,11 @@ Three test tiers with increasing infrastructure requirements:
 - `set_policy()` / `get_current_policy()` — admin API wrappers
 - `gateway_healthy` — fixture that skips if gateway unreachable
 
-## Streaming Pipeline Architecture (2025-11-05)
+## Streaming Pipeline (2026-04-10)
 
-**Two-stage queue-based pipeline** with dependency injection and explicit data flow.
+Anthropic streaming lives inside `src/luthien_proxy/pipeline/anthropic_processor.py`. The gateway calls `AnthropicClient.stream(...)` (Anthropic SDK), hands the async iterator to an execution-interface policy, and the policy emits `RawMessageStreamEvent`s that the processor forwards as SSE to the client. Policies implement `AnthropicExecutionInterface.run_anthropic(io, context)` and use the `io` surface to call `io.stream()` / `io.complete()` zero or more times.
 
-### Architecture
-
-```
-Backend LLM (via LiteLLM)
-         ↓
-AsyncIterator[ModelResponse] ← LiteLLM provides common format
-         ↓
-    PolicyExecutor (stage 1)
-    - Block assembly (StreamingChunkAssembler)
-    - Policy hook invocation
-    - Timeout + keepalive monitoring
-         ↓
-policy_out_queue: Queue[ModelResponse]
-         ↓
-   ClientFormatter (stage 2)
-    - OpenAI or Anthropic SSE conversion
-         ↓
-sse_queue: Queue[str]
-         ↓
-    Gateway yields to client
-```
-
-### Key Design Principles
-
-1. **No Ingress Formatting**: LiteLLM already normalizes backend responses to ModelResponse format
-2. **Dependency Injection**: Gateway instantiates PolicyExecutor and ClientFormatter, injects into PolicyOrchestrator
-3. **Explicit Queues**: Typed queues (`Queue[ModelResponse]`, `Queue[str]`) define clear data contracts
-4. **Context Threading**: `ObservabilityContext` and `PolicyContext` created at gateway, passed through entire lifecycle
-5. **Bounded Queues**: maxsize=10000 with 30s timeout on put() operations (circuit breaker)
-6. **Separation of Concerns**: Keepalive in PolicyExecutor (not PolicyContext), policies are stateless hooks
-
-### Why This Architecture
-
-**Simplified from original 3-stage plan**: Discovered LiteLLM provides ModelResponse, eliminating need for CommonFormatter stage.
-
-**Benefits**:
-- Clear data flow visible in code structure
-- Type safety at queue boundaries
-- Easy to test each stage in isolation
-
-- ~200 lines of unnecessary code eliminated
-
-**Files**:
-- `orchestration/policy_orchestrator.py` - orchestration (~30 lines)
-- `streaming/policy_executor/` - block assembly + policy hooks (55 tests)
-- `streaming/client_formatter/` - SSE conversion (12 tests)
-- `policy_core/policy_context.py` - per-request state (transaction_id + scratchpad)
+Do not trust older notes that describe a `PolicyOrchestrator` + `PolicyExecutor` + `ClientFormatter` + `Queue[ModelResponse]` pipeline or a separate `orchestration/` / `streaming/` package — those modules do not exist in the current codebase. When in doubt, read `src/luthien_proxy/pipeline/anthropic_processor.py` directly; `ARCHITECTURE.md` also describes the flow but has known staleness (tracked separately on Trello).
 
 ---
 

--- a/dev/context/codebase_learnings.md
+++ b/dev/context/codebase_learnings.md
@@ -29,7 +29,7 @@ Integrated single-process gateway. Authoritative module map and request lifecycl
   - `on_anthropic_request(request, context) -> AnthropicRequest`
   - `on_anthropic_response(response, context) -> AnthropicResponse`
   - `on_anthropic_stream_event(event, context) -> list[MessageStreamEvent]`
-  - `on_anthropic_stream_complete(context) -> list[MessageStreamEvent]`
+  - `on_anthropic_stream_complete(context) -> list[AnthropicPolicyEmission]` — where `AnthropicPolicyEmission = AnthropicResponse | MessageStreamEvent`, so tail emissions can include a non-streaming response object, not only stream events.
 - Policies never see the IO layer directly. The executor wraps the backend in `_AnthropicPolicyIO` (implementing `AnthropicPolicyIOProtocol`) and calls `io.stream(request)` or `io.complete(request)` exactly once per request based on the incoming `stream` flag.
 
 ## Key Patterns (2025-10-24)
@@ -82,7 +82,7 @@ Three test tiers with increasing infrastructure requirements:
 
 ## Streaming Pipeline (2026-04-10)
 
-Anthropic streaming lives inside `src/luthien_proxy/pipeline/anthropic_processor.py`. The gateway calls `AnthropicClient.stream(...)` (Anthropic SDK), hands the async iterator to an execution-interface policy, and the policy emits `RawMessageStreamEvent`s that the processor forwards as SSE to the client. Policies implement `AnthropicExecutionInterface.run_anthropic(io, context)` and use the `io` surface to call `io.stream()` / `io.complete()` zero or more times.
+Anthropic streaming lives inside `src/luthien_proxy/pipeline/anthropic_processor.py`. The executor (`_run_policy_hooks`) owns the backend call: it calls `io.stream(request)` on the `_AnthropicPolicyIO` helper, which invokes `AnthropicClient.stream(...)` (Anthropic SDK), and then iterates the resulting async stream. For each backend event it invokes `policy.on_anthropic_stream_event(event, context)`, which returns zero or more `MessageStreamEvent` values to emit downstream; after the backend stream is exhausted it calls `policy.on_anthropic_stream_complete(context)` to pick up any tail emissions. The processor serializes each emitted event with `_format_sse_event` and yields it to the client as SSE. Policies never see the IO layer directly — they only implement hooks.
 
 Do not trust older notes that describe a `PolicyOrchestrator` + `PolicyExecutor` + `ClientFormatter` + `Queue[ModelResponse]` pipeline or a separate `orchestration/` / `streaming/` package — those modules do not exist in the current codebase. When in doubt, read `src/luthien_proxy/pipeline/anthropic_processor.py` directly; `ARCHITECTURE.md` also describes the flow but has known staleness (tracked separately on Trello).
 

--- a/dev/context/codebase_learnings.md
+++ b/dev/context/codebase_learnings.md
@@ -43,14 +43,16 @@ Integrated single-process gateway. Authoritative module map and request lifecycl
 
 LiteLLM is NOT on the main request path. Anthropic `/v1/messages` traffic is handled by `AnthropicClient` (Anthropic SDK) in `pipeline/anthropic_processor.py`, and the processor never imports `litellm`.
 
-Current imports of `litellm` in `src/luthien_proxy/`:
+Current references to LiteLLM in `src/luthien_proxy/`:
 
-- `llm/judge_client.py` — wraps `litellm.acompletion` for judge-LLM calls.
-- `policies/simple_llm_utils.py` and `policies/tool_call_judge_utils.py` — call `acompletion` directly for judge decisions (these are the underlying utilities for `SimpleLLMPolicy` and `ToolCallJudgePolicy`).
-- `main.py` — sets `litellm.drop_params = True` once at startup so judge calls tolerate unknown kwargs.
-- `admin/routes.py` — reads `litellm.anthropic_models` to list available Claude models in the admin UI.
-- `exceptions.py` — `map_litellm_error_type()` maps litellm exception classes onto `BackendAPIError` codes for judge-path errors.
-- `config_fields.py` / `settings.py` — retain `litellm_master_key` as a legacy fallback when resolving judge API keys.
+- **Direct imports** (`import litellm` / `from litellm import ...`):
+  - `llm/judge_client.py` — wraps `litellm.acompletion` for judge-LLM calls.
+  - `policies/simple_llm_utils.py` and `policies/tool_call_judge_utils.py` — call `acompletion` directly for judge decisions (these are the underlying utilities for `SimpleLLMPolicy` and `ToolCallJudgePolicy`).
+  - `main.py` — sets `litellm.drop_params = True` once at startup so judge calls tolerate unknown kwargs.
+  - `admin/routes.py` — reads `litellm.anthropic_models` to list available Claude models in the admin UI.
+- **Indirect references** (no `import litellm`, but tied to the judge path):
+  - `exceptions.py` — `map_litellm_error_type()` maps LiteLLM exception **class names** onto `BackendAPIError` codes via string lookup (`type(exception).__name__`).
+  - `config_fields.py` / `settings.py` — retain `litellm_master_key` as a legacy fallback when resolving judge API keys (env var name only; no module import).
 
 **Key rule**: Do not introduce new LiteLLM imports from gateway request processing, streaming, or the `pipeline/` package. Judge-LLM calls (and the startup/admin touches listed above) are the only supported entry points today.
 

--- a/dev/context/codebase_learnings.md
+++ b/dev/context/codebase_learnings.md
@@ -29,7 +29,7 @@ Integrated single-process gateway. Authoritative module map and request lifecycl
   - `on_anthropic_request(request, context) -> AnthropicRequest`
   - `on_anthropic_response(response, context) -> AnthropicResponse`
   - `on_anthropic_stream_event(event, context) -> list[MessageStreamEvent]`
-  - `on_anthropic_stream_complete(context) -> list[AnthropicPolicyEmission]` — where `AnthropicPolicyEmission = AnthropicResponse | MessageStreamEvent`, so tail emissions can include a non-streaming response object, not only stream events.
+  - `on_anthropic_stream_complete(context) -> list[AnthropicPolicyEmission]` — where `AnthropicPolicyEmission = AnthropicResponse | MessageStreamEvent`. The type union is wide, but `_handle_execution_streaming` raises `TypeError` if a policy tries to emit an `AnthropicResponse` on the streaming path (and `_handle_execution_non_streaming` rejects stream events symmetrically), so in practice this hook should only yield `MessageStreamEvent`s.
 - Policies never see the IO layer directly. The executor wraps the backend in `_AnthropicPolicyIO` (implementing `AnthropicPolicyIOProtocol`) and calls `io.stream(request)` or `io.complete(request)` exactly once per request based on the incoming `stream` flag.
 
 ## Key Patterns (2025-10-24)

--- a/dev/context/decisions.md
+++ b/dev/context/decisions.md
@@ -22,9 +22,9 @@ If updating existing content significantly, note it: `## Topic (2025-10-08, upda
 
 ---
 
-## V2 Architecture: Integrated Gateway (2025-10-24)
+## Integrated Gateway (2025-10-24)
 
-**Decision**: Replace separate litellm-proxy + control-plane services with single integrated V2 gateway.
+**Decision**: Replace the previous two-process architecture (a separate LiteLLM proxy plus a control-plane service) with a single integrated gateway.
 
 **Rationale**:
 - **Simpler deployment**: One service instead of two, easier to reason about
@@ -107,34 +107,9 @@ The V2 architecture supports this range:
 
 This is infrastructure-first: AI Control is an important use case, not the defining architecture.
 
-## Streaming Pipeline: Queue-Based Architecture (2025-11-05)
+## Streaming Pipeline: Queue-Based Architecture (2025-11-05, superseded 2026-04-10)
 
-**Decision**: Refactor streaming pipeline from implicit callback-based to explicit queue-based architecture with dependency injection.
-
-**Rationale**:
-- **Explicit data flow**: Clear pipeline stages with typed queues make architecture obvious from code
-- **Testability**: Each stage (PolicyExecutor, ClientFormatter) can be tested in isolation
-- **Type safety**: Explicit `Queue[ModelResponse]` and `Queue[str]` types catch errors early
-- **Separation of concerns**: Policy logic separate from streaming mechanics
-- **Debuggability**: Can inspect queue states, add recording at boundaries
-
-**Key insight**: LiteLLM already provides ModelResponse format from backends, so no ingress formatting needed. This simplified original 3-stage plan to 2 stages.
-
-**Architecture**:
-```
-PolicyExecutor: AsyncIterator[ModelResponse] → Queue[ModelResponse]
-ClientFormatter: Queue[ModelResponse] → Queue[str]
-```
-
-**Trade-offs accepted**:
-- More verbose setup (dependency injection) vs. simpler implicit flow
-- Queue memory overhead vs. backpressure control (bounded queues mitigate this)
-
-**Benefits realized**:
-- Removed ~200 lines of unnecessary CommonFormatter code
-- PolicyOrchestrator simplified to ~30 lines
-- 67 new unit tests added (pipeline is well-tested)
-- All 309 existing tests continue passing
+**Historical only.** This entry described a short-lived two-stage queue pipeline (`PolicyExecutor` → `Queue[ModelResponse]` → `ClientFormatter` → `Queue[str]`) built around LiteLLM's `ModelResponse` type. That design was removed when the gateway moved to direct Anthropic SDK usage. The current Anthropic streaming path lives in `src/luthien_proxy/pipeline/anthropic_processor.py` and uses `AnthropicClient` + `AnthropicExecutionInterface`; there is no `orchestration/` or `streaming/` package. Read the processor module for the up-to-date flow.
 
 ## Context Threading Pattern (2025-11-05)
 
@@ -236,13 +211,8 @@ orchestrator.process_streaming_response(stream, obs_ctx, policy_ctx)
 
 **Rationale**:
 - **Signal-to-noise**: Public repo should help contributors understand the codebase, not internal planning
-- **Industry norm**: LiteLLM uses GitHub Issues/Projects for planning, not in-repo docs
+- **Industry norm**: Many OSS projects (e.g., LiteLLM) keep planning in GitHub Issues/Projects rather than in-repo docs
 - **Focus**: Developers cloning the repo need implementation context, not product strategy
-
-**How LiteLLM handles this** (for reference):
-- Planning in GitHub Issues and Projects
-- README + docs/ for public technical docs
-- No in-repo planning docs or user stories
 
 ---
 
@@ -334,7 +304,7 @@ orchestrator.process_streaming_response(stream, obs_ctx, policy_ctx)
 **Decision**: Use an explicit allowlist (`_REQUEST_PARAM_ALLOWLIST`) when passing request parameters to the conversation viewer frontend, rather than excluding known-sensitive fields.
 
 **Rationale**:
-- A blocklist (`if k not in ("messages", "system")`) forwards every unknown field — any new field added to the request pipeline (by policies, LiteLLM, or the Anthropic API) is automatically leaked to the browser.
+- A blocklist (`if k not in ("messages", "system")`) forwards every unknown field — any new field added to the request pipeline (by policies or the Anthropic API) is automatically leaked to the browser.
 - An allowlist (`model`, `max_tokens`, `stream`, `temperature`, `top_p`, `top_k`, `stop_sequences`, `output_config`) only passes explicitly approved fields.
 - `output_config` is further sanitized to only include `format.type` (not the full JSON schema body, which may contain proprietary structure).
 

--- a/dev/context/gotchas.md
+++ b/dev/context/gotchas.md
@@ -7,13 +7,12 @@ If updating existing content significantly, note it: `## Topic (2025-10-08, upda
 
 ---
 
-## Testing (2025-10-08, updated 2025-10-24)
+## Testing (2025-10-08, updated 2026-04-10)
 
 - E2E tests (`pytest -m e2e`) are SLOW - use sparingly, prefer unit tests for rapid iteration
 - Always run `./scripts/dev_checks.sh` before committing - formats, lints, type-checks, and tests
 - **OTel disabled in tests**: Set `OTEL_ENABLED=false` in test environment to avoid connection errors to Tempo endpoint. Module-level `tracer = trace.get_tracer()` calls trigger OTel initialization at import time.
-- **LiteLLM type warnings**: When working with `ModelResponse`, use proper typed objects (`Choices`, `StreamingChoices`, `Message`, `Delta`) to avoid Pydantic serialization warnings from LiteLLM's `Union` types. See test fixtures for examples.
-- **E2E tests**: E2E tests remain (test_gateway_matrix.py, test_streaming_chunk_structure.py).
+- **LiteLLM type warnings (judge policies only)**: `judge_client.judge_completion` and the judge-side utilities in `simple_llm_utils.py` / `tool_call_judge_utils.py` still call `litellm.acompletion` and receive `ModelResponse`. When constructing judge-call fixtures, use proper typed objects (`Choices`, `Message`) to avoid Pydantic serialization warnings. The main gateway request path is Anthropic-SDK-only and does not touch these types.
 
 ## Docker Development (2025-10-08, updated 2026-02-03)
 
@@ -28,11 +27,12 @@ If updating existing content significantly, note it: `## Topic (2025-10-08, upda
 - Uses OpenTelemetry for observability - see `dev/observability.md` and `dev/VIEWING_TRACES_GUIDE.md`
 - Live activity monitoring available at `/history` on the gateway
 
-## Documentation Structure (2025-10-10, updated 2025-11-11)
+## Documentation Structure (2025-10-10, updated 2026-04-10)
 
-- **Active docs**: dev/REQUEST_PROCESSING_ARCHITECTURE.md, dev/observability.md, dev/VIEWING_TRACES_GUIDE.md
-- **Common places to check**: README.md, CLAUDE.md, dev planning docs, inline code comments
-- **Streaming behavior**: Emits conversation events via `storage/events.py` using background queue for non-blocking persistence
+- **Start with code**: For anything load-bearing, read the module in `src/luthien_proxy/` — architecture documents lag.
+- **Canonical docs**: `ARCHITECTURE.md` (has known staleness tracked on Trello), `dev-README.md`, inline docstrings.
+- **Common places to check**: README.md, CLAUDE.md, inline code comments.
+- **Streaming behavior**: Emits conversation events via `storage/events.py` using a background queue for non-blocking persistence.
 
 ## Queue Shutdown for Stream Termination (2025-01-20, updated 2025-10-20)
 
@@ -73,66 +73,20 @@ See `SimplePolicy.on_stream_complete()` for the pattern.
 - **Right**: `claude -p "run echo hello"` - uses default tool set including Bash
 - **Why**: The `--tools` flag with permission patterns appears to filter the tool list differently than expected. When testing Claude Code through the gateway, omit `--tools` to get the full default tool set.
 
-## Image/Multimodal Handling Through Proxy (2025-12-15)
+## Image/Multimodal Handling Through Proxy (2025-12-15, note 2026-04-10)
 
 **Gotcha**: Images pass validation after PR #104 fix, but Claude may respond to wrong image content.
 
 - **Fixed (PR #104)**: Validation error - changed `Request.messages` to `list[dict[str, Any]]`, added image block conversion
-- **Still broken**: Claude sometimes describes wrong image - suspect LiteLLM→Anthropic conversion issue
+- **Still broken**: Claude sometimes describes wrong image
 - **Tracking**: Issue #108 has full troubleshooting logs
+- **Stale caveat**: The original note attributed this to a "LiteLLM→Anthropic conversion issue" from an older architecture where the gateway went through LiteLLM. The Anthropic path no longer uses LiteLLM, so the root cause needs to be re-investigated if this still reproduces.
 
-## Thinking Blocks Must Come First in Anthropic Responses (2026-01-14)
+## Extended Thinking Blocks (2026-01-14, superseded 2026-04-10)
 
-- Anthropic API requires `thinking`/`redacted_thinking` blocks BEFORE text content
-- LiteLLM exposes these via `message.thinking_blocks` (list of dicts)
-- Wrong order causes: `Expected 'thinking' or 'redacted_thinking', but found 'text'`
+**Historical only.** Earlier notes in this section described thinking-block handling from the era when the gateway ran backend calls through LiteLLM and had to untangle `thinking_blocks` / `reasoning_content` / `signature_delta` ordering, along with referenced modules (`anthropic_sse_assembler.py`, `response_normalizer.py`, `litellm_client.py`, `litellm_test_utils.py`) that no longer exist. The current Anthropic path uses the Anthropic SDK directly and consumes `MessageStreamEvent` values (from `anthropic.lib.streaming`) unmodified, so those workarounds do not apply. If thinking-block ordering bugs resurface, re-investigate against `pipeline/anthropic_processor.py` and the SDK event types rather than the old LiteLLM behavior.
 
-## Thinking Blocks in Multi-Turn Conversations (2026-01-24)
-
-**Gotcha**: Extended thinking requires fixes at THREE layers - streaming, format conversion, AND request validation.
-
-1. **Streaming assembler** must recognize `reasoning_content` and `thinking_blocks` from LiteLLM
-2. **Format conversion** (`anthropic_to_openai_request`) must preserve thinking blocks in message history - they were silently dropped!
-3. **Pydantic validation** must allow list content in `AssistantMessage` - OpenAI types don't natively support thinking blocks
-
-**Symptoms by layer**:
-- Layer 1 missing: Single-turn works, but no thinking content visible
-- Layer 2 missing: 500 error from Anthropic: `"Expected 'thinking' or 'redacted_thinking', but found 'text'"`
-- Layer 3 missing: 400 error from proxy: `"AssistantMessage.content: Input should be a valid string"`
-
-**Files involved**: `anthropic_sse_assembler.py`, `llm_format_utils.py`, `types/anthropic.py`, `types/openai.py`
-
-## LiteLLM Delivers Thinking Signatures Out of Order (2026-01-24)
-
-**Gotcha**: LiteLLM sends `signature_delta` AFTER text content starts, but Anthropic requires it BEFORE the thinking block closes.
-
-**Expected order** (Anthropic native):
-1. thinking_deltas → 2. signature_delta → 3. content_block_stop → 4. text starts
-
-**LiteLLM actual order**:
-1. thinking_deltas → 2. text starts → 3. signature_delta (too late!)
-
-**Fix**: Delay `content_block_stop` for thinking blocks until signature arrives. Track `thinking_block_needs_close` flag and `last_thinking_block_index`.
-
-## LiteLLM >= 1.81.0 Breaking Changes in Streaming (2026-01-29)
-
-**Gotcha**: litellm 1.81.0+ introduced breaking changes in streaming response handling.
-
-**Breaking changes**:
-1. `StreamingChoices.delta` returns a `dict` instead of a `Delta` object
-2. `finish_reason` defaults to `"stop"` instead of `None` for intermediate chunks
-3. `StreamingChoices` passed to `ModelResponse` may get converted to `Choices`
-
-**Fix**: Use `response_normalizer.py` to normalize all streaming chunks:
-- `normalize_chunk()` - converts dict deltas to `Delta` objects
-- `normalize_chunk_with_finish_reason()` - also restores intended `finish_reason`
-- `normalize_stream()` - wraps async streams to normalize each chunk
-
-**Where normalization happens**:
-- `litellm_client.py` calls `normalize_stream()` on raw litellm output
-- Downstream code should receive already-normalized chunks
-
-**Test helpers**: Use `litellm_test_utils.make_streaming_chunk()` to create normalized chunks for tests.
+Still relevant from that era: the **Anthropic API invariant** that all content-block events must complete before `message_delta` (see "Anthropic Streaming: All Content Blocks Must Precede message_delta" below) and the general requirement that `thinking` / `redacted_thinking` blocks appear before plain text in an assistant message.
 
 ## Content and finish_reason Must Be in Separate Chunks (2026-01-30)
 
@@ -183,7 +137,7 @@ if stream_state.finish_reason:
 2. **Compare streaming chunks**: Enable debug logging to see each SSE chunk as it flows through pipeline
 3. **Isolate the layer**: Is it request conversion? Response assembly? Policy transformation?
 4. **Reproduce minimally**: Strip the request down to simplest failing case
-5. **Check LiteLLM version**: Breaking changes in LiteLLM streaming have caused issues (see litellm >= 1.81.0 gotcha)
+5. **Check the Anthropic SDK version**: Gateway request processing is SDK-direct. If upstream stream events change shape, `pipeline/anthropic_processor.py` is where the breakage will surface. LiteLLM is only used inside judge policies and is isolated from the main request path.
 
 **Tools available**:
 - History/Conversation view: `/history` - conversation sessions and live details

--- a/dev/context/streaming_response_structures.md
+++ b/dev/context/streaming_response_structures.md
@@ -1,7 +1,7 @@
 # Streaming Response Structures
 
-**Date**: 2025-10-23
-**Testing**: Live responses from Claude Sonnet 4 and GPT-4o-mini via LiteLLM
+**Date**: 2025-10-23 (historical capture)
+**Testing**: Live responses from Claude Sonnet 4 and GPT-4o-mini, captured when the gateway still routed backend calls through LiteLLM. The observed chunk shapes and ordering invariants are still useful as reference, but note that the current Anthropic path uses the Anthropic SDK directly and produces `MessageStreamEvent` values (from `anthropic.lib.streaming`) rather than the OpenAI-style `ModelResponse` chunks shown below.
 **Data**: See `/tmp/*_chunks.json` from `scripts/test_response_structures.py`
 
 ## Executive Summary


### PR DESCRIPTION
## Summary

- Scrub stale LiteLLM-era content from agent context docs (`dev/context/*.md`) and rewrite `dev/REQUEST_PROCESSING_ARCHITECTURE.md` against the current `pipeline/anthropic_processor.py`.
- Correct the Anthropic runtime description: the current `AnthropicExecutionInterface` is hook-based (`on_anthropic_request` / `on_anthropic_response` / `on_anthropic_stream_event` / `on_anthropic_stream_complete`), the executor owns backend I/O, and policies do not see the IO layer directly. Earlier notes claimed `run_anthropic(io, context)` which does not exist.
- Remove references to non-existent modules (`PolicyOrchestrator`, `PolicyExecutor`, `ClientFormatter`, `orchestration/`, `streaming/`, `anthropic_sse_assembler.py`, `response_normalizer.py`, `litellm_client.py`, `litellm_test_utils.py`).
- Scope remaining LiteLLM references explicitly to the judge-LLM path (`llm/judge_client.py`, `policies/simple_llm_utils.py`, `policies/tool_call_judge_utils.py`) plus the limited startup / admin / exception-mapping touches — all verified against the source.
- Mark the LiteLLM-era thinking-block gotchas and queue-based streaming pipeline decision as historical rather than deleting them, so the rationale is still recoverable.

## Incidental fix (one concern carve-out)

- Regenerate `.env.example`, which was committed empty on main in 1b28e4d5 ('fix: propagate CLI overrides to env'). The `dev_checks.sh` clean-tree gate runs `generate_env_example.py` and then checks for uncommitted changes, so every PR branched from main is currently red on that gate. This PR restores the 150-line generated file as a separate prep commit so its own CI can pass. Followup tracked on Trello: https://trello.com/c/hZLATRuZ

## Out of scope (filed as separate tickets already)

- ARCHITECTURE.md rewrite (Trello 69d85b641c6fe0510dd5c015)
- CLAUDE.md project-structure refresh (Trello 69d85b9714f2c135a603e6ec)
- Full LiteLLM dependency removal — separate open PR #441

## Test plan

- [x] `scripts/dev_checks.sh` passes on clean tree (format, lint, type check, unit tests)
- [x] Every LiteLLM reference left in `dev/context/` and `dev/REQUEST_PROCESSING_ARCHITECTURE.md` was verified against the current source
- [x] New REQUEST_PROCESSING_ARCHITECTURE.md claims cross-checked against `pipeline/anthropic_processor.py` (`_run_policy_hooks`, `_execute_anthropic_policy`, `_handle_execution_streaming`, `_handle_execution_non_streaming`, span hierarchy)

---
*Posted by Claude Code (claude-opus-4-6[1m])*

🤖 Generated with [Claude Code](https://claude.com/claude-code)