### PR TITLE
feat: supply chain advisory policy (narrow scope)

### DIFF
--- a/changelog.d/supply-chain-advisory.md
+++ b/changelog.d/supply-chain-advisory.md
@@ -1,0 +1,10 @@
+---
+category: Features
+---
+
+**SupplyChainAdvisoryPolicy**: Best-effort CVE warning for cooperative LLMs.
+  - Loose-regex extraction of `pip|uv|poetry|pipenv|conda|npm|yarn|pnpm|bun install/add` commands from outgoing Bash tool_use blocks and incoming tool_result text.
+  - Concurrent OSV.dev lookups (capped by semaphore) with DB-backed caching of positive and negative results.
+  - Injects an advisory text block alongside the original tool_use when any referenced package has a HIGH+ severity advisory; existing system prompt is preserved.
+  - Threshold configurable via `advisory_severity_threshold` (default `HIGH`); `hard_block_versions` is reserved for a future release and rejected if set.
+  - **Non-goals**: this is NOT a security boundary. It does not parse `sh -c`, chain operators, `eval`, base64, or any other obfuscation. Run OSV-Scanner inside the sandbox for hardened supply-chain defense.

--- a/config/policy_config.yaml
+++ b/config/policy_config.yaml
@@ -39,3 +39,19 @@ policy:
 #     # judge_instructions: "You are a security analyst. Evaluate tool calls for risk..."
 #     # Optional: Customize blocked message template
 #     # Variables: {tool_name}, {tool_arguments}, {probability}, {explanation}
+
+# Supply Chain Advisory Policy - warn (do NOT block) on known-vulnerable
+# packages in pip/npm/poetry/uv/etc. install commands and tool_result output.
+# Best-effort CVE warning for cooperative LLMs only — NOT a security boundary
+# (does not parse `sh -c`, chained commands, eval, etc.). Run OSV-Scanner
+# inside the sandbox for hardened supply-chain defense.
+# policy:
+#   class: "luthien_proxy.policies.supply_chain_advisory_policy:SupplyChainAdvisoryPolicy"
+#   config:
+#     advisory_severity_threshold: "HIGH"  # LOW | MEDIUM | HIGH | CRITICAL
+#     warn_on_osv_error: true              # inject "OSV unreachable" advisories
+#     max_concurrent_lookups: 10
+#     cache_ttl_seconds: 86400             # 1 day for successful lookups
+#     error_cache_ttl_seconds: 60          # 1 minute for failed lookups
+#     bash_tool_names: ["Bash"]
+#     # hard_block_versions: []            # reserved for a future release

