### PR TITLE
fix: use Enum.value in generated .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@
 # ADMIN_API_KEY=
 
 # Authentication mode: proxy_key, passthrough, or both (managed via /api/admin/auth/config)
-# AUTH_MODE=AuthMode.BOTH
+# AUTH_MODE=both
 
 # Skip authentication for requests from localhost
 # (can also be set at runtime via admin API)

--- a/changelog.d/fix-enum-env-example.md
+++ b/changelog.d/fix-enum-env-example.md
@@ -1,0 +1,6 @@
+---
+category: Fixes
+pr: 534
+---
+
+**Enum defaults in generated `.env.example`**: `AuthMode(str, Enum)` fields rendered as `AuthMode.BOTH` instead of `both` because `Enum.__str__` wins over `str.__str__`. The generator now explicitly unwraps `Enum` defaults via `.value`, and a regression test guards the behavior.

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -6,6 +6,7 @@ Usage:
 """
 
 import sys
+from enum import Enum
 from pathlib import Path
 
 # Add src to path so we can import config_fields when run as a script
@@ -62,9 +63,17 @@ def build_env_example_text() -> str:
                 lines.append(f"# (default derived from {symbol} at startup)")
                 lines.append(f"# {meta.env_var}=")
             else:
-                default_str = "" if meta.default is None else str(meta.default)
-                if isinstance(meta.default, bool):
+                if meta.default is None:
+                    default_str = ""
+                elif isinstance(meta.default, bool):
                     default_str = str(meta.default).lower()
+                elif isinstance(meta.default, Enum):
+                    # `(str, Enum)` subclasses stringify to "ClassName.MEMBER",
+                    # not the underlying value — use `.value` explicitly so the
+                    # generated example round-trips through the env parser.
+                    default_str = str(meta.default.value)
+                else:
+                    default_str = str(meta.default)
                 lines.append(f"# {meta.env_var}={default_str}")
             lines.append("")
 

--- a/tests/luthien_proxy/unit_tests/test_config_registry.py
+++ b/tests/luthien_proxy/unit_tests/test_config_registry.py
@@ -446,6 +446,29 @@ class TestConfigFieldsCompleteness:
             f"Duplicate env vars: {[v for v in env_vars if env_vars.count(v) > 1]}"
         )
 
+    def test_generator_uses_enum_value_not_repr(self):
+        """Enum defaults must serialize to their .value, not ClassName.MEMBER.
+
+        Regression guard: `AuthMode(str, Enum)` previously rendered as
+        `AUTH_MODE=AuthMode.BOTH` because `str(meta.default)` hits Enum's
+        __str__ before str's, producing an invalid default value.
+        """
+        from luthien_proxy.credential_manager import AuthMode
+
+        auth_meta = CONFIG_FIELDS_BY_NAME["auth_mode"]
+        assert isinstance(auth_meta.default, AuthMode)
+
+        repo_root = Path(__file__).resolve().parents[3]
+        generator_path = repo_root / "scripts" / "generate_env_example.py"
+        spec = importlib.util.spec_from_file_location("_generate_env_example", generator_path)
+        assert spec is not None and spec.loader is not None
+        generator = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(generator)
+        text = generator.build_env_example_text()
+
+        assert f"# {auth_meta.env_var}={auth_meta.default.value}" in text
+        assert "AuthMode.BOTH" not in text
+
     def test_env_example_matches_generator(self):
         """The .env.example about to land in a commit must match the generator.
 


### PR DESCRIPTION
## Summary

`AuthMode(str, Enum)` defaults were rendering as `AUTH_MODE=AuthMode.BOTH` in `.env.example` because `Enum.__str__` takes precedence over `str.__str__` for `(str, Enum)` subclasses (this would only work automatically for `StrEnum`). Uncommenting that line would feed an invalid value to the coercer.

`scripts/generate_env_example.py` now explicitly unwraps `Enum` defaults via `.value`, matching how the config registry already parses the env var on load.

## Changes

- `scripts/generate_env_example.py` — special-case `Enum` defaults (use `.value`); refactor the default-stringification into a clean `if/elif` ladder.
- `.env.example` — regenerate; `AUTH_MODE` line now reads `# AUTH_MODE=both`.
- `tests/luthien_proxy/unit_tests/test_config_registry.py` — add regression test `test_generator_uses_enum_value_not_repr` that asserts `AuthMode.BOTH` never appears in the generated text.

## Context

Found during review of #528 (ARCHITECTURE.md rewrite), which was the first PR to actually commit a regenerated `.env.example` and thereby expose the latent generator bug. Split out per "One PR = One Concern" — #528 will rebase on top once this merges.

## Test plan

- [x] `uv run pytest tests/luthien_proxy/unit_tests/test_config_registry.py` — 43 passed
- [x] `./scripts/dev_checks.sh` — clean
- [x] Manually verified `grep AUTH_MODE .env.example` shows `# AUTH_MODE=both`

---
*Posted by Claude Code (claude-opus-4-6)*