### PR TITLE
fix: clear settings cache in sqlite e2e conftest before create_app

### DIFF
--- a/tests/luthien_proxy/e2e_tests/sqlite/conftest.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/conftest.py
@@ -18,6 +18,7 @@ import pytest
 import uvicorn
 
 from luthien_proxy.main import create_app
+from luthien_proxy.settings import clear_settings_cache
 from luthien_proxy.utils.db import DatabasePool
 from luthien_proxy.utils.migration_check import check_migrations
 
@@ -53,6 +54,10 @@ def sqlite_gateway_url(mock_anthropic):
         old_env[k] = os.environ.get(k)
         os.environ[k] = v
 
+    # Flush cached settings so create_app() picks up the env vars set above.
+    # Without this, get_settings() may return a stale instance that lacks
+    # ANTHROPIC_API_KEY, causing credential resolution to fail.
+    clear_settings_cache()
     app = create_app(
         api_key=_API_KEY,
         admin_key=_ADMIN_API_KEY,


### PR DESCRIPTION
## Summary

- Fixes a pre-existing bug where the sqlite e2e gateway fixture could pick up stale cached settings that lack `ANTHROPIC_API_KEY`, causing credential resolution to fail

## Root cause

The session-scoped `sqlite_gateway_url` fixture in `conftest.py` sets `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` env vars before calling `create_app()`. However, `get_settings()` uses `@lru_cache` — if any prior import triggered settings resolution, the cached instance won't include the newly-set env vars.

## Fix

Call `clear_settings_cache()` after setting env vars and before `create_app()`, matching the pattern used by the root test conftest's autouse fixture.

Split from PR #517 per "One PR = One Concern" policy.