--- a/src/luthien_proxy/policies/supply_chain_advisory_policy.py
+++ b/src/luthien_proxy/policies/supply_chain_advisory_policy.py
@@ -1,0 +1,563 @@
+"""SupplyChainAdvisoryPolicy — warn on known-vulnerable package installs.
+
+This is a **best-effort CVE advisory policy for cooperative LLMs**. It is
+NOT a security boundary and is NOT designed to resist an adversarial LLM
+obfuscating install commands (e.g. ``sh -c``, chain operators, ``eval``,
+base64 decoding, or non-standard package managers). Its purpose is to
+warn a cooperative LLM — and through it, the user — when a
+known-compromised package version (CVSS severity >= HIGH by default) is
+about to be installed or is already present in tool output. For hardened
+supply-chain defence, run OSV-Scanner inside the sandbox at install time.
+
+Threat model
+------------
+The real-world cases this policy addresses are recent incidents (litellm,
+axios) where a CVE was public but the poisoned version was still
+installable because the registry had not yanked it yet. The LLM is
+cooperative — it is not trying to sneak anything past the policy — it's
+just as blind to the CVE as the user. A loose regex over the outgoing
+command is enough to catch the common case, and false negatives from
+exotic command shapes are acceptable: they're simply outside scope.
+
+Hooks
+-----
+- ``on_anthropic_request``: scans ``tool_result`` blocks in the latest
+  user message for already-installed vulnerable versions (``pip freeze``,
+  ``npm ls``, ``cat package.json`` output) and prepends an advisory to
+  the system prompt.
+- ``on_anthropic_stream_event``: buffers ``Bash`` tool_use blocks until
+  the input JSON is complete, runs the advisory scan, and emits an
+  advisory text block alongside the original tool_use when flagged.
+- ``on_anthropic_response`` (non-streaming): same as the stream path but
+  applied to an already-complete response.
+
+OSV lookup results are cached via ``context.policy_cache`` when a cache
+factory is available, falling back to no-cache otherwise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, cast
+
+from anthropic.lib.streaming import MessageStreamEvent
+from anthropic.types import (
+    InputJSONDelta,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    TextBlock,
+    TextDelta,
+    ToolUseBlock,
+)
+
+from luthien_proxy.policies.supply_chain_advisory_utils import (
+    OSVClient,
+    PackageCheckResult,
+    PackageRef,
+    Severity,
+    SupplyChainAdvisoryConfig,
+    VulnInfo,
+    extract_install_packages,
+    extract_tool_result_packages,
+    format_advisory_message,
+    redact_credentials,
+)
+from luthien_proxy.policy_core import AnthropicHookPolicy, BasePolicy
+from luthien_proxy.policy_core.anthropic_execution_interface import AnthropicPolicyEmission
+
+if TYPE_CHECKING:
+    from luthien_proxy.llm.types.anthropic import (
+        AnthropicContentBlock,
+        AnthropicMessage,
+        AnthropicRequest,
+        AnthropicResponse,
+        AnthropicSystemBlock,
+        AnthropicToolResultBlock,
+        AnthropicToolUseBlock,
+    )
+    from luthien_proxy.policy_core.policy_context import PolicyContext
+    from luthien_proxy.utils.policy_cache import PolicyCache
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _BufferedBashToolUse:
+    """A tool_use block we've started buffering during streaming."""
+
+    id: str
+    name: str
+    input_json: str = ""
+
+
+@dataclass
+class _AdvisoryState:
+    """Per-request streaming state."""
+
+    buffered_tool_uses: dict[int, _BufferedBashToolUse] = field(default_factory=dict)
+
+
+class SupplyChainAdvisoryPolicy(BasePolicy, AnthropicHookPolicy):
+    """Warn when a Bash command mentions a known-vulnerable package."""
+
+    @property
+    def short_policy_name(self) -> str:
+        """Short human-readable name for the policy."""
+        return "SupplyChainAdvisory"
+
+    def __init__(
+        self,
+        config: SupplyChainAdvisoryConfig | dict | None = None,
+        osv_client: OSVClient | None = None,
+    ) -> None:
+        """Initialize with optional config and an injectable OSV client (tests)."""
+        self.config = self._init_config(config, SupplyChainAdvisoryConfig)
+        self._threshold: Severity = self.config.severity_threshold_enum
+        self._bash_tool_names: frozenset[str] = frozenset(self.config.bash_tool_names)
+        self._osv = osv_client or OSVClient(
+            api_url=self.config.osv_api_url,
+            timeout_seconds=self.config.osv_timeout_seconds,
+        )
+        logger.info(
+            "SupplyChainAdvisoryPolicy initialized: threshold=%s, warn_on_osv_error=%s",
+            self._threshold.label,
+            self.config.warn_on_osv_error,
+        )
+
+    # ========================================================================
+    # State / cache helpers
+    # ========================================================================
+
+    def _state(self, context: "PolicyContext") -> _AdvisoryState:
+        return context.get_request_state(self, _AdvisoryState, _AdvisoryState)
+
+    def _buffered(self, context: "PolicyContext") -> dict[int, _BufferedBashToolUse]:
+        return self._state(context).buffered_tool_uses
+
+    def _cache(self, context: "PolicyContext") -> "PolicyCache | None":
+        if not context.has_policy_cache:
+            return None
+        try:
+            return context.policy_cache(self.short_policy_name)
+        except RuntimeError:
+            return None
+
+    async def _lookup_vulns(
+        self,
+        package: PackageRef,
+        context: "PolicyContext",
+    ) -> tuple[list[VulnInfo], str | None]:
+        """Get vulns for ``package``, using the policy cache when available."""
+        cache = self._cache(context)
+        key = package.cache_key()
+
+        if cache is not None:
+            try:
+                cached = await cache.get(key)
+            except Exception as exc:
+                logger.warning("policy_cache get failed for %s: %s", key, exc)
+                cached = None
+            if cached is not None:
+                cached_error = cached.get("error")
+                if cached_error is not None:
+                    return [], str(cached_error)
+                return [VulnInfo.from_dict(v) for v in cached.get("vulns", [])], None
+
+        try:
+            vulns = await self._osv.query(package)
+        except Exception as exc:
+            logger.warning("OSV query failed for %s: %s", key, exc)
+            if cache is not None and self.config.error_cache_ttl_seconds > 0:
+                try:
+                    await cache.put(
+                        key,
+                        {"error": str(exc), "vulns": []},
+                        ttl_seconds=self.config.error_cache_ttl_seconds,
+                    )
+                except Exception as cache_exc:
+                    logger.warning("policy_cache put (error) failed for %s: %s", key, cache_exc)
+            return [], str(exc)
+
+        if cache is not None:
+            try:
+                await cache.put(
+                    key,
+                    {"vulns": [v.to_dict() for v in vulns]},
+                    ttl_seconds=self.config.cache_ttl_seconds,
+                )
+            except Exception as exc:
+                logger.warning("policy_cache put failed for %s: %s", key, exc)
+
+        return vulns, None
+
+    async def _check_packages(
+        self,
+        packages: list[PackageRef],
+        context: "PolicyContext",
+    ) -> list[PackageCheckResult]:
+        """Look up every package concurrently, capped by the semaphore."""
+        if not packages:
+            return []
+
+        semaphore = asyncio.Semaphore(self.config.max_concurrent_lookups)
+
+        async def bounded(pkg: PackageRef) -> tuple[list[VulnInfo], str | None]:
+            async with semaphore:
+                return await self._lookup_vulns(pkg, context)
+
+        # _lookup_vulns swallows its own exceptions and returns them via the
+        # error field, so gather() without return_exceptions is safe.
+        lookups = await asyncio.gather(*(bounded(p) for p in packages))
+        return [
+            PackageCheckResult(package=pkg, vulns=vulns, error=error) for pkg, (vulns, error) in zip(packages, lookups)
+        ]
+
+    def _advisory_results(self, results: list[PackageCheckResult]) -> list[PackageCheckResult]:
+        """Return the subset of results to surface in an advisory."""
+        flagged = [r for r in results if r.has_advisory(self._threshold)]
+        if self.config.warn_on_osv_error:
+            flagged += [r for r in results if r.error and r not in flagged]
+        return flagged
+
+    # ========================================================================
+    # Streaming
+    # ========================================================================
+
+    async def on_anthropic_streaming_policy_complete(self, context: "PolicyContext") -> None:
+        """Drop per-request state when streaming finishes (multi-policy path)."""
+        context.pop_request_state(self, _AdvisoryState)
+
+    async def on_anthropic_stream_complete(self, context: "PolicyContext") -> list[AnthropicPolicyEmission]:
+        """Flush any tool_use blocks still buffered when the upstream stream ends.
+
+        If the stream was truncated mid tool_use we never saw the stop event,
+        so the buffered data never got re-emitted. Emit the raw tool_use
+        events as we have them (no advisory scan is possible without the
+        complete input JSON) so the client still sees a coherent response.
+        """
+        buffered_map = self._buffered(context)
+        if not buffered_map:
+            return []
+        emissions: list[AnthropicPolicyEmission] = []
+        for index, buffered in sorted(buffered_map.items()):
+            logger.warning(
+                "Stream ended with tool_use still buffered (index=%d, id=%s); emitting as-is",
+                index,
+                buffered.id,
+            )
+            emissions.extend(_reemit_tool_use(buffered, index))
+        buffered_map.clear()
+        return emissions
+
+    async def on_anthropic_stream_event(
+        self, event: MessageStreamEvent, context: "PolicyContext"
+    ) -> list[MessageStreamEvent]:
+        """Buffer Bash tool_use blocks until complete and inject an advisory if needed."""
+        if isinstance(event, RawContentBlockStartEvent):
+            return self._handle_block_start(event, context)
+        if isinstance(event, RawContentBlockDeltaEvent):
+            return self._handle_block_delta(event, context)
+        if isinstance(event, RawContentBlockStopEvent):
+            return await self._handle_block_stop(event, context)
+        return [event]
+
+    def _handle_block_start(
+        self, event: RawContentBlockStartEvent, context: "PolicyContext"
+    ) -> list[MessageStreamEvent]:
+        block = event.content_block
+        if isinstance(block, ToolUseBlock) and block.name in self._bash_tool_names:
+            self._buffered(context)[event.index] = _BufferedBashToolUse(id=block.id, name=block.name)
+            return []  # suppress until we've seen the complete input JSON
+        return [event]
+
+    def _handle_block_delta(
+        self, event: RawContentBlockDeltaEvent, context: "PolicyContext"
+    ) -> list[MessageStreamEvent]:
+        buffered = self._buffered(context)
+        if event.index not in buffered:
+            return [event]
+        if isinstance(event.delta, InputJSONDelta):
+            buffered[event.index].input_json += event.delta.partial_json
+            return []
+        # Non-input-json delta at a buffered index shouldn't happen under
+        # the Anthropic protocol; pass it through so we don't silently drop
+        # anything the client might need.
+        logger.warning(
+            "Unexpected delta type %s at buffered index %d; passing through",
+            type(event.delta).__name__,
+            event.index,
+        )
+        return [event]
+
+    async def _handle_block_stop(
+        self, event: RawContentBlockStopEvent, context: "PolicyContext"
+    ) -> list[MessageStreamEvent]:
+        buffered_map = self._buffered(context)
+        if event.index not in buffered_map:
+            return [cast(MessageStreamEvent, event)]
+        buffered = buffered_map.pop(event.index)
+
+        command = _extract_command_from_json(buffered.input_json)
+        advisory_text = await self._advisory_for_command(command, context)
+
+        reemit = _reemit_tool_use(buffered, event.index)
+        reemit.append(cast(MessageStreamEvent, event))
+
+        if advisory_text is None:
+            return reemit
+
+        # Inject a text block BEFORE the tool_use at a lower index so the
+        # LLM sees the advisory before the tool call in the client's view.
+        # The re-emitted tool_use keeps its original index so downstream
+        # tool_result correlation still works.
+        advisory_events = _build_advisory_text_events(advisory_text, index=event.index + 1000)
+        return [*advisory_events, *reemit]
+
+    # ========================================================================
+    # Non-streaming response
+    # ========================================================================
+
+    async def on_anthropic_response(
+        self, response: "AnthropicResponse", context: "PolicyContext"
+    ) -> "AnthropicResponse":
+        """Scan content blocks of a non-streaming response and inject advisory if needed."""
+        content = response.get("content", [])
+        if not content:
+            return response
+
+        new_content: list[AnthropicContentBlock] = []
+        modified = False
+
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                tool_use = cast("AnthropicToolUseBlock", block)
+                if tool_use.get("name") in self._bash_tool_names:
+                    command = _extract_bash_command(tool_use.get("input", {}))
+                    advisory = await self._advisory_for_command(command, context)
+                    if advisory is not None:
+                        new_content.append({"type": "text", "text": advisory})
+                        modified = True
+            new_content.append(block)
+
+        if not modified:
+            return response
+        modified_response = dict(response)
+        modified_response["content"] = new_content
+        return cast("AnthropicResponse", modified_response)
+
+    async def _advisory_for_command(self, command: str | None, context: "PolicyContext") -> str | None:
+        """Check a Bash command for supply-chain advisories and render a warning."""
+        if not command:
+            return None
+        packages = extract_install_packages(command)
+        if not packages:
+            return None
+
+        unique = _dedupe_packages(packages)
+        results = await self._check_packages(unique, context)
+        advisory_subset = self._advisory_results(results)
+        if not advisory_subset:
+            return None
+
+        context.record_event(
+            "policy.supply_chain_advisory.flagged",
+            {
+                "summary": f"Supply chain advisory flagged {len(advisory_subset)} package(s)",
+                "command": redact_credentials(command),
+                "packages": [
+                    {
+                        "ecosystem": r.package.ecosystem,
+                        "name": r.package.name,
+                        "version": r.package.version,
+                        "max_severity": r.max_severity.label,
+                        "error": r.error,
+                    }
+                    for r in advisory_subset
+                ],
+            },
+        )
+        return format_advisory_message(advisory_subset, self._threshold, command=command)
+
+    # ========================================================================
+    # Incoming request: scan tool_results from prior commands
+    # ========================================================================
+
+    async def on_anthropic_request(self, request: "AnthropicRequest", context: "PolicyContext") -> "AnthropicRequest":
+        """Inject a system-prompt advisory when prior tool_results mention vulnerable versions."""
+        messages: list[AnthropicMessage] = list(request.get("messages") or [])
+        if not messages:
+            return request
+
+        last_message = messages[-1]
+        if last_message.get("role") != "user":
+            return request
+
+        tool_result_texts = _collect_tool_result_texts(last_message)
+        if not tool_result_texts:
+            return request
+
+        all_packages: list[PackageRef] = []
+        for text in tool_result_texts:
+            # Install commands could appear in tool results (shell transcripts
+            # pasted back by the user) and fresh "currently installed" output.
+            all_packages.extend(extract_install_packages(text))
+            all_packages.extend(extract_tool_result_packages(text))
+        if not all_packages:
+            return request
+
+        unique = _dedupe_packages(all_packages)
+        results = await self._check_packages(unique, context)
+        advisory_subset = self._advisory_results(results)
+        if not advisory_subset:
+            return request
+
+        warning = format_advisory_message(advisory_subset, self._threshold)
+        modified = dict(request)
+        modified["system"] = _prepend_system_warning(request.get("system"), warning)
+
+        context.record_event(
+            "policy.supply_chain_advisory.incoming_warning",
+            {
+                "summary": f"Detected {len(advisory_subset)} vulnerable package(s) in tool output",
+                "packages": [
+                    {
+                        "ecosystem": r.package.ecosystem,
+                        "name": r.package.name,
+                        "version": r.package.version,
+                        "max_severity": r.max_severity.label,
+                    }
+                    for r in advisory_subset
+                ],
+            },
+        )
+        return cast("AnthropicRequest", modified)
+
+
+# =============================================================================
+# Module-level helpers
+# =============================================================================
+
+
+def _extract_bash_command(tool_input: object) -> str | None:
+    """Pull the ``command`` string out of a Bash tool_use input dict."""
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command")
+        if isinstance(command, str):
+            return command
+    return None
+
+
+def _extract_command_from_json(raw_json: str) -> str | None:
+    """Best-effort parse of a buffered tool_use input JSON."""
+    if not raw_json:
+        return None
+    try:
+        parsed = json.loads(raw_json)
+    except json.JSONDecodeError:
+        return None
+    return _extract_bash_command(parsed)
+
+
+def _dedupe_packages(packages: list[PackageRef]) -> list[PackageRef]:
+    """De-dupe by (ecosystem, name, version), preserving order."""
+    seen: set[tuple[str, str, str | None]] = set()
+    unique: list[PackageRef] = []
+    for pkg in packages:
+        key = (pkg.ecosystem, pkg.name, pkg.version)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(pkg)
+    return unique
+
+
+def _collect_tool_result_texts(message: "AnthropicMessage") -> list[str]:
+    """Return the text contents of every tool_result block in a user message."""
+    content = message.get("content")
+    if not isinstance(content, list):
+        return []
+    texts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") != "tool_result":
+            continue
+        tool_result = cast("AnthropicToolResultBlock", block)
+        texts.extend(_tool_result_text(tool_result))
+    return texts
+
+
+def _tool_result_text(tool_result: "AnthropicToolResultBlock") -> list[str]:
+    """Extract text fragments from a tool_result block.
+
+    Anthropic tool_result content may be a string or a list of content blocks.
+    We collect only text blocks; non-text blocks (images, etc.) can't
+    plausibly contain version info for this best-effort scan.
+    """
+    raw = tool_result.get("content")
+    if isinstance(raw, str):
+        return [raw]
+    if not isinstance(raw, list):
+        return []
+    out: list[str] = []
+    for item in raw:
+        if isinstance(item, dict) and item.get("type") == "text":
+            text = item.get("text")
+            if isinstance(text, str):
+                out.append(text)
+    return out
+
+
+def _prepend_system_warning(
+    existing: "str | list[AnthropicSystemBlock] | None",
+    warning: str,
+) -> "str | list[AnthropicSystemBlock]":
+    """Prepend a warning string to the request's ``system`` field."""
+    if existing is None:
+        return warning
+    if isinstance(existing, str):
+        return f"{warning}\n\n{existing}" if existing else warning
+    warning_block: AnthropicSystemBlock = {"type": "text", "text": warning}
+    return [warning_block, *existing]
+
+
+def _reemit_tool_use(buffered: _BufferedBashToolUse, index: int) -> list[MessageStreamEvent]:
+    """Rebuild the (start, delta) events for a buffered tool_use block.
+
+    Upstream may have sent multiple partial-JSON deltas; we coalesce them
+    into a single delta because we only buffered the accumulated JSON, not
+    the original chunk boundaries. Clients tolerate this.
+    """
+    tool_use_block = ToolUseBlock(type="tool_use", id=buffered.id, name=buffered.name, input={})
+    start_event = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=tool_use_block)
+    delta_event = RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=InputJSONDelta(type="input_json_delta", partial_json=buffered.input_json or "{}"),
+    )
+    return [
+        cast(MessageStreamEvent, start_event),
+        cast(MessageStreamEvent, delta_event),
+    ]
+
+
+def _build_advisory_text_events(text: str, index: int) -> list[MessageStreamEvent]:
+    """Build (start, delta, stop) events for an injected text advisory block."""
+    text_block = TextBlock(type="text", text="")
+    start = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=text_block)
+    delta = RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=TextDelta(type="text_delta", text=text),
+    )
+    stop = RawContentBlockStopEvent(type="content_block_stop", index=index)
+    return [
+        cast(MessageStreamEvent, start),
+        cast(MessageStreamEvent, delta),
+        cast(MessageStreamEvent, stop),
+    ]
+
+
+__all__ = ["SupplyChainAdvisoryPolicy"]

