### PR TITLE
fix(test): raise TTL in policy-cache self-evict test to 60s

### DIFF
--- a/changelog.d/policy-cache-test-flake.md
+++ b/changelog.d/policy-cache-test-flake.md
@@ -1,0 +1,5 @@
+---
+category: Chores & Docs
+---
+
+**Fix flaky `test_new_key_is_never_immediately_self_evicted`**: The test used `ttl_seconds=1` to demonstrate "short TTL" but SQLite stores `expires_at` at second precision (`datetime('now')` truncates fractional seconds), so up to ~1 full second of the TTL could vanish before the assertion. On loaded CI runners the entry would already be expired when the test asserted `cache.get("c_new") == {"v": "new"}`, producing an `AssertionError: assert None == {'v': 'new'}`. Raised the TTL to 60s — still much shorter than the 10,000s of the other rows (which is what the test actually needs to exercise FIFO-vs-expires_at ordering), and now comfortably above any realistic put→get latency.

--- a/tests/luthien_proxy/unit_tests/utils/test_policy_cache.py
+++ b/tests/luthien_proxy/unit_tests/utils/test_policy_cache.py
@@ -695,10 +695,14 @@ class TestPolicyCacheSizeCap:
         await cache.put("a_old", {"v": "old1"}, ttl_seconds=10_000)
         await cache.put("b_old", {"v": "old2"}, ttl_seconds=10_000)
 
-        # Now put a new entry with a much *shorter* TTL. Under a
-        # naive expires_at-ASC eviction this would evict itself; under
-        # FIFO-by-created_at the new entry survives and an old one goes.
-        await cache.put("c_new", {"v": "new"}, ttl_seconds=1)
+        # Put a new entry with a *shorter* TTL than the long-lived rows.
+        # Under a naive expires_at-ASC eviction this would evict itself;
+        # under FIFO-by-created_at the new entry survives and an old one
+        # goes. TTL must be long enough to survive SQLite's second-
+        # precision expires_at (datetime('now') truncates fractional
+        # seconds) plus worst-case CI latency between put() and get() —
+        # a 1s TTL flakes on loaded CI runners.
+        await cache.put("c_new", {"v": "new"}, ttl_seconds=60)
 
         assert await _count_entries(db_pool, "selfevict") == 2
         assert await cache.get("c_new") == {"v": "new"}


### PR DESCRIPTION
## Summary

`tests/luthien_proxy/unit_tests/utils/test_policy_cache.py::TestPolicyCacheSizeCap::test_new_key_is_never_immediately_self_evicted` flakes on loaded CI runners because it uses `ttl_seconds=1` — too tight for SQLite's second-precision `expires_at` storage.

### Root cause

`PolicyCache.put()` formats `expires_at` as `%Y-%m-%d %H:%M:%S` (second precision) and `get()` compares against SQLite's `datetime('now')` (also second precision, truncates fractional seconds). A put at wall-clock time `10:00:00.500` with TTL=1 stores `expires_at = '10:00:01'`, and a get at `10:00:01.100` sees `datetime('now') = '10:00:01'` — the `expires_at > now` comparison fails and the entry is reported as missing. Up to ~1 full second of the nominal TTL can vanish to truncation.

Under fast conditions the test passes; under any CI load it flakes. Observed on PR #531 merge-check run [24271278937](https://github.com/LuthienResearch/luthien-proxy/actions/runs/24271278937) (passed on the #533 merge run 5 minutes earlier, failed here).

### Fix

Raise the TTL from 1s → 60s. The test's intent is to demonstrate that FIFO-by-`created_at` eviction keeps a new-but-shorter-TTL entry alive; 60s is still dramatically shorter than the other rows' 10,000s (which is what actually exercises the FIFO-vs-expires_at distinction) and now comfortably above any realistic put→get latency.

## Test plan

- [x] Run `uv run pytest tests/luthien_proxy/unit_tests/utils/test_policy_cache.py::TestPolicyCacheSizeCap --no-cov -q` locally — all 11 tests pass
- [ ] CI `dev-checks` passes on this PR
- [ ] After merge, PR #531's merge check re-runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)