### PR TITLE
fix(test): clear settings cache in activity stream sqlite fixture

### DIFF
--- a/changelog.d/fix-activity-stream-settings-cache.md
+++ b/changelog.d/fix-activity-stream-settings-cache.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**Activity stream sqlite e2e fixture settings cache**: Follow-up to PR #538. The `gateway_url` module-scoped fixture in `tests/luthien_proxy/e2e_tests/sqlite/test_activity_stream.py` had the same stale-settings-cache bug: it set `ANTHROPIC_*` env vars then called `create_app()` without flushing `get_settings()`, and module-scoped fixtures run before the function-scoped autouse cache clearer. Now calls `clear_settings_cache()` before `create_app()` and again in teardown. Also added a teardown `clear_settings_cache()` to `sqlite/conftest.py::sqlite_gateway_url` for full hermeticity.

--- a/tests/luthien_proxy/e2e_tests/sqlite/conftest.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/conftest.py
@@ -94,6 +94,7 @@ def sqlite_gateway_url(mock_anthropic):
             os.environ.pop(k, None)
         else:
             os.environ[k] = v
+    clear_settings_cache()
 
 
 # --- Fixture overrides ---

--- a/tests/luthien_proxy/e2e_tests/sqlite/test_activity_stream.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/test_activity_stream.py
@@ -22,6 +22,7 @@ from tests.luthien_proxy.e2e_tests.mock_anthropic.responses import text_response
 from tests.luthien_proxy.e2e_tests.mock_anthropic.server import MockAnthropicServer
 
 from luthien_proxy.main import create_app
+from luthien_proxy.settings import clear_settings_cache
 from luthien_proxy.utils.db import DatabasePool
 from luthien_proxy.utils.migration_check import check_migrations
 
@@ -65,6 +66,11 @@ def gateway_url(mock_server):
         old_env[k] = os.environ.get(k)
         os.environ[k] = v
 
+    # Flush cached settings so create_app() picks up the env vars set above.
+    # Without this, get_settings() may return a stale instance that lacks
+    # ANTHROPIC_API_KEY, causing credential resolution to fail. Module-scoped
+    # fixtures run before function-scoped autouse fixtures can clear the cache.
+    clear_settings_cache()
     app = create_app(
         api_key=_API_KEY,
         admin_key=_ADMIN_KEY,
@@ -100,6 +106,7 @@ def gateway_url(mock_server):
             os.environ.pop(k, None)
         else:
             os.environ[k] = v
+    clear_settings_cache()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #538 addressing review comments in https://github.com/LuthienResearch/luthien-proxy/pull/538#issuecomment-4227674213.

- **Primary fix**: `tests/luthien_proxy/e2e_tests/sqlite/test_activity_stream.py::gateway_url` had the same stale-settings-cache bug that #538 fixed in `sqlite/conftest.py`. It's a module-scoped fixture that mutates `ANTHROPIC_*` env vars then calls `create_app()` without flushing `get_settings()`. Module-scoped fixtures run before the function-scoped autouse cache clearer (`tests/luthien_proxy/conftest.py:6`), so the cache can go stale depending on import order. Added `clear_settings_cache()` before `create_app()`.
- **Minor**: Added `clear_settings_cache()` to both fixture teardowns so they're fully hermetic — the review flagged this as not load-bearing, but it's a one-liner and documents intent.

This is exactly the PR #133 → #277 class of bug the "One PR = One Concern" rule is trying to prevent — patching now while the root cause is fresh.

Not addressed here (out of scope, deferred to a separate follow-up PR as the reviewer suggested): deduplicating the ~40 lines of near-identical sqlite-gateway boot scaffolding between `sqlite/conftest.py::sqlite_gateway_url` and `sqlite/test_activity_stream.py::gateway_url`.

## Test plan

- [x] \`uv run pytest -m sqlite_e2e tests/luthien_proxy/e2e_tests/sqlite/test_activity_stream.py -x -v --timeout=60\` passes (2 passed)
- [x] \`./scripts/dev_checks.sh\` passes
- [ ] Full sqlite_e2e tier passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)