--- a/src/luthien_proxy/policies/supply_chain_advisory_utils.py
+++ b/src/luthien_proxy/policies/supply_chain_advisory_utils.py
@@ -1,0 +1,705 @@
+"""Utilities for SupplyChainAdvisoryPolicy.
+
+This module contains the pure helpers the policy relies on:
+
+- Data types for packages, vulnerabilities, and check results.
+- A deliberately loose regex-based extractor for package install commands.
+- An OSV.dev client that queries for known vulnerabilities.
+- A severity parser that understands CVSS v3 vectors, numeric scores, and
+  qualitative labels, and deliberately fails-safe on CVSS v4 vectors.
+- Credential redaction and prompt-injection-safe summary formatting.
+
+The extractor is best-effort: it recognises the common case of
+``pip install <pkg>==<ver>``/``npm install <pkg>@<ver>``/etc. without
+trying to defeat adversarial obfuscation. See the policy docstring for
+the full threat model.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Any, Final
+
+import httpx
+from pydantic import BaseModel, Field, field_validator
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Types
+# =============================================================================
+
+
+class Severity(IntEnum):
+    """Ordered severity levels. Higher is worse."""
+
+    UNKNOWN = 0
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+    CRITICAL = 4
+
+    @classmethod
+    def from_label(cls, label: str | None) -> "Severity":
+        """Parse a qualitative severity label like ``"HIGH"``."""
+        if not label:
+            return cls.UNKNOWN
+        upper = label.strip().upper()
+        if upper in cls.__members__:
+            return cls[upper]
+        return cls.UNKNOWN
+
+    @classmethod
+    def from_cvss_score(cls, score: float) -> "Severity":
+        """Convert a CVSS numeric score into a qualitative bucket."""
+        if score >= 9.0:
+            return cls.CRITICAL
+        if score >= 7.0:
+            return cls.HIGH
+        if score >= 4.0:
+            return cls.MEDIUM
+        if score > 0.0:
+            return cls.LOW
+        return cls.UNKNOWN
+
+    @property
+    def label(self) -> str:
+        """Human-readable label (``"HIGH"``, ``"CRITICAL"``, ...)."""
+        return self.name
+
+
+@dataclass(frozen=True)
+class PackageRef:
+    """A reference to a single package in a specific ecosystem."""
+
+    ecosystem: str  # OSV ecosystem label, e.g. "PyPI"
+    name: str
+    version: str | None = None
+
+    def cache_key(self) -> str:
+        """Key used for caching this package's OSV lookup result."""
+        version_part = self.version or "*"
+        return f"osv:{self.ecosystem}:{self.name}:{version_part}"
+
+
+@dataclass(frozen=True)
+class VulnInfo:
+    """Summary of a single OSV vulnerability."""
+
+    id: str
+    summary: str
+    severity: Severity
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain JSON-safe dict for caching."""
+        return {"id": self.id, "summary": self.summary, "severity": int(self.severity)}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "VulnInfo":
+        """Rehydrate from a dict previously produced by :meth:`to_dict`."""
+        return cls(
+            id=str(data.get("id", "")),
+            summary=str(data.get("summary", "")),
+            severity=Severity(int(data.get("severity", 0))),
+        )
+
+
+@dataclass
+class PackageCheckResult:
+    """Result of checking one package against OSV."""
+
+    package: PackageRef
+    vulns: list[VulnInfo] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def max_severity(self) -> Severity:
+        """Highest severity among this package's known vulnerabilities."""
+        if not self.vulns:
+            return Severity.UNKNOWN
+        return max((v.severity for v in self.vulns), default=Severity.UNKNOWN)
+
+    def has_advisory(self, threshold: Severity) -> bool:
+        """Whether at least one vuln reaches ``threshold`` severity."""
+        return any(v.severity >= threshold for v in self.vulns)
+
+    def advisory_vulns(self, threshold: Severity) -> list[VulnInfo]:
+        """Return the subset of vulns at or above ``threshold``."""
+        return [v for v in self.vulns if v.severity >= threshold]
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+
+class SupplyChainAdvisoryConfig(BaseModel):
+    """Configuration for SupplyChainAdvisoryPolicy."""
+
+    osv_api_url: str = Field(
+        default="https://api.osv.dev/v1/query",
+        description="OSV.dev query endpoint.",
+    )
+    osv_timeout_seconds: float = Field(
+        default=5.0,
+        description="HTTP timeout for each OSV lookup.",
+        gt=0.0,
+    )
+    cache_ttl_seconds: int = Field(
+        default=86400,
+        description=(
+            "How long to cache a successful OSV lookup result. Longer TTLs "
+            "reduce load on OSV but increase the lag before a new advisory "
+            "becomes visible to the advisory policy."
+        ),
+        gt=0,
+    )
+    error_cache_ttl_seconds: int = Field(
+        default=60,
+        description=(
+            "How long to cache a *failed* OSV lookup. Short by design so an "
+            "outage recovers quickly. Set to 0 to disable negative caching."
+        ),
+        ge=0,
+    )
+    max_concurrent_lookups: int = Field(
+        default=10,
+        description=(
+            "Upper bound on concurrent OSV lookups per request. Bounds fan-out on commands that mention many packages."
+        ),
+        ge=1,
+    )
+    advisory_severity_threshold: str = Field(
+        default="HIGH",
+        description=(
+            "Surface advisories whose max vulnerability severity is at or "
+            "above this level. One of LOW, MEDIUM, HIGH, CRITICAL."
+        ),
+    )
+    hard_block_versions: tuple[str, ...] = Field(
+        default=(),
+        description=(
+            "Reserved for future hard-block support. In v1 this list must "
+            "be empty — the policy only warns, never blocks."
+        ),
+    )
+    warn_on_osv_error: bool = Field(
+        default=True,
+        description=(
+            "If true, inject an 'OSV unavailable' advisory when the lookup "
+            "fails. If false, silently skip. Default: warn (fail-closed-ish)."
+        ),
+    )
+    bash_tool_names: tuple[str, ...] = Field(
+        default=("Bash",),
+        description=(
+            "Tool names that represent shell execution and should be "
+            "inspected for install commands. Claude Code uses `Bash`; MCP "
+            "servers may expose shell access under other names."
+        ),
+    )
+
+    @field_validator("bash_tool_names", "hard_block_versions", mode="before")
+    @classmethod
+    def _coerce_tuple(cls, value: Any) -> tuple[str, ...]:
+        """Accept list input (from YAML) and normalise to a tuple."""
+        if value is None:
+            return ()
+        if isinstance(value, str):
+            return (value,)
+        if isinstance(value, (list, tuple)):
+            return tuple(str(v) for v in value)
+        return value
+
+    @field_validator("advisory_severity_threshold")
+    @classmethod
+    def _validate_severity(cls, value: str) -> str:
+        if Severity.from_label(value) is Severity.UNKNOWN and value.strip().upper() != "UNKNOWN":
+            valid = ", ".join(s.label for s in Severity if s is not Severity.UNKNOWN)
+            raise ValueError(f"unknown severity threshold {value!r}; expected one of: {valid}")
+        return value
+
+    @field_validator("hard_block_versions")
+    @classmethod
+    def _reject_hard_blocks_in_v1(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        """v1 does not implement hard-block; error loudly if the field is used.
+
+        The field exists in the schema as a forward-compatibility marker so
+        that a future release can populate it without a migration. Silently
+        accepting values now would give operators a false sense that the
+        policy is enforcing them.
+        """
+        if value:
+            raise ValueError(
+                "hard_block_versions is reserved for a future release. "
+                "v1 of SupplyChainAdvisoryPolicy only warns; it does not block."
+            )
+        return value
+
+    @property
+    def severity_threshold_enum(self) -> Severity:
+        """Parsed severity threshold enum."""
+        return Severity.from_label(self.advisory_severity_threshold)
+
+
+# =============================================================================
+# Regex-based install-command extractor
+# =============================================================================
+
+
+# Package managers we recognise. Keep the list short — each entry adds a
+# maintenance burden and false-positive risk. `uv pip install …` is handled
+# by the optional `pip\s+` prefix after the outer manager token.
+_INSTALL_CMD_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b(?P<mgr>pip|pip3|uv|poetry|pipenv|conda|npm|yarn|pnpm|bun)\s+"
+    r"(?:pip\s+)?"
+    r"(?P<verb>install|add|i|update|upgrade)\b"
+    r"(?P<args>[^&|;><\n]*)",
+    re.IGNORECASE,
+)
+
+
+_PYPI_MGRS: Final[frozenset[str]] = frozenset({"pip", "pip3", "uv", "poetry", "pipenv", "conda"})
+_NPM_MGRS: Final[frozenset[str]] = frozenset({"npm", "yarn", "pnpm", "bun"})
+
+
+def _ecosystem_for(manager: str) -> str | None:
+    """Map a recognised manager token to an OSV ecosystem label."""
+    m = manager.lower()
+    if m in _PYPI_MGRS:
+        return "PyPI"
+    if m in _NPM_MGRS:
+        return "npm"
+    return None
+
+
+# Match `pkg==1.2.3` (PyPI exact-pin) — used by the tool_result scanner.
+_PYPI_PIN_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?<![\w.-])(?P<name>[A-Za-z0-9][A-Za-z0-9._-]{0,80})==(?P<version>[0-9][0-9A-Za-z.+!-]*)",
+)
+
+# Match `"pkg": "1.2.3"` (package.json dependency line).
+_NPM_JSON_DEP_RE: Final[re.Pattern[str]] = re.compile(
+    r'"(?P<name>@?[A-Za-z0-9][A-Za-z0-9._/-]{0,80})"\s*:\s*'
+    r'"[~^>=<]*(?P<version>[0-9][0-9A-Za-z.+!-]*)"',
+)
+
+
+def _split_pip_specifier(raw: str) -> tuple[str, str | None]:
+    """Split ``requests==2.31.0`` into ("requests", "2.31.0")."""
+    # Strip extras: ``pkg[extra]==1.0`` -> ``pkg==1.0``
+    bracket_start = raw.find("[")
+    bracket_end = raw.find("]") if bracket_start != -1 else -1
+    if bracket_start != -1 and bracket_end != -1:
+        raw = raw[:bracket_start] + raw[bracket_end + 1 :]
+    for op in ("===", "==", ">=", "<=", "!=", "~=", ">", "<"):
+        if op in raw:
+            name, _, version = raw.partition(op)
+            return name.strip(), version.strip() or None
+    return raw.strip(), None
+
+
+def _split_npm_specifier(raw: str) -> tuple[str, str | None]:
+    """Split ``left-pad@1.3.0`` / ``@scope/pkg@1.0`` into name and version."""
+    if raw.startswith("@"):
+        at = raw.find("@", 1)
+        if at == -1:
+            return raw, None
+        return raw[:at], _normalise_exact_version(raw[at + 1 :])
+    if "@" in raw:
+        name, _, version = raw.partition("@")
+        return name, _normalise_exact_version(version)
+    return raw, None
+
+
+def _normalise_exact_version(version: str) -> str | None:
+    """Return ``version`` if it looks like an exact pin, else ``None``.
+
+    OSV's single-package query expects an exact version string. Ranges,
+    tags (``latest``), and prefixes like ``^`` or ``~`` all yield no
+    matches even when the underlying version is known-vulnerable, so we
+    drop them and let OSV return all-version advisories.
+    """
+    version = version.strip()
+    if not version:
+        return None
+    if version in {"latest", "next", "beta", "alpha", "rc", "canary"}:
+        return None
+    if version[0] in "^~<>=!|*x" or " " in version:
+        return None
+    return version
+
+
+def _looks_like_installable_token(token: str) -> bool:
+    """Filter out tokens that obviously aren't package specifiers."""
+    if not token:
+        return False
+    if token.startswith("-"):
+        return False  # flag
+    if token.startswith((".", "/")):
+        return False  # local path
+    if "://" in token:
+        return False  # URL
+    if token.endswith((".tar.gz", ".whl", ".zip", ".tgz")):
+        return False  # archive file
+    return True
+
+
+def extract_install_packages(text: str) -> list[PackageRef]:
+    """Best-effort regex scan of ``text`` for package install commands.
+
+    Returns a list of (ecosystem, name, version) refs. Duplicates are
+    preserved — callers that care about uniqueness should dedupe. If the
+    regex misses a command shape (``sh -c ...``, chained commands, eval,
+    base64, unusual managers), the package is simply not emitted. This
+    is intentional: the policy is an advisory, not a security boundary.
+    """
+    refs: list[PackageRef] = []
+    for match in _INSTALL_CMD_RE.finditer(text):
+        manager = match.group("mgr")
+        ecosystem = _ecosystem_for(manager)
+        if ecosystem is None:
+            continue
+        args = match.group("args") or ""
+        for raw in args.split():
+            if not _looks_like_installable_token(raw):
+                continue
+            if ecosystem == "PyPI":
+                name, version = _split_pip_specifier(raw)
+            else:
+                name, version = _split_npm_specifier(raw)
+            if not name:
+                continue
+            refs.append(PackageRef(ecosystem=ecosystem, name=name, version=version))
+    return refs
+
+
+def extract_tool_result_packages(text: str) -> list[PackageRef]:
+    """Best-effort scan for 'currently installed' version mentions.
+
+    Matches ``pkg==1.2.3`` (pip freeze / pip show output) and
+    ``"pkg": "1.2.3"`` (package.json / npm ls output). Designed for the
+    common happy path — deliberately not exhaustive.
+    """
+    refs: list[PackageRef] = []
+    for match in _PYPI_PIN_RE.finditer(text):
+        name = match.group("name")
+        version = match.group("version")
+        # Reject obvious non-packages: bare numbers or versions without a name.
+        if name and (name[0].isalpha() or name[0] == "_"):
+            refs.append(PackageRef(ecosystem="PyPI", name=name, version=version))
+    for match in _NPM_JSON_DEP_RE.finditer(text):
+        name = match.group("name")
+        version = match.group("version")
+        if not name:
+            continue
+        # Skip known non-package JSON keys that accidentally look like deps.
+        if name in {"version", "name", "main", "license", "description"}:
+            continue
+        refs.append(PackageRef(ecosystem="npm", name=name, version=version))
+    return refs
+
+
+# =============================================================================
+# OSV client
+# =============================================================================
+
+
+_SHARED_HTTP_CLIENT: httpx.AsyncClient | None = None
+
+
+def _get_shared_http_client() -> httpx.AsyncClient:
+    """Return (creating lazily) the module-level httpx.AsyncClient."""
+    global _SHARED_HTTP_CLIENT
+    if _SHARED_HTTP_CLIENT is None:
+        _SHARED_HTTP_CLIENT = httpx.AsyncClient(
+            timeout=httpx.Timeout(10.0, connect=5.0),
+            limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
+        )
+    return _SHARED_HTTP_CLIENT
+
+
+class OSVClient:
+    """Minimal async client for the OSV.dev v1 query endpoint."""
+
+    def __init__(
+        self,
+        api_url: str = "https://api.osv.dev/v1/query",
+        timeout_seconds: float = 5.0,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        """Initialize with endpoint URL, timeout, and optional injected client."""
+        self._api_url = api_url
+        self._timeout = timeout_seconds
+        self._client = http_client
+
+    async def query(self, package: PackageRef) -> list[VulnInfo]:
+        """Look up vulnerabilities for a single package.
+
+        Returns a (possibly empty) list of VulnInfos. Raises ``httpx.HTTPError``
+        on transport errors or non-2xx responses — callers decide whether to
+        treat those as warn-on-error or silently skip.
+        """
+        body: dict[str, Any] = {"package": {"name": package.name, "ecosystem": package.ecosystem}}
+        if package.version:
+            body["version"] = package.version
+        client = self._client if self._client is not None else _get_shared_http_client()
+        response = await client.post(self._api_url, json=body, timeout=self._timeout)
+        response.raise_for_status()
+        payload = response.json()
+        return _parse_osv_response(payload)
+
+
+def _parse_osv_response(payload: Any) -> list[VulnInfo]:
+    """Turn the OSV query JSON into VulnInfos."""
+    if not isinstance(payload, dict):
+        return []
+    raw_vulns = payload.get("vulns") or []
+    if not isinstance(raw_vulns, list):
+        return []
+    results: list[VulnInfo] = []
+    for entry in raw_vulns:
+        if not isinstance(entry, dict):
+            continue
+        results.append(
+            VulnInfo(
+                id=str(entry.get("id", "")),
+                summary=str(entry.get("summary") or entry.get("details") or ""),
+                severity=_extract_max_severity(entry),
+            )
+        )
+    return results
+
+
+def _extract_max_severity(entry: dict[str, Any]) -> Severity:
+    """Pull the highest severity we can find in one OSV vuln entry."""
+    max_sev = Severity.UNKNOWN
+    saw_unparseable_vector = False
+
+    for sev in entry.get("severity") or []:
+        if not isinstance(sev, dict):
+            continue
+        raw_score = sev.get("score")
+        score = _parse_cvss_score(raw_score)
+        if score is not None:
+            candidate = Severity.from_cvss_score(score)
+            if candidate > max_sev:
+                max_sev = candidate
+        elif isinstance(raw_score, str) and raw_score.strip().upper().startswith("CVSS:"):
+            # CVSS v4 (or any future vector we can't parse). We deliberately
+            # don't silently downgrade to UNKNOWN — that would hide real HIGH
+            # advisories just because OSV started publishing v4 vectors.
+            saw_unparseable_vector = True
+
+    db_specific = entry.get("database_specific")
+    if isinstance(db_specific, dict):
+        label_sev = Severity.from_label(db_specific.get("severity"))
+        if label_sev > max_sev:
+            max_sev = label_sev
+
+    for affected in entry.get("affected") or []:
+        if not isinstance(affected, dict):
+            continue
+        aff_db = affected.get("database_specific")
+        if isinstance(aff_db, dict):
+            label_sev = Severity.from_label(aff_db.get("severity"))
+            if label_sev > max_sev:
+                max_sev = label_sev
+
+    if saw_unparseable_vector and max_sev is Severity.UNKNOWN:
+        logger.info("OSV advisory %s has unparseable CVSS vector; treating as HIGH", entry.get("id"))
+        max_sev = Severity.HIGH
+
+    return max_sev
+
+
+def _parse_cvss_score(raw: Any) -> float | None:
+    """Extract the numeric score from an OSV ``severity[].score`` entry."""
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if not isinstance(raw, str):
+        return None
+    stripped = raw.strip()
+    try:
+        return float(stripped)
+    except ValueError:
+        pass
+    if stripped.upper().startswith("CVSS:3"):
+        return _cvss3_base_score(stripped)
+    return None
+
+
+# CVSS v3 base metric values (CVSS 3.0 and 3.1 spec).
+_CVSS3_AV: Final[dict[str, float]] = {"N": 0.85, "A": 0.62, "L": 0.55, "P": 0.2}
+_CVSS3_AC: Final[dict[str, float]] = {"L": 0.77, "H": 0.44}
+_CVSS3_PR_UNCHANGED: Final[dict[str, float]] = {"N": 0.85, "L": 0.62, "H": 0.27}
+_CVSS3_PR_CHANGED: Final[dict[str, float]] = {"N": 0.85, "L": 0.68, "H": 0.5}
+_CVSS3_UI: Final[dict[str, float]] = {"N": 0.85, "R": 0.62}
+_CVSS3_CIA: Final[dict[str, float]] = {"H": 0.56, "L": 0.22, "N": 0.0}
+
+
+def _cvss3_base_score(vector: str) -> float | None:
+    """Compute the CVSS v3.x base score from a vector string."""
+    metrics: dict[str, str] = {}
+    for part in vector.split("/")[1:]:
+        if ":" not in part:
+            continue
+        key, _, value = part.partition(":")
+        metrics[key.strip().upper()] = value.strip().upper()
+
+    required = ("AV", "AC", "PR", "UI", "S", "C", "I", "A")
+    if not all(metric in metrics for metric in required):
+        return None
+
+    scope = metrics["S"]
+    try:
+        av = _CVSS3_AV[metrics["AV"]]
+        ac = _CVSS3_AC[metrics["AC"]]
+        ui = _CVSS3_UI[metrics["UI"]]
+        pr_table = _CVSS3_PR_CHANGED if scope == "C" else _CVSS3_PR_UNCHANGED
+        pr = pr_table[metrics["PR"]]
+        conf = _CVSS3_CIA[metrics["C"]]
+        integ = _CVSS3_CIA[metrics["I"]]
+        avail = _CVSS3_CIA[metrics["A"]]
+    except KeyError:
+        return None
+
+    isc_base = 1 - (1 - conf) * (1 - integ) * (1 - avail)
+    if scope == "C":
+        impact = 7.52 * (isc_base - 0.029) - 3.25 * pow(isc_base - 0.02, 15)
+    else:
+        impact = 6.42 * isc_base
+
+    if impact <= 0:
+        return 0.0
+
+    exploitability = 8.22 * av * ac * pr * ui
+    raw = impact + exploitability
+    if scope == "C":
+        raw *= 1.08
+    base = min(raw, 10.0)
+    return _cvss_roundup(base)
+
+
+def _cvss_roundup(value: float) -> float:
+    """CVSS specification roundup: round up to the nearest 0.1."""
+    int_input = round(value * 100_000)
+    if int_input % 10_000 == 0:
+        return int_input / 100_000
+    return (int_input // 10_000 + 1) / 10
+
+
+# =============================================================================
+# Redaction and formatting
+# =============================================================================
+
+
+_URL_CREDENTIAL_RE: Final[re.Pattern[str]] = re.compile(r"([a-zA-Z][a-zA-Z0-9+.\-]*://)[^/@\s]+:[^/@\s]+@")
+_SENSITIVE_FLAG_VALUE_RE: Final[re.Pattern[str]] = re.compile(
+    r"(--(?:token|password|api[-_]key|auth|secret|header)[=\s])(\S+)",
+    re.IGNORECASE,
+)
+
+
+def redact_credentials(text: str) -> str:
+    """Strip embedded credentials from a command or URL.
+
+    Used before putting a command into an advisory message (visible to the
+    LLM) or an event payload. The policy should not be the vector that
+    leaks credentials to its own telemetry pipeline.
+    """
+    text = _URL_CREDENTIAL_RE.sub(r"\1<redacted>@", text)
+    text = _SENSITIVE_FLAG_VALUE_RE.sub(r"\1<redacted>", text)
+    return text
+
+
+# Max chars of untrusted OSV-summary text to show per vuln. Longer summaries
+# are a larger prompt-injection surface and rarely informative.
+_UNTRUSTED_SUMMARY_MAX = 200
+
+
+def format_untrusted_summary(summary: str) -> str:
+    """Render an OSV summary with a clear untrusted-content delimiter.
+
+    OSV.dev accepts third-party advisory submissions, so the summary field
+    is untrusted text that will be shown back to the LLM. Wrap it in a
+    labelled quote so a malicious advisory can't cleanly impersonate
+    policy instructions.
+    """
+    text = (summary or "no summary").strip().splitlines()[0]
+    if len(text) > _UNTRUSTED_SUMMARY_MAX:
+        text = text[:_UNTRUSTED_SUMMARY_MAX] + "…"
+    return f"<untrusted OSV advisory text> {text}"
+
+
+def format_advisory_message(
+    results: list[PackageCheckResult],
+    threshold: Severity,
+    command: str | None = None,
+) -> str:
+    """Render an advisory message the LLM can relay to the user."""
+    lines: list[str] = [
+        "SUPPLY CHAIN ADVISORY: one or more referenced packages have known advisories "
+        f"at severity {threshold.label} or higher. This is informational — the "
+        "command is NOT blocked. Please surface this to the user before proceeding.",
+        "",
+    ]
+    if command:
+        lines.append(f"Command: {redact_credentials(command)}")
+        lines.append("")
+
+    flagged = [r for r in results if r.advisory_vulns(threshold)]
+    errored = [r for r in results if r.error]
+
+    if flagged:
+        lines.append("Packages with known advisories:")
+        for result in flagged:
+            advisories = result.advisory_vulns(threshold)
+            version_part = f"@{result.package.version}" if result.package.version else ""
+            header = (
+                f"- {result.package.name}{version_part} ({result.package.ecosystem}): "
+                f"{len(advisories)} advisor{'y' if len(advisories) == 1 else 'ies'} "
+                f"[{result.max_severity.label}]"
+            )
+            lines.append(header)
+            for vuln in advisories[:5]:
+                lines.append(f"    {vuln.id} [{vuln.severity.label}]: {format_untrusted_summary(vuln.summary)}")
+            if len(advisories) > 5:
+                lines.append(f"    ... and {len(advisories) - 5} more")
+
+    if errored:
+        if flagged:
+            lines.append("")
+        lines.append("Packages where the OSV lookup failed (advisory status unknown):")
+        for result in errored:
+            lines.append(f"- {result.package.name} ({result.package.ecosystem}): {result.error or 'unknown error'}")
+
+    lines.append("")
+    lines.append(
+        "Recommendation: verify the advisory at https://osv.dev, pin to a patched "
+        "version if one exists, or choose an alternative package. This policy is "
+        "best-effort and may miss obfuscated commands; run OSV-Scanner inside the "
+        "sandbox for hardened supply-chain coverage."
+    )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "OSVClient",
+    "PackageCheckResult",
+    "PackageRef",
+    "Severity",
+    "SupplyChainAdvisoryConfig",
+    "VulnInfo",
+    "extract_install_packages",
+    "extract_tool_result_packages",
+    "format_advisory_message",
+    "format_untrusted_summary",
+    "redact_credentials",
+]

--- a/tests/luthien_proxy/unit_tests/policies/test_supply_chain_advisory_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_supply_chain_advisory_policy.py
@@ -1,0 +1,727 @@
+"""Unit tests for SupplyChainAdvisoryPolicy.
+
+These tests focus on the integration between the policy hooks, the OSV
+client (mocked), and the per-request state. The regex/severity/redaction
+helpers have their own dedicated test module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+from anthropic.types import (
+    InputJSONDelta,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    TextBlock,
+    TextDelta,
+    ToolUseBlock,
+)
+
+from luthien_proxy.policies.supply_chain_advisory_policy import (
+    SupplyChainAdvisoryPolicy,
+    _AdvisoryState,
+    _collect_tool_result_texts,
+    _dedupe_packages,
+    _extract_bash_command,
+    _extract_command_from_json,
+    _prepend_system_warning,
+)
+from luthien_proxy.policies.supply_chain_advisory_utils import (
+    OSVClient,
+    PackageRef,
+    Severity,
+    SupplyChainAdvisoryConfig,
+    VulnInfo,
+)
+from luthien_proxy.policy_core.policy_context import PolicyContext
+
+# =============================================================================
+# Fakes
+# =============================================================================
+
+
+class _FakeOSVClient(OSVClient):
+    """In-memory OSV client. Maps cache_key -> list[VulnInfo] or raises."""
+
+    def __init__(
+        self,
+        responses: dict[str, list[VulnInfo]] | None = None,
+        raise_for: set[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self._responses = responses or {}
+        self._raise_for = raise_for or set()
+        self.calls: list[PackageRef] = []
+        self.call_started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.release.set()
+        self.concurrent_high_water = 0
+        self._in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def query(self, package: PackageRef) -> list[VulnInfo]:
+        self.calls.append(package)
+        async with self._lock:
+            self._in_flight += 1
+            if self._in_flight > self.concurrent_high_water:
+                self.concurrent_high_water = self._in_flight
+        self.call_started.set()
+        try:
+            await self.release.wait()
+            if package.name in self._raise_for:
+                raise RuntimeError(f"OSV down for {package.name}")
+            return list(self._responses.get(package.cache_key(), []))
+        finally:
+            async with self._lock:
+                self._in_flight -= 1
+
+
+def _make_policy(
+    osv: OSVClient,
+    config: dict[str, Any] | None = None,
+) -> SupplyChainAdvisoryPolicy:
+    cfg = SupplyChainAdvisoryConfig.model_validate(config or {})
+    return SupplyChainAdvisoryPolicy(config=cfg, osv_client=osv)
+
+
+def _make_context() -> PolicyContext:
+    return PolicyContext.for_testing(transaction_id="test-txn")
+
+
+def _critical(name: str) -> VulnInfo:
+    return VulnInfo(id=f"GHSA-{name}", summary=f"{name} bad", severity=Severity.CRITICAL)
+
+
+def _medium(name: str) -> VulnInfo:
+    return VulnInfo(id=f"GHSA-{name}-med", summary=f"{name} mild", severity=Severity.MEDIUM)
+
+
+# =============================================================================
+# Module-level helpers
+# =============================================================================
+
+
+class TestExtractBashCommand:
+    def test_dict(self):
+        assert _extract_bash_command({"command": "ls"}) == "ls"
+
+    def test_missing(self):
+        assert _extract_bash_command({}) is None
+
+    def test_non_dict(self):
+        assert _extract_bash_command("ls") is None
+
+    def test_non_string_command(self):
+        assert _extract_bash_command({"command": 5}) is None
+
+
+class TestExtractCommandFromJson:
+    def test_valid(self):
+        assert _extract_command_from_json('{"command": "ls"}') == "ls"
+
+    def test_empty(self):
+        assert _extract_command_from_json("") is None
+
+    def test_invalid(self):
+        assert _extract_command_from_json("{not json") is None
+
+
+class TestDedupePackages:
+    def test_dedupe(self):
+        pkgs = [
+            PackageRef("PyPI", "requests", "2.31.0"),
+            PackageRef("PyPI", "requests", "2.31.0"),
+            PackageRef("PyPI", "flask", None),
+        ]
+        result = _dedupe_packages(pkgs)
+        assert result == [
+            PackageRef("PyPI", "requests", "2.31.0"),
+            PackageRef("PyPI", "flask", None),
+        ]
+
+    def test_different_versions_kept(self):
+        pkgs = [
+            PackageRef("PyPI", "requests", "2.31.0"),
+            PackageRef("PyPI", "requests", "2.30.0"),
+        ]
+        assert _dedupe_packages(pkgs) == pkgs
+
+
+class TestCollectToolResultTexts:
+    def test_string_content(self):
+        msg: dict[str, Any] = {
+            "role": "user",
+            "content": [{"type": "tool_result", "content": "requests==2.31.0"}],
+        }
+        assert _collect_tool_result_texts(msg) == ["requests==2.31.0"]  # type: ignore[arg-type]
+
+    def test_list_content(self):
+        msg: dict[str, Any] = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "content": [
+                        {"type": "text", "text": "axios@1.6.8"},
+                        {"type": "text", "text": "left-pad"},
+                    ],
+                }
+            ],
+        }
+        assert _collect_tool_result_texts(msg) == ["axios@1.6.8", "left-pad"]  # type: ignore[arg-type]
+
+    def test_no_tool_result(self):
+        msg: dict[str, Any] = {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+        assert _collect_tool_result_texts(msg) == []  # type: ignore[arg-type]
+
+    def test_string_message_content(self):
+        msg: dict[str, Any] = {"role": "user", "content": "hi"}
+        assert _collect_tool_result_texts(msg) == []  # type: ignore[arg-type]
+
+
+class TestPrependSystemWarning:
+    def test_none(self):
+        assert _prepend_system_warning(None, "warn") == "warn"
+
+    def test_string(self):
+        assert _prepend_system_warning("you are helpful", "warn") == "warn\n\nyou are helpful"
+
+    def test_empty_string(self):
+        assert _prepend_system_warning("", "warn") == "warn"
+
+    def test_list_blocks(self):
+        existing = [{"type": "text", "text": "be helpful"}]
+        result = _prepend_system_warning(existing, "warn")  # type: ignore[arg-type]
+        assert isinstance(result, list)
+        assert result[0] == {"type": "text", "text": "warn"}
+        assert result[1] == {"type": "text", "text": "be helpful"}
+
+
+# =============================================================================
+# Init / config
+# =============================================================================
+
+
+class TestInit:
+    def test_default_config(self):
+        policy = SupplyChainAdvisoryPolicy()
+        assert policy._threshold is Severity.HIGH
+        assert "Bash" in policy._bash_tool_names
+
+    def test_custom_threshold(self):
+        policy = _make_policy(_FakeOSVClient(), {"advisory_severity_threshold": "MEDIUM"})
+        assert policy._threshold is Severity.MEDIUM
+
+    def test_freeze_configured_state_passes(self):
+        policy = _make_policy(_FakeOSVClient())
+        # freeze_configured_state must succeed: no mutable containers on the
+        # instance. The frozenset/tuple choices in __init__ are intentional.
+        policy.freeze_configured_state()
+
+    def test_short_policy_name(self):
+        assert SupplyChainAdvisoryPolicy().short_policy_name == "SupplyChainAdvisory"
+
+
+# =============================================================================
+# on_anthropic_response (non-streaming)
+# =============================================================================
+
+
+class TestOnAnthropicResponse:
+    @pytest.mark.asyncio
+    async def test_passthrough_when_no_tool_use(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {"content": [{"type": "text", "text": "hi"}]}
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+        assert osv.calls == []
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_no_install_command(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "echo hello"},
+                }
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+        assert osv.calls == []
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_no_advisory(self):
+        osv = _FakeOSVClient(responses={"osv:PyPI:requests:2.31.0": []})
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install requests==2.31.0"},
+                }
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+        assert len(osv.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_injects_advisory_for_critical_package(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.48.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install litellm==1.48.0"},
+                }
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        # Advisory text block inserted before the tool_use block.
+        assert result["content"][0]["type"] == "text"
+        assert "SUPPLY CHAIN ADVISORY" in result["content"][0]["text"]
+        assert "litellm" in result["content"][0]["text"]
+        assert "GHSA-LITELLM" in result["content"][0]["text"]
+        # The original tool_use block is preserved unchanged.
+        assert result["content"][1]["type"] == "tool_use"
+
+    @pytest.mark.asyncio
+    async def test_skips_below_threshold(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:flask:3.0.0": [_medium("FLASK")]},
+        )
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install flask==3.0.0"},
+                }
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+
+    @pytest.mark.asyncio
+    async def test_threshold_lowered_to_medium(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:flask:3.0.0": [_medium("FLASK")]},
+        )
+        policy = _make_policy(osv, {"advisory_severity_threshold": "MEDIUM"})
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install flask==3.0.0"},
+                }
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result["content"][0]["type"] == "text"
+        assert "MEDIUM" in result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_bash_tool(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.48.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Read",
+                    "input": {"command": "pip install litellm==1.48.0"},
+                }
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+        assert osv.calls == []
+
+    @pytest.mark.asyncio
+    async def test_warn_on_osv_error(self):
+        osv = _FakeOSVClient(raise_for={"litellm"})
+        policy = _make_policy(osv, {"warn_on_osv_error": True})
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install litellm==1.48.0"},
+                }
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result["content"][0]["type"] == "text"
+        assert "OSV lookup failed" in result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_silent_on_osv_error_when_disabled(self):
+        osv = _FakeOSVClient(raise_for={"litellm"})
+        policy = _make_policy(osv, {"warn_on_osv_error": False})
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install litellm==1.48.0"},
+                }
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+
+
+# =============================================================================
+# on_anthropic_request (incoming tool_results)
+# =============================================================================
+
+
+class TestOnAnthropicRequest:
+    @pytest.mark.asyncio
+    async def test_passthrough_no_messages(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        request: dict[str, Any] = {"messages": [], "model": "claude", "max_tokens": 100}
+        result = await policy.on_anthropic_request(request, _make_context())  # type: ignore[arg-type]
+        assert result is request
+
+    @pytest.mark.asyncio
+    async def test_passthrough_assistant_last(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        request: dict[str, Any] = {
+            "messages": [{"role": "assistant", "content": "hi"}],
+            "model": "claude",
+            "max_tokens": 100,
+        }
+        result = await policy.on_anthropic_request(request, _make_context())  # type: ignore[arg-type]
+        assert result is request
+
+    @pytest.mark.asyncio
+    async def test_passthrough_no_install_in_tool_result(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        request: dict[str, Any] = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "content": "hello world"}],
+                }
+            ],
+            "model": "claude",
+            "max_tokens": 100,
+        }
+        result = await policy.on_anthropic_request(request, _make_context())  # type: ignore[arg-type]
+        assert result is request
+        assert osv.calls == []
+
+    @pytest.mark.asyncio
+    async def test_warns_on_pip_freeze_with_vulnerable_pkg(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.48.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        request: dict[str, Any] = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "content": "litellm==1.48.0\nnumpy==1.26.0",
+                        }
+                    ],
+                }
+            ],
+            "model": "claude",
+            "max_tokens": 100,
+        }
+        result = await policy.on_anthropic_request(request, _make_context())  # type: ignore[arg-type]
+        assert result is not request
+        system = result.get("system")
+        assert system is not None
+        assert "SUPPLY CHAIN ADVISORY" in (system if isinstance(system, str) else system[0]["text"])
+
+    @pytest.mark.asyncio
+    async def test_prepends_to_existing_system(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.48.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        request: dict[str, Any] = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "content": "litellm==1.48.0"},
+                    ],
+                }
+            ],
+            "system": "You are helpful.",
+            "model": "claude",
+            "max_tokens": 100,
+        }
+        result = await policy.on_anthropic_request(request, _make_context())  # type: ignore[arg-type]
+        system = result.get("system")
+        assert isinstance(system, str)
+        assert "SUPPLY CHAIN ADVISORY" in system
+        assert "You are helpful." in system
+
+
+# =============================================================================
+# Streaming
+# =============================================================================
+
+
+def _start_event(index: int, block: ToolUseBlock | TextBlock) -> RawContentBlockStartEvent:
+    return RawContentBlockStartEvent(type="content_block_start", index=index, content_block=block)
+
+
+def _delta_event(index: int, delta: InputJSONDelta | TextDelta) -> RawContentBlockDeltaEvent:
+    return RawContentBlockDeltaEvent(type="content_block_delta", index=index, delta=delta)
+
+
+def _stop_event(index: int) -> RawContentBlockStopEvent:
+    return RawContentBlockStopEvent(type="content_block_stop", index=index)
+
+
+class TestStreaming:
+    @pytest.mark.asyncio
+    async def test_passthrough_text_block(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        text_event = _start_event(0, TextBlock(type="text", text=""))
+        out = await policy.on_anthropic_stream_event(text_event, ctx)  # type: ignore[arg-type]
+        assert out == [text_event]
+
+    @pytest.mark.asyncio
+    async def test_buffers_bash_tool_use_until_stop(self):
+        osv = _FakeOSVClient(responses={"osv:PyPI:requests:2.31.0": []})
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        tool_block = ToolUseBlock(type="tool_use", id="t1", name="Bash", input={})
+
+        out_start = await policy.on_anthropic_stream_event(_start_event(0, tool_block), ctx)  # type: ignore[arg-type]
+        assert out_start == []  # suppressed
+
+        out_delta = await policy.on_anthropic_stream_event(
+            _delta_event(
+                0, InputJSONDelta(type="input_json_delta", partial_json='{"command": "pip install requests==2.31.0"}')
+            ),  # type: ignore[arg-type]
+            ctx,
+        )
+        assert out_delta == []  # suppressed
+
+        out_stop = await policy.on_anthropic_stream_event(_stop_event(0), ctx)  # type: ignore[arg-type]
+        # No advisory: re-emit start, delta, stop.
+        assert len(out_stop) == 3
+        types = [type(e).__name__ for e in out_stop]
+        assert types == [
+            "RawContentBlockStartEvent",
+            "RawContentBlockDeltaEvent",
+            "RawContentBlockStopEvent",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_advisory_injected_when_critical_match(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.48.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        tool_block = ToolUseBlock(type="tool_use", id="t1", name="Bash", input={})
+
+        await policy.on_anthropic_stream_event(_start_event(0, tool_block), ctx)  # type: ignore[arg-type]
+        await policy.on_anthropic_stream_event(
+            _delta_event(
+                0, InputJSONDelta(type="input_json_delta", partial_json='{"command": "pip install litellm==1.48.0"}')
+            ),  # type: ignore[arg-type]
+            ctx,
+        )
+        out_stop = await policy.on_anthropic_stream_event(_stop_event(0), ctx)  # type: ignore[arg-type]
+        # Advisory (3 events: start/delta/stop) + tool_use (start/delta/stop).
+        assert len(out_stop) == 6
+        # Advisory comes first.
+        first = out_stop[0]
+        assert isinstance(first, RawContentBlockStartEvent)
+        assert isinstance(first.content_block, TextBlock)
+        # The text delta carries the advisory body.
+        delta_evt = out_stop[1]
+        assert isinstance(delta_evt, RawContentBlockDeltaEvent)
+        assert isinstance(delta_evt.delta, TextDelta)
+        assert "SUPPLY CHAIN ADVISORY" in delta_evt.delta.text
+        assert "litellm" in delta_evt.delta.text
+
+    @pytest.mark.asyncio
+    async def test_non_bash_tool_passthrough(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        tool_block = ToolUseBlock(type="tool_use", id="t1", name="Read", input={})
+        evt = _start_event(0, tool_block)
+        out = await policy.on_anthropic_stream_event(evt, ctx)  # type: ignore[arg-type]
+        assert out == [evt]
+        assert osv.calls == []
+
+    @pytest.mark.asyncio
+    async def test_stream_complete_flushes_orphan(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        tool_block = ToolUseBlock(type="tool_use", id="t1", name="Bash", input={})
+        await policy.on_anthropic_stream_event(_start_event(0, tool_block), ctx)  # type: ignore[arg-type]
+        await policy.on_anthropic_stream_event(
+            _delta_event(0, InputJSONDelta(type="input_json_delta", partial_json='{"command": "echo hi"}')),  # type: ignore[arg-type]
+            ctx,
+        )
+        # No stop event arrived; stream complete should flush.
+        emissions = await policy.on_anthropic_stream_complete(ctx)
+        assert len(emissions) == 2  # start + delta
+        # Orphan map cleared.
+        state = ctx.get_request_state(policy, _AdvisoryState, _AdvisoryState)
+        assert state.buffered_tool_uses == {}
+
+    @pytest.mark.asyncio
+    async def test_stream_complete_empty(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        emissions = await policy.on_anthropic_stream_complete(ctx)
+        assert emissions == []
+
+    @pytest.mark.asyncio
+    async def test_streaming_policy_complete_pops_state(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        # Force state creation.
+        ctx.get_request_state(policy, _AdvisoryState, _AdvisoryState)
+        await policy.on_anthropic_streaming_policy_complete(ctx)
+        # State popped.
+        assert ctx.pop_request_state(policy, _AdvisoryState) is None
+
+
+# =============================================================================
+# Concurrent lookups / semaphore
+# =============================================================================
+
+
+class TestConcurrentLookups:
+    @pytest.mark.asyncio
+    async def test_semaphore_caps_concurrency(self):
+        # Five packages, max_concurrent_lookups=2 — high water must not exceed 2.
+        osv = _FakeOSVClient()
+        osv.release.clear()  # block all calls until we let them go
+        policy = _make_policy(osv, {"max_concurrent_lookups": 2})
+        ctx = _make_context()
+        command = "pip install a==1 b==1 c==1 d==1 e==1"
+        task = asyncio.create_task(policy._advisory_for_command(command, ctx))
+        # Wait for at least one call to start, then a tiny moment for the
+        # semaphore to settle, then release everything.
+        await osv.call_started.wait()
+        await asyncio.sleep(0.05)
+        osv.release.set()
+        await task
+        assert osv.concurrent_high_water <= 2
+        assert len(osv.calls) == 5
+
+    @pytest.mark.asyncio
+    async def test_dedupes_before_lookup(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        # Same package mentioned twice.
+        await policy._advisory_for_command("pip install requests==2.31.0 requests==2.31.0", ctx)
+        assert len(osv.calls) == 1
+
+
+# =============================================================================
+# Cache integration
+# =============================================================================
+
+
+class _StubPolicyCache:
+    """Minimal in-memory PolicyCache stand-in for tests."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, Any] = {}
+        self.get_calls = 0
+        self.put_calls = 0
+
+    async def get(self, key: str) -> Any:
+        self.get_calls += 1
+        return self.store.get(key)
+
+    async def put(self, key: str, value: Any, ttl_seconds: int) -> None:
+        self.put_calls += 1
+        self.store[key] = value
+
+
+def _ctx_with_cache(cache: _StubPolicyCache) -> PolicyContext:
+    return PolicyContext.for_testing(
+        transaction_id="test-txn",
+        policy_cache_factory=lambda _name: cast(Any, cache),
+    )
+
+
+class TestCache:
+    @pytest.mark.asyncio
+    async def test_cache_miss_then_hit(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.48.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        cache = _StubPolicyCache()
+        ctx = _ctx_with_cache(cache)
+
+        await policy._advisory_for_command("pip install litellm==1.48.0", ctx)
+        assert len(osv.calls) == 1
+        assert cache.put_calls == 1
+
+        # Second call with the same context should hit the cache.
+        await policy._advisory_for_command("pip install litellm==1.48.0", ctx)
+        assert len(osv.calls) == 1  # no new OSV call
+        assert cache.get_calls >= 2
+
+    @pytest.mark.asyncio
+    async def test_error_cached_negatively(self):
+        osv = _FakeOSVClient(raise_for={"litellm"})
+        policy = _make_policy(osv)
+        cache = _StubPolicyCache()
+        ctx = _ctx_with_cache(cache)
+
+        await policy._advisory_for_command("pip install litellm==1.48.0", ctx)
+        # Error stored under the key.
+        key = PackageRef("PyPI", "litellm", "1.48.0").cache_key()
+        assert cache.store[key].get("error") is not None
+
+        # Second call hits the cached error and does NOT re-query.
+        await policy._advisory_for_command("pip install litellm==1.48.0", ctx)
+        assert len(osv.calls) == 1

--- a/tests/luthien_proxy/unit_tests/policies/test_supply_chain_advisory_utils.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_supply_chain_advisory_utils.py
@@ -1,0 +1,499 @@
+"""Unit tests for SupplyChainAdvisoryPolicy utility helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from luthien_proxy.policies.supply_chain_advisory_utils import (
+    OSVClient,
+    PackageCheckResult,
+    PackageRef,
+    Severity,
+    SupplyChainAdvisoryConfig,
+    VulnInfo,
+    _cvss3_base_score,
+    _extract_max_severity,
+    _parse_cvss_score,
+    extract_install_packages,
+    extract_tool_result_packages,
+    format_advisory_message,
+    format_untrusted_summary,
+    redact_credentials,
+)
+
+# =============================================================================
+# Severity
+# =============================================================================
+
+
+class TestSeverity:
+    def test_from_label_known(self):
+        assert Severity.from_label("HIGH") is Severity.HIGH
+        assert Severity.from_label("critical") is Severity.CRITICAL
+        assert Severity.from_label("low") is Severity.LOW
+
+    def test_from_label_unknown(self):
+        assert Severity.from_label(None) is Severity.UNKNOWN
+        assert Severity.from_label("") is Severity.UNKNOWN
+        assert Severity.from_label("bogus") is Severity.UNKNOWN
+
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            (9.5, Severity.CRITICAL),
+            (9.0, Severity.CRITICAL),
+            (7.5, Severity.HIGH),
+            (7.0, Severity.HIGH),
+            (4.0, Severity.MEDIUM),
+            (1.0, Severity.LOW),
+            (0.0, Severity.UNKNOWN),
+        ],
+    )
+    def test_from_cvss_score(self, score: float, expected: Severity):
+        assert Severity.from_cvss_score(score) is expected
+
+    def test_ordering(self):
+        assert Severity.CRITICAL > Severity.HIGH > Severity.MEDIUM > Severity.LOW > Severity.UNKNOWN
+
+
+# =============================================================================
+# Config validation
+# =============================================================================
+
+
+class TestConfig:
+    def test_defaults(self):
+        cfg = SupplyChainAdvisoryConfig()
+        assert cfg.advisory_severity_threshold == "HIGH"
+        assert cfg.severity_threshold_enum is Severity.HIGH
+        assert cfg.warn_on_osv_error is True
+        assert cfg.hard_block_versions == ()
+        assert cfg.bash_tool_names == ("Bash",)
+
+    def test_bash_tool_names_from_list(self):
+        # The validator coerces lists into tuples; pyright doesn't see this
+        # so the type: ignore is needed.
+        cfg = SupplyChainAdvisoryConfig(bash_tool_names=["Bash", "Terminal"])  # type: ignore[arg-type]
+        assert cfg.bash_tool_names == ("Bash", "Terminal")
+
+    def test_invalid_severity_threshold(self):
+        with pytest.raises(ValueError, match="unknown severity threshold"):
+            SupplyChainAdvisoryConfig(advisory_severity_threshold="HIH")
+
+    def test_hard_block_reserved_in_v1(self):
+        with pytest.raises(ValueError, match="reserved for a future release"):
+            SupplyChainAdvisoryConfig(hard_block_versions=["PyPI:axios:1.6.8"])  # type: ignore[arg-type]
+
+    def test_empty_hard_block_ok(self):
+        cfg = SupplyChainAdvisoryConfig(hard_block_versions=[])  # type: ignore[arg-type]
+        assert cfg.hard_block_versions == ()
+
+
+# =============================================================================
+# extract_install_packages — regex happy paths
+# =============================================================================
+
+
+class TestExtractInstallPackages:
+    def test_pip_pinned(self):
+        pkgs = extract_install_packages("pip install requests==2.31.0")
+        assert pkgs == [PackageRef("PyPI", "requests", "2.31.0")]
+
+    def test_pip_unversioned(self):
+        pkgs = extract_install_packages("pip install flask")
+        assert pkgs == [PackageRef("PyPI", "flask", None)]
+
+    def test_pip3(self):
+        pkgs = extract_install_packages("pip3 install numpy==1.26.0")
+        assert pkgs == [PackageRef("PyPI", "numpy", "1.26.0")]
+
+    def test_uv_pip_install(self):
+        pkgs = extract_install_packages("uv pip install litellm==1.48.0")
+        assert pkgs == [PackageRef("PyPI", "litellm", "1.48.0")]
+
+    def test_uv_add(self):
+        pkgs = extract_install_packages("uv add requests==2.31.0")
+        assert pkgs == [PackageRef("PyPI", "requests", "2.31.0")]
+
+    def test_poetry_add(self):
+        pkgs = extract_install_packages("poetry add django==5.0")
+        assert pkgs == [PackageRef("PyPI", "django", "5.0")]
+
+    def test_pipenv_install(self):
+        pkgs = extract_install_packages("pipenv install flask==3.0.0")
+        assert pkgs == [PackageRef("PyPI", "flask", "3.0.0")]
+
+    def test_conda_install(self):
+        pkgs = extract_install_packages("conda install numpy")
+        assert pkgs == [PackageRef("PyPI", "numpy", None)]
+
+    def test_npm_install_versioned(self):
+        pkgs = extract_install_packages("npm install axios@1.6.8")
+        assert pkgs == [PackageRef("npm", "axios", "1.6.8")]
+
+    def test_npm_install_unversioned(self):
+        pkgs = extract_install_packages("npm install left-pad")
+        assert pkgs == [PackageRef("npm", "left-pad", None)]
+
+    def test_npm_install_scoped(self):
+        pkgs = extract_install_packages("npm install @scope/pkg@1.2.3")
+        assert pkgs == [PackageRef("npm", "@scope/pkg", "1.2.3")]
+
+    def test_yarn_add(self):
+        pkgs = extract_install_packages("yarn add react@18.2.0")
+        assert pkgs == [PackageRef("npm", "react", "18.2.0")]
+
+    def test_pnpm_add(self):
+        pkgs = extract_install_packages("pnpm add typescript@5.4.0")
+        assert pkgs == [PackageRef("npm", "typescript", "5.4.0")]
+
+    def test_bun_add(self):
+        pkgs = extract_install_packages("bun add react@18.2.0")
+        assert pkgs == [PackageRef("npm", "react", "18.2.0")]
+
+    def test_npm_i_alias(self):
+        pkgs = extract_install_packages("npm i axios@1.6.8")
+        assert pkgs == [PackageRef("npm", "axios", "1.6.8")]
+
+    def test_multiple_packages(self):
+        pkgs = extract_install_packages("pip install requests==2.31.0 flask==3.0.0 numpy")
+        assert pkgs == [
+            PackageRef("PyPI", "requests", "2.31.0"),
+            PackageRef("PyPI", "flask", "3.0.0"),
+            PackageRef("PyPI", "numpy", None),
+        ]
+
+    def test_pip_extras_stripped(self):
+        pkgs = extract_install_packages("pip install requests[security]==2.31.0")
+        assert pkgs == [PackageRef("PyPI", "requests", "2.31.0")]
+
+    def test_flags_skipped(self):
+        pkgs = extract_install_packages("pip install --no-deps requests==2.31.0")
+        assert pkgs == [PackageRef("PyPI", "requests", "2.31.0")]
+
+    def test_pip_range_stops_at_gt(self):
+        # The regex args group stops at `>`, so `flask>=2.0` is truncated
+        # to `flask` — emitted as an unversioned ref. Intentional: the loose
+        # regex trades precision for simplicity.
+        pkgs = extract_install_packages("pip install flask>=2.0")
+        assert pkgs == [PackageRef("PyPI", "flask", None)]
+
+    def test_npm_range_prefix_dropped(self):
+        pkgs = extract_install_packages("npm install axios@^1.6.8")
+        assert pkgs == [PackageRef("npm", "axios", None)]
+
+    def test_npm_latest_tag_dropped(self):
+        pkgs = extract_install_packages("npm install axios@latest")
+        assert pkgs == [PackageRef("npm", "axios", None)]
+
+    def test_local_path_skipped(self):
+        pkgs = extract_install_packages("pip install ./local-package")
+        assert pkgs == []
+
+    def test_url_skipped(self):
+        pkgs = extract_install_packages("pip install https://example.com/pkg.whl")
+        assert pkgs == []
+
+    def test_case_insensitive(self):
+        pkgs = extract_install_packages("PIP INSTALL Requests==2.31.0")
+        # The manager/verb regex is case-insensitive, name is taken verbatim.
+        assert pkgs == [PackageRef("PyPI", "Requests", "2.31.0")]
+
+    def test_no_install_command(self):
+        assert extract_install_packages("echo hello") == []
+        assert extract_install_packages("ls -la") == []
+
+    def test_args_stop_at_chain_operator(self):
+        # We deliberately don't follow chain operators — the brief calls this
+        # out as explicitly out of scope. But packages before the operator
+        # should still be caught.
+        pkgs = extract_install_packages("pip install requests==2.31.0 && echo done")
+        assert pkgs == [PackageRef("PyPI", "requests", "2.31.0")]
+
+    def test_sh_c_is_best_effort(self):
+        # Documented non-goal: we do not parse sh -c wrappers or quoting.
+        # The regex may either find the inner command (with garbled version
+        # tokens from surrounding quotes) or miss it entirely; either is
+        # acceptable. Just assert the call doesn't crash.
+        pkgs = extract_install_packages("sh -c 'pip install requests==2.31.0'")
+        # Name should be recognised even if the version token gets mangled.
+        assert any(p.name == "requests" for p in pkgs)
+
+
+# =============================================================================
+# extract_tool_result_packages — tool output scanning
+# =============================================================================
+
+
+class TestExtractToolResultPackages:
+    def test_pip_freeze_output(self):
+        text = "requests==2.31.0\nflask==3.0.0\nurllib3==2.0.7"
+        pkgs = extract_tool_result_packages(text)
+        assert PackageRef("PyPI", "requests", "2.31.0") in pkgs
+        assert PackageRef("PyPI", "flask", "3.0.0") in pkgs
+        assert PackageRef("PyPI", "urllib3", "2.0.7") in pkgs
+
+    def test_package_json_format(self):
+        text = '{"dependencies": {"axios": "1.6.8", "left-pad": "1.3.0"}}'
+        pkgs = extract_tool_result_packages(text)
+        assert PackageRef("npm", "axios", "1.6.8") in pkgs
+        assert PackageRef("npm", "left-pad", "1.3.0") in pkgs
+
+    def test_package_json_caret_prefix_stripped(self):
+        text = '{"axios": "^1.6.8"}'
+        pkgs = extract_tool_result_packages(text)
+        assert PackageRef("npm", "axios", "1.6.8") in pkgs
+
+    def test_scoped_npm_in_json(self):
+        text = '{"@scope/pkg": "1.2.3"}'
+        pkgs = extract_tool_result_packages(text)
+        assert PackageRef("npm", "@scope/pkg", "1.2.3") in pkgs
+
+    def test_skips_non_package_json_keys(self):
+        text = '{"name": "my-app", "version": "1.0.0", "axios": "1.6.8"}'
+        pkgs = extract_tool_result_packages(text)
+        names = {p.name for p in pkgs}
+        assert "axios" in names
+        assert "name" not in names
+        assert "version" not in names
+
+    def test_pip_show_output(self):
+        text = "Name: requests\nVersion: 2.31.0\n"
+        # Plain "Version: 2.31.0" has no name==version pattern; the simple
+        # scanner shouldn't hallucinate. Documented best-effort miss.
+        assert extract_tool_result_packages(text) == []
+
+    def test_empty_text(self):
+        assert extract_tool_result_packages("") == []
+
+    def test_no_matches(self):
+        assert extract_tool_result_packages("hello world") == []
+
+
+# =============================================================================
+# OSV severity extraction
+# =============================================================================
+
+
+class TestExtractMaxSeverity:
+    def test_cvss_v3_high(self):
+        entry = {
+            "severity": [
+                {"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+            ],
+        }
+        assert _extract_max_severity(entry) is Severity.CRITICAL
+
+    def test_cvss_v3_medium(self):
+        entry = {
+            "severity": [
+                {"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"},
+            ],
+        }
+        assert _extract_max_severity(entry) is Severity.MEDIUM
+
+    def test_numeric_score(self):
+        entry = {"severity": [{"type": "CVSS_V3", "score": "7.5"}]}
+        assert _extract_max_severity(entry) is Severity.HIGH
+
+    def test_label_fallback(self):
+        entry = {"database_specific": {"severity": "CRITICAL"}}
+        assert _extract_max_severity(entry) is Severity.CRITICAL
+
+    def test_affected_db_specific(self):
+        entry = {"affected": [{"database_specific": {"severity": "HIGH"}}]}
+        assert _extract_max_severity(entry) is Severity.HIGH
+
+    def test_max_across_signals(self):
+        entry = {
+            "severity": [{"type": "CVSS_V3", "score": "4.0"}],
+            "database_specific": {"severity": "CRITICAL"},
+        }
+        assert _extract_max_severity(entry) is Severity.CRITICAL
+
+    def test_empty_entry(self):
+        assert _extract_max_severity({}) is Severity.UNKNOWN
+
+    def test_cvss_v4_falls_back_to_high(self):
+        # CVSS v4 vectors we can't parse must NOT silently downgrade to UNKNOWN;
+        # OSV only publishes these for real advisories, so fail-safe is HIGH.
+        entry = {"severity": [{"type": "CVSS_V4", "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N"}]}
+        assert _extract_max_severity(entry) is Severity.HIGH
+
+    def test_cvss_v4_with_label_prefers_label(self):
+        entry = {
+            "severity": [{"type": "CVSS_V4", "score": "CVSS:4.0/AV:N/AC:L"}],
+            "database_specific": {"severity": "CRITICAL"},
+        }
+        assert _extract_max_severity(entry) is Severity.CRITICAL
+
+
+class TestParseCvssScore:
+    def test_numeric(self):
+        assert _parse_cvss_score(7.5) == 7.5
+        assert _parse_cvss_score(10) == 10.0
+
+    def test_bare_numeric_string(self):
+        assert _parse_cvss_score("7.5") == 7.5
+
+    def test_cvss_v3_vector(self):
+        score = _parse_cvss_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+        assert score is not None
+        assert score >= 9.0  # critical
+
+    def test_cvss_v4_returns_none(self):
+        assert _parse_cvss_score("CVSS:4.0/AV:N") is None
+
+    def test_malformed(self):
+        assert _parse_cvss_score("nonsense") is None
+
+    def test_none(self):
+        assert _parse_cvss_score(None) is None
+
+
+class TestCvss3BaseScore:
+    def test_critical(self):
+        score = _cvss3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+        assert score == 9.8
+
+    def test_missing_metric_returns_none(self):
+        assert _cvss3_base_score("CVSS:3.1/AV:N/AC:L/PR:N") is None
+
+    def test_malformed_metric_returns_none(self):
+        assert _cvss3_base_score("CVSS:3.1/AV:X/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H") is None
+
+
+# =============================================================================
+# Credential redaction
+# =============================================================================
+
+
+class TestRedactCredentials:
+    def test_url_credentials(self):
+        text = "pip install --index-url https://user:secret@example.com/simple/ pkg"
+        redacted = redact_credentials(text)
+        assert "secret" not in redacted
+        assert "<redacted>@" in redacted
+
+    def test_token_flag(self):
+        text = "pip install --token abc123xyz pkg"
+        redacted = redact_credentials(text)
+        assert "abc123xyz" not in redacted
+        assert "<redacted>" in redacted
+
+    def test_password_flag_equals(self):
+        text = "tool --password=topsecret"
+        redacted = redact_credentials(text)
+        assert "topsecret" not in redacted
+
+    def test_no_credentials(self):
+        text = "pip install requests==2.31.0"
+        assert redact_credentials(text) == text
+
+
+# =============================================================================
+# Formatting
+# =============================================================================
+
+
+class TestFormatting:
+    def test_untrusted_summary_adds_delimiter(self):
+        out = format_untrusted_summary("malicious SQL injection")
+        assert out.startswith("<untrusted OSV advisory text>")
+
+    def test_untrusted_summary_truncates(self):
+        long = "x" * 500
+        out = format_untrusted_summary(long)
+        assert len(out) < 500
+
+    def test_untrusted_summary_first_line_only(self):
+        out = format_untrusted_summary("line1\nline2")
+        assert "line1" in out
+        assert "line2" not in out
+
+    def test_format_advisory_flagged(self):
+        result = PackageCheckResult(
+            package=PackageRef("PyPI", "litellm", "1.48.0"),
+            vulns=[VulnInfo("CVE-2025-12345", "remote code execution", Severity.CRITICAL)],
+        )
+        msg = format_advisory_message([result], Severity.HIGH, command="pip install litellm==1.48.0")
+        assert "SUPPLY CHAIN ADVISORY" in msg
+        assert "litellm@1.48.0" in msg
+        assert "CVE-2025-12345" in msg
+        assert "CRITICAL" in msg
+        # Confirms the "not blocked" framing.
+        assert "NOT blocked" in msg
+
+    def test_format_advisory_errored(self):
+        result = PackageCheckResult(
+            package=PackageRef("PyPI", "requests", "2.31.0"),
+            error="connection refused",
+        )
+        msg = format_advisory_message([result], Severity.HIGH)
+        assert "OSV lookup failed" in msg
+        assert "requests" in msg
+        assert "connection refused" in msg
+
+
+# =============================================================================
+# OSV client (no network; uses dummy httpx client)
+# =============================================================================
+
+
+class _DummyResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _DummyClient:
+    def __init__(self, payload: dict):
+        self._payload = payload
+        self.calls: list[dict] = []
+
+    async def post(self, url: str, json: dict, timeout: float):
+        self.calls.append(json)
+        return _DummyResponse(self._payload)
+
+
+@pytest.mark.asyncio
+async def test_osv_client_versioned_query():
+    client = _DummyClient({"vulns": []})
+    osv = OSVClient(http_client=client)  # type: ignore[arg-type]
+    await osv.query(PackageRef("PyPI", "requests", "2.31.0"))
+    assert client.calls[0] == {
+        "package": {"name": "requests", "ecosystem": "PyPI"},
+        "version": "2.31.0",
+    }
+
+
+@pytest.mark.asyncio
+async def test_osv_client_unversioned_query():
+    client = _DummyClient({"vulns": []})
+    osv = OSVClient(http_client=client)  # type: ignore[arg-type]
+    await osv.query(PackageRef("npm", "axios", None))
+    assert client.calls[0] == {"package": {"name": "axios", "ecosystem": "npm"}}
+
+
+@pytest.mark.asyncio
+async def test_osv_client_parses_vulns():
+    payload = {
+        "vulns": [
+            {
+                "id": "GHSA-xxxx",
+                "summary": "bad",
+                "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}],
+            }
+        ]
+    }
+    client = _DummyClient(payload)
+    osv = OSVClient(http_client=client)  # type: ignore[arg-type]
+    vulns = await osv.query(PackageRef("PyPI", "thing", "1.0"))
+    assert len(vulns) == 1
+    assert vulns[0].id == "GHSA-xxxx"
+    assert vulns[0].severity is Severity.CRITICAL


### PR DESCRIPTION
## Summary

Replaces the closed [PR #522](https://github.com/LuthienResearch/luthien-proxy/pull/522) (`SupplyChainGuardPolicy`) with a deliberately narrower `SupplyChainAdvisoryPolicy`.

The previous PR grew into a 4,800-line shell-command parser trying to be robust against an adversarial LLM obfuscating install commands. Seven rounds of adversarial review kept finding bypasses because **that's not the threat model that matters**.

The actual threat is much narrower: known-compromised package versions being installed *innocently* during the window between CVE publication and registry yank (e.g. the recent `litellm` and `axios` incidents). The LLM is cooperative — it's just as blind to the CVE as the user. A loose regex is enough to catch the common case; obfuscation bypasses are out of scope.

## What this PR does

- **`SupplyChainAdvisoryPolicy`** hooks into the Anthropic request, response, and stream lifecycle.
- On outgoing `Bash` `tool_use` blocks (streaming and non-streaming), buffers the input JSON, regex-extracts `(ecosystem, name, version)` tuples for `pip|pip3|uv|poetry|pipenv|conda|npm|yarn|pnpm|bun` install/add/upgrade commands, queries OSV.dev concurrently (capped by semaphore), and **injects a visible advisory text block** alongside the original tool_use whenever any package matches a HIGH+ severity advisory.
- On incoming `tool_result` text in the latest user message, scans for `pkg==1.2.3` (pip freeze / pip show) and `"pkg": "1.2.3"` (package.json) patterns and prepends a system-prompt advisory if any "currently installed" package is flagged.
- Caches OSV results via `PolicyContext.policy_cache` (positive + negative TTL).
- Configurable threshold (`advisory_severity_threshold`, default `HIGH`).
- Fail-closed on OSV unreachability by default (`warn_on_osv_error: true`) — injects an "OSV unavailable" advisory rather than silently passing.
- `hard_block_versions` config field reserved as a forward-compatibility marker; v1 rejects any non-empty value to avoid giving operators a false sense of enforcement.
- Reuses the OSV client, severity parser (CVSS v3 base-score implementation + v4 fail-safe), credential redaction, and untrusted-summary delimiter from PR #522.

## What was dropped from PR #522

- Entire shell parser machinery: `_normalise_chain_operators`, `_strip_wrapper_prefix`, `_detect_unsupported_install_form`, `_find_hard_block_reason_recursive`, `_split_on_chaining`, `sh -c` recursion, `env --` handling, `parse_install_commands`, etc.
- `_CHAIN_PATTERN`, `_HARD_BLOCK_*` patterns, all wrapper/prefix detection.
- The "unsupported manager" concept (regex misses are simply not flagged).
- Hard blocking. All matches become warnings; the LLM relays them to the user.
- 220 of the 346 tests (~all the bypass-resistance tests).

## Non-goals (explicit)

This is a **best-effort CVE advisory policy for cooperative LLMs**. It is **NOT a security boundary** and is not designed to resist:

- `sh -c '<obfuscated>'` wrappers
- Chain operators (`&&`, `||`, `;`)
- `eval`, `exec`, base64 / hex decoding, variable indirection
- Non-standard package managers
- Quoting tricks

For hardened supply-chain defense, run OSV-Scanner inside the sandbox at install time. This policy's purpose is to warn a cooperative LLM — and through it, the user — when a known-compromised package version is about to be installed or is already present in tool output. The threat model is "innocent install of a freshly-disclosed CVE", not "attacker-controlled LLM trying to slip a poisoned package past a static checker".

## Test plan

- [x] `./scripts/dev_checks.sh` passes (format + lint + tests + pyright + radon)
- [x] 126 unit tests pass (`test_supply_chain_advisory_policy.py` + `test_supply_chain_advisory_utils.py`)
- [x] Pyright clean on all four new files
- [ ] Manual smoke: configure the policy in `policy_config.yaml`, run a Claude Code session that calls `Bash` with `pip install litellm==1.48.0`, observe the advisory text block
- [ ] Manual smoke: same setup, run `pip freeze | grep litellm` in the prior turn, observe the system-prompt advisory injected on the next request

---
*Posted by Claude Code (claude-opus-4-6[1m])*