### PR TITLE
feat: supply chain gate policy (command substitution)

### DIFF
--- a/changelog.d/supply-chain-gate.md
+++ b/changelog.d/supply-chain-gate.md
@@ -1,0 +1,20 @@
+---
+category: Features
+---
+
+**Supply chain gate policy**: A new opt-in policy (`SupplyChainGatePolicy`) that
+intercepts bash tool_use calls, detects package install commands via loose
+regex, queries OSV.dev for known vulnerabilities, and rewrites the tool_use's
+`command` field in place to fail loudly when a flagged package matches the
+configured severity threshold. The cooperative LLM sees the failed command in
+the next turn's tool_result and relays the CVE information to the user.
+
+- Command-substitution intervention shape: the tool_use block keeps its
+  original stream index so indices remain monotonic across the stream.
+- Lockfile installs (`npm ci`, `pip install -r requirements.txt`, etc.) are
+  substituted with a dry-run-only command so the LLM can review the resolved
+  package list before re-invoking with explicit package names.
+- Optional `explicit_blocklist` supports pinned versions that bypass OSV
+  (e.g. `PyPI:litellm:1.59.0`).
+- Best-effort gate for cooperative LLMs — explicitly NOT a security boundary.
+  Use OSV-Scanner inside the execution sandbox for adversarial defense.

--- a/config/policy_config.yaml
+++ b/config/policy_config.yaml
@@ -39,3 +39,23 @@ policy:
 #     # judge_instructions: "You are a security analyst. Evaluate tool calls for risk..."
 #     # Optional: Customize blocked message template
 #     # Variables: {tool_name}, {tool_arguments}, {probability}, {explanation}
+
+# Supply Chain Gate Policy - rewrites bash installs of known-vulnerable
+# packages as failing commands. Queries OSV.dev to check package versions.
+# Lockfile installs (npm ci, pip install -r requirements.txt) are always
+# substituted with a dry-run so the LLM can review resolved versions first.
+# This is a best-effort gate for cooperative LLMs — NOT a security boundary.
+# policy:
+#   class: "luthien_proxy.policies.supply_chain_gate_policy:SupplyChainGatePolicy"
+#   config:
+#     severity_threshold: "critical"  # low | medium | high | critical
+#     osv_fail_mode: "warn"            # block | allow | warn
+#     osv_timeout_seconds: 5.0
+#     max_concurrent_lookups: 10
+#     cache_ttl_seconds: 3600
+#     negative_cache_ttl_seconds: 300
+#     block_lockfile_installs: true
+#     explicit_blocklist:
+#       # Hard blocklist that bypasses OSV and the severity threshold:
+#       # - "PyPI:litellm:1.59.0"
+#       # - "npm:axios:1.6.8"

--- a/dev/context/decisions.md
+++ b/dev/context/decisions.md
@@ -7,6 +7,19 @@ If updating existing content significantly, note it: `## Topic (2025-10-08, upda
 
 ---
 
+## SupplyChainGate v3 drops the tool_result scanner (2026-04-10)
+
+**Decision**: v3 of `SupplyChainGatePolicy` (command-substitution design) does not scan incoming `tool_result` content for already-installed compromised packages. v2 (PR #536) had a scanner that inspected output of `pip freeze`, `npm ls`, `cat package.json`, etc., and injected an awareness-only warning into the assistant's context. v3 removes this entirely.
+
+**Rationale**:
+- The install-time gate catches all future installs from the cooperative LLM — which is the actionable case.
+- The awareness-only signal on existing installs added prompt-injection surface (OSV text, package names from untrusted command output) and complicated the injection shape, for marginal value (the LLM cannot uninstall on its own anyway).
+- Operators who need to detect already-installed compromised versions should run OSV-Scanner against their lockfiles out-of-band. That is the right layer for that check, and it runs without LLM involvement.
+
+This is a deliberate scope decision, not an oversight. Revisit only if the install-time gate proves insufficient and there's a specific cooperative-LLM workflow that requires the awareness signal.
+
+---
+
 ## Auto-Release on Merge to Main (2026-04-09)
 
 **Decision**: Fully automated patch releases on every merge to main. Replaces the previous manual tag-based workflow (2026-03-18). See `dev-README.md` § Releasing for the full procedure.

--- a/src/luthien_proxy/policies/supply_chain_gate_policy.py
+++ b/src/luthien_proxy/policies/supply_chain_gate_policy.py
@@ -1,0 +1,428 @@
+"""SupplyChainGatePolicy — command substitution for vulnerable package installs.
+
+Best-effort supply-chain gate for cooperative LLMs at the Luthien proxy layer.
+This policy intercepts bash tool_use calls in Anthropic responses, regex-detects
+package install commands, queries OSV for known vulnerabilities, and rewrites
+the tool_use's ``command`` field in place to fail loudly with a descriptive
+error when a package matches the configured severity threshold. The cooperative
+LLM then sees the failed command in the next turn's tool_result and relays the
+CVE information to the user through its normal error-reporting path.
+
+This is NOT a security boundary. It does not resist adversarial obfuscation
+(``sh -c "$(base64 -d ...)"``, ``eval``, writing scripts and sourcing them,
+etc.). A motivated adversarial LLM can trivially bypass it. For hardened
+supply-chain defense, run OSV-Scanner inside the execution sandbox at install
+time.
+
+The intervention shape is **command substitution**, not content injection.
+Flagged tool_use blocks keep their original stream index so indices remain
+monotonic and no untrusted OSV text reaches the LLM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+from anthropic.lib.streaming import MessageStreamEvent
+from anthropic.types import (
+    InputJSONDelta,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    ToolUseBlock,
+)
+
+from luthien_proxy.policies.supply_chain_gate_utils import (
+    InstallMatch,
+    OSVClient,
+    PackageCheckResult,
+    PackageRef,
+    Severity,
+    SupplyChainGateConfig,
+    VulnInfo,
+    build_blocked_command,
+    build_lockfile_review_command,
+    extract_install_commands,
+    redact_credentials,
+)
+from luthien_proxy.policy_core import AnthropicHookPolicy, BasePolicy
+from luthien_proxy.policy_core.anthropic_execution_interface import AnthropicPolicyEmission
+
+if TYPE_CHECKING:
+    from luthien_proxy.llm.types.anthropic import (
+        AnthropicContentBlock,
+        AnthropicResponse,
+        AnthropicToolUseBlock,
+    )
+    from luthien_proxy.policy_core.policy_context import PolicyContext
+    from luthien_proxy.utils.policy_cache import PolicyCache
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _BufferedBashToolUse:
+    """A tool_use block we're buffering during streaming."""
+
+    id: str
+    name: str
+    input_json: str = ""
+
+
+@dataclass
+class _GateState:
+    """Per-request streaming state."""
+
+    buffered_tool_uses: dict[int, _BufferedBashToolUse] = field(default_factory=dict)
+
+
+class SupplyChainGatePolicy(BasePolicy, AnthropicHookPolicy):
+    """Rewrite bash installs of known-vulnerable packages as failing commands."""
+
+    @property
+    def short_policy_name(self) -> str:
+        """Short human-readable name."""
+        return "SupplyChainGate"
+
+    def __init__(
+        self,
+        config: SupplyChainGateConfig | dict | None = None,
+        osv_client: OSVClient | None = None,
+    ) -> None:
+        """Initialize with optional config and an injectable OSV client (tests)."""
+        self.config = self._init_config(config, SupplyChainGateConfig)
+        self._threshold: Severity = self.config.severity_threshold_enum
+        self._bash_tool_names: frozenset[str] = frozenset(self.config.bash_tool_names)
+        self._blocklist: frozenset[str] = frozenset(self.config.explicit_blocklist)
+        self._osv = osv_client or OSVClient(
+            api_url=self.config.osv_api_url,
+            timeout_seconds=self.config.osv_timeout_seconds,
+        )
+        logger.info(
+            "SupplyChainGatePolicy initialized: threshold=%s, fail_mode=%s, block_lockfile=%s",
+            self._threshold.label,
+            self.config.osv_fail_mode,
+            self.config.block_lockfile_installs,
+        )
+
+    def _state(self, context: "PolicyContext") -> _GateState:
+        return context.get_request_state(self, _GateState, _GateState)
+
+    def _buffered(self, context: "PolicyContext") -> dict[int, _BufferedBashToolUse]:
+        return self._state(context).buffered_tool_uses
+
+    def _cache(self, context: "PolicyContext") -> "PolicyCache | None":
+        if not context.has_policy_cache:
+            return None
+        try:
+            return context.policy_cache(self.short_policy_name)
+        except RuntimeError:
+            return None
+
+    async def _lookup_vulns(self, package: PackageRef, context: "PolicyContext") -> tuple[list[VulnInfo], str | None]:
+        """Get vulns for ``package``, using the policy cache when available."""
+        cache = self._cache(context)
+        key = package.cache_key()
+        if cache is not None:
+            try:
+                cached = await cache.get(key)
+            except Exception as exc:
+                logger.warning("policy_cache get failed for %s: %s", key, exc)
+                cached = None
+            if cached is not None:
+                if cached.get("error") is not None:
+                    return [], str(cached["error"])
+                return [VulnInfo.from_dict(v) for v in cached.get("vulns", [])], None
+        try:
+            vulns = await self._osv.query(package)
+        except Exception as exc:
+            logger.warning("OSV query failed for %s: %s", key, exc)
+            if cache is not None and self.config.negative_cache_ttl_seconds > 0:
+                try:
+                    await cache.put(
+                        key,
+                        {"error": str(exc), "vulns": []},
+                        ttl_seconds=self.config.negative_cache_ttl_seconds,
+                    )
+                except Exception as cache_exc:
+                    logger.warning("policy_cache put (error) failed for %s: %s", key, cache_exc)
+            return [], str(exc)
+        if cache is not None and self.config.cache_ttl_seconds > 0:
+            try:
+                await cache.put(
+                    key,
+                    {"vulns": [v.to_dict() for v in vulns]},
+                    ttl_seconds=self.config.cache_ttl_seconds,
+                )
+            except Exception as exc:
+                logger.warning("policy_cache put failed for %s: %s", key, exc)
+        return vulns, None
+
+    async def _check_packages(self, packages: list[PackageRef], context: "PolicyContext") -> list[PackageCheckResult]:
+        """Look up every package concurrently, capped by the semaphore."""
+        if not packages:
+            return []
+        semaphore = asyncio.Semaphore(self.config.max_concurrent_lookups)
+
+        async def bounded(pkg: PackageRef) -> tuple[list[VulnInfo], str | None]:
+            async with semaphore:
+                return await self._lookup_vulns(pkg, context)
+
+        lookups = await asyncio.gather(*(bounded(p) for p in packages))
+        return [
+            PackageCheckResult(package=pkg, vulns=vulns, error=error, blocklisted=self._is_blocklisted(pkg))
+            for pkg, (vulns, error) in zip(packages, lookups)
+        ]
+
+    def _is_blocklisted(self, package: PackageRef) -> bool:
+        key = package.blocklist_key()
+        return key is not None and key in self._blocklist
+
+    def _should_substitute(self, results: list[PackageCheckResult]) -> bool:
+        """Decide whether to substitute the command based on check results."""
+        if any(r.triggers(self._threshold) for r in results):
+            return True
+        if self.config.osv_fail_mode == "block":
+            return any(r.error is not None for r in results)
+        return False
+
+    async def _rewrite_if_needed(self, command: str, context: "PolicyContext") -> str | None:
+        """Return the substitute command if the gate fires, else ``None``."""
+        if not command:
+            return None
+        matches = extract_install_commands(command)
+        if not matches:
+            return None
+        lockfile_hit = self._maybe_lockfile_substitute(command, matches, context)
+        if lockfile_hit is not None:
+            return lockfile_hit
+        packages = _dedupe_packages([p for m in matches for p in m.packages])
+        if not packages:
+            return None
+        results = await self._check_packages(packages, context)
+        if any(r.error is not None for r in results) and self.config.osv_fail_mode == "warn":
+            errored = [r.package.name for r in results if r.error is not None]
+            logger.warning(
+                "OSV unreachable for %d package(s); passing through per fail_mode=warn: %s",
+                len(errored),
+                ", ".join(errored),
+            )
+        if not self._should_substitute(results):
+            return None
+        context.record_event(
+            "policy.supply_chain_gate.substituted",
+            {
+                "summary": f"Supply chain gate substituted install command ({len(results)} pkg)",
+                "command": redact_credentials(command),
+                "threshold": self._threshold.label,
+                "packages": [
+                    {
+                        "ecosystem": r.package.ecosystem,
+                        "name": r.package.name,
+                        "version": r.package.version,
+                        "max_severity": r.max_severity.label,
+                        "blocklisted": r.blocklisted,
+                        "error": r.error,
+                    }
+                    for r in results
+                ],
+            },
+        )
+        return build_blocked_command(command, results, self._threshold)
+
+    def _maybe_lockfile_substitute(
+        self, command: str, matches: list[InstallMatch], context: "PolicyContext"
+    ) -> str | None:
+        """Return a lockfile-review substitute if any match is a lockfile install."""
+        if not self.config.block_lockfile_installs:
+            return None
+        for match in matches:
+            if match.is_lockfile:
+                context.record_event(
+                    "policy.supply_chain_gate.lockfile_held",
+                    {
+                        "summary": "Lockfile install held by supply-chain gate",
+                        "command": redact_credentials(command),
+                        "manager": match.manager,
+                        "verb": match.verb,
+                    },
+                )
+                return build_lockfile_review_command(command, match.manager, match.verb)
+        return None
+
+    async def on_anthropic_streaming_policy_complete(self, context: "PolicyContext") -> None:
+        """Drop per-request state when streaming finishes."""
+        context.pop_request_state(self, _GateState)
+
+    async def on_anthropic_stream_complete(self, context: "PolicyContext") -> list[AnthropicPolicyEmission]:
+        """Flush any tool_use blocks still buffered when the upstream stream ends."""
+        buffered_map = self._buffered(context)
+        if not buffered_map:
+            return []
+        emissions: list[AnthropicPolicyEmission] = []
+        for index, buffered in sorted(buffered_map.items()):
+            logger.warning(
+                "Stream ended with tool_use still buffered (index=%d, id=%s); emitting as-is",
+                index,
+                buffered.id,
+            )
+            emissions.extend(_reemit_tool_use_events(buffered, index, buffered.input_json or "{}"))
+            emissions.append(
+                cast(
+                    MessageStreamEvent,
+                    RawContentBlockStopEvent(type="content_block_stop", index=index),
+                )
+            )
+        buffered_map.clear()
+        return emissions
+
+    async def on_anthropic_stream_event(
+        self, event: MessageStreamEvent, context: "PolicyContext"
+    ) -> list[MessageStreamEvent]:
+        """Buffer Bash tool_use blocks; rewrite the command at stop time."""
+        if isinstance(event, RawContentBlockStartEvent):
+            return self._handle_block_start(event, context)
+        if isinstance(event, RawContentBlockDeltaEvent):
+            return self._handle_block_delta(event, context)
+        if isinstance(event, RawContentBlockStopEvent):
+            return await self._handle_block_stop(event, context)
+        return [event]
+
+    def _handle_block_start(
+        self, event: RawContentBlockStartEvent, context: "PolicyContext"
+    ) -> list[MessageStreamEvent]:
+        block = event.content_block
+        if isinstance(block, ToolUseBlock) and block.name in self._bash_tool_names:
+            self._buffered(context)[event.index] = _BufferedBashToolUse(id=block.id, name=block.name)
+            return []
+        return [event]
+
+    def _handle_block_delta(
+        self, event: RawContentBlockDeltaEvent, context: "PolicyContext"
+    ) -> list[MessageStreamEvent]:
+        buffered = self._buffered(context)
+        if event.index not in buffered:
+            return [event]
+        if isinstance(event.delta, InputJSONDelta):
+            buffered[event.index].input_json += event.delta.partial_json
+            return []
+        logger.warning(
+            "Unexpected delta type %s at buffered index %d; passing through",
+            type(event.delta).__name__,
+            event.index,
+        )
+        return [event]
+
+    async def _handle_block_stop(
+        self, event: RawContentBlockStopEvent, context: "PolicyContext"
+    ) -> list[MessageStreamEvent]:
+        buffered_map = self._buffered(context)
+        if event.index not in buffered_map:
+            return [cast(MessageStreamEvent, event)]
+        buffered = buffered_map.pop(event.index)
+        command = _extract_command_from_json(buffered.input_json)
+        substitute = await self._rewrite_if_needed(command or "", context)
+        input_json = (
+            _rewrite_command_in_input_json(buffered.input_json, substitute)
+            if substitute is not None
+            else (buffered.input_json or "{}")
+        )
+        reemit = _reemit_tool_use_events(buffered, event.index, input_json)
+        reemit.append(cast(MessageStreamEvent, event))
+        return reemit
+
+    async def on_anthropic_response(
+        self, response: "AnthropicResponse", context: "PolicyContext"
+    ) -> "AnthropicResponse":
+        """Mutate ``content[]`` in place for any flagged bash tool_use blocks."""
+        content = response.get("content", [])
+        if not content:
+            return response
+        new_content: list[AnthropicContentBlock] = []
+        modified = False
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                tool_use = cast("AnthropicToolUseBlock", block)
+                if tool_use.get("name") in self._bash_tool_names:
+                    command = _extract_bash_command(tool_use.get("input", {}))
+                    substitute = await self._rewrite_if_needed(command or "", context)
+                    if substitute is not None:
+                        new_block = dict(tool_use)
+                        new_input = dict(tool_use.get("input") or {})
+                        new_input["command"] = substitute
+                        new_block["input"] = cast(Any, new_input)
+                        new_content.append(cast("AnthropicContentBlock", new_block))
+                        modified = True
+                        continue
+            new_content.append(block)
+        if not modified:
+            return response
+        modified_response = dict(response)
+        modified_response["content"] = new_content
+        return cast("AnthropicResponse", modified_response)
+
+
+def _extract_bash_command(tool_input: object) -> str | None:
+    """Pull the ``command`` string out of a Bash tool_use input dict."""
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command")
+        if isinstance(command, str):
+            return command
+    return None
+
+
+def _extract_command_from_json(raw_json: str) -> str | None:
+    """Best-effort parse of a buffered tool_use input JSON."""
+    if not raw_json:
+        return None
+    try:
+        parsed = json.loads(raw_json)
+    except json.JSONDecodeError:
+        return None
+    return _extract_bash_command(parsed)
+
+
+def _rewrite_command_in_input_json(raw_json: str, new_command: str) -> str:
+    """Return a fresh input-json string with ``command`` replaced."""
+    try:
+        parsed = json.loads(raw_json) if raw_json else {}
+    except json.JSONDecodeError:
+        parsed = {}
+    if not isinstance(parsed, dict):
+        parsed = {}
+    parsed["command"] = new_command
+    return json.dumps(parsed, ensure_ascii=False)
+
+
+def _dedupe_packages(packages: list[PackageRef]) -> list[PackageRef]:
+    """De-dupe by (ecosystem, name, version), preserving order."""
+    seen: set[tuple[str, str, str | None]] = set()
+    unique: list[PackageRef] = []
+    for pkg in packages:
+        key = (pkg.ecosystem, pkg.name, pkg.version)
+        if key not in seen:
+            seen.add(key)
+            unique.append(pkg)
+    return unique
+
+
+def _reemit_tool_use_events(buffered: _BufferedBashToolUse, index: int, input_json: str) -> list[MessageStreamEvent]:
+    """Rebuild the (start, delta) events for a buffered tool_use block.
+
+    Partial-json chunk boundaries are lost; we coalesce into a single delta.
+    """
+    tool_use_block = ToolUseBlock(type="tool_use", id=buffered.id, name=buffered.name, input={})
+    start_event = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=tool_use_block)
+    delta_event = RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=InputJSONDelta(type="input_json_delta", partial_json=input_json or "{}"),
+    )
+    return [cast(MessageStreamEvent, start_event), cast(MessageStreamEvent, delta_event)]
+
+
+__all__ = ["SupplyChainGatePolicy"]

--- a/src/luthien_proxy/policies/supply_chain_gate_policy.py
+++ b/src/luthien_proxy/policies/supply_chain_gate_policy.py
@@ -17,6 +17,19 @@ time.
 The intervention shape is **command substitution**, not content injection.
 Flagged tool_use blocks keep their original stream index so indices remain
 monotonic and no untrusted OSV text reaches the LLM.
+
+Scope: v3 does not scan incoming tool_result content (e.g., output of
+``pip freeze``, ``npm ls``, ``cat package.json``) for already-installed
+compromised versions. v2 (PR #536) had such a scanner; v3 drops it because:
+
+(a) the install-time gate catches all future installs;
+(b) the awareness-only signal added prompt-injection surface and complex
+    injection-shape problems for marginal value;
+(c) operators who need to detect already-installed compromised versions
+    should run OSV-Scanner against their lockfiles out-of-band.
+
+This is a deliberate scope decision, not an oversight. See
+``dev/context/decisions.md`` entry dated 2026-04-10 for the rationale.
 """
 
 from __future__ import annotations
@@ -45,7 +58,7 @@ from luthien_proxy.policies.supply_chain_gate_utils import (
     SupplyChainGateConfig,
     VulnInfo,
     build_blocked_command,
-    build_lockfile_review_command,
+    build_lockfile_substitute,
     extract_install_commands,
     redact_credentials,
 )
@@ -249,9 +262,11 @@ class SupplyChainGatePolicy(BasePolicy, AnthropicHookPolicy):
                         "command": redact_credentials(command),
                         "manager": match.manager,
                         "verb": match.verb,
+                        "requirement_file": match.requirement_file,
+                        "constraint_file": match.constraint_file,
                     },
                 )
-                return build_lockfile_review_command(command, match.manager, match.verb)
+                return build_lockfile_substitute(match, command)
         return None
 
     async def on_anthropic_streaming_policy_complete(self, context: "PolicyContext") -> None:
@@ -310,12 +325,21 @@ class SupplyChainGatePolicy(BasePolicy, AnthropicHookPolicy):
         if isinstance(event.delta, InputJSONDelta):
             buffered[event.index].input_json += event.delta.partial_json
             return []
+        # Unexpected delta type at a buffered tool_use index. We already
+        # swallowed the content_block_start; emitting the delta alone would
+        # leave downstream with an orphaned delta. Flush the buffered block
+        # in passthrough mode (unmodified start + any accumulated input JSON)
+        # and then emit the unexpected delta. Future events at this index
+        # pass through untouched.
         logger.warning(
-            "Unexpected delta type %s at buffered index %d; passing through",
+            "Unexpected delta type %s at buffered index %d; flushing buffered block and releasing",
             type(event.delta).__name__,
             event.index,
         )
-        return [event]
+        flushed = buffered.pop(event.index)
+        emissions = _reemit_tool_use_events(flushed, event.index, flushed.input_json or "{}")
+        emissions.append(event)
+        return emissions
 
     async def _handle_block_stop(
         self, event: RawContentBlockStopEvent, context: "PolicyContext"

--- a/src/luthien_proxy/policies/supply_chain_gate_utils.py
+++ b/src/luthien_proxy/policies/supply_chain_gate_utils.py
@@ -1,0 +1,593 @@
+"""Utilities for SupplyChainGatePolicy.
+
+Pure helpers: data types, loose regex install-command extraction, an OSV.dev
+client, CVSS v3 severity parsing, credential redaction, and blocked-command
+builders. See supply_chain_gate_policy.py for the threat model.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Any, Final, Literal
+
+import httpx
+from pydantic import BaseModel, Field, field_validator
+
+logger = logging.getLogger(__name__)
+
+
+class Severity(IntEnum):
+    """Ordered severity levels. Higher is worse."""
+
+    UNKNOWN = 0
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+    CRITICAL = 4
+
+    @classmethod
+    def from_label(cls, label: str | None) -> "Severity":
+        """Parse a qualitative severity label like ``"HIGH"``."""
+        if not label:
+            return cls.UNKNOWN
+        upper = label.strip().upper()
+        return cls[upper] if upper in cls.__members__ else cls.UNKNOWN
+
+    @classmethod
+    def from_cvss_score(cls, score: float) -> "Severity":
+        """Convert a CVSS numeric base score into a qualitative bucket."""
+        if score >= 9.0:
+            return cls.CRITICAL
+        if score >= 7.0:
+            return cls.HIGH
+        if score >= 4.0:
+            return cls.MEDIUM
+        if score > 0.0:
+            return cls.LOW
+        return cls.UNKNOWN
+
+    @property
+    def label(self) -> str:
+        """Human-readable label."""
+        return self.name
+
+
+@dataclass(frozen=True)
+class PackageRef:
+    """A reference to a single package in a specific ecosystem."""
+
+    ecosystem: str
+    name: str
+    version: str | None = None
+
+    def cache_key(self) -> str:
+        """Key used for caching this package's OSV lookup result."""
+        return f"osv:{self.ecosystem}:{self.name}:{self.version or '*'}"
+
+    def blocklist_key(self) -> str | None:
+        """Canonical key for matching against the explicit_blocklist."""
+        return f"{self.ecosystem}:{self.name}:{self.version}" if self.version else None
+
+
+@dataclass(frozen=True)
+class VulnInfo:
+    """OSV vulnerability summary. Deliberately omits the untrusted ``summary`` field."""
+
+    id: str
+    severity: Severity
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-safe dict for caching."""
+        return {"id": self.id, "severity": int(self.severity)}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "VulnInfo":
+        """Rehydrate from a dict produced by :meth:`to_dict`."""
+        return cls(id=str(data.get("id", "")), severity=Severity(int(data.get("severity", 0))))
+
+
+@dataclass
+class PackageCheckResult:
+    """Result of checking one package against OSV + the explicit blocklist."""
+
+    package: PackageRef
+    vulns: list[VulnInfo] = field(default_factory=list)
+    error: str | None = None
+    blocklisted: bool = False
+
+    @property
+    def max_severity(self) -> Severity:
+        """Highest severity among known vulnerabilities."""
+        return max((v.severity for v in self.vulns), default=Severity.UNKNOWN)
+
+    def triggers(self, threshold: Severity) -> bool:
+        """Whether this result should fire the gate at ``threshold``."""
+        if self.blocklisted:
+            return True
+        return any(v.severity >= threshold for v in self.vulns)
+
+    def triggering_vulns(self, threshold: Severity) -> list[VulnInfo]:
+        """Vulns at or above ``threshold`` (may be empty)."""
+        return [v for v in self.vulns if v.severity >= threshold]
+
+
+_SEVERITY_LITERAL = Literal["low", "medium", "high", "critical"]
+_FAIL_MODE_LITERAL = Literal["block", "allow", "warn"]
+
+
+class SupplyChainGateConfig(BaseModel):
+    """Configuration for SupplyChainGatePolicy."""
+
+    severity_threshold: _SEVERITY_LITERAL = Field(
+        default="critical",
+        description=(
+            "Minimum severity at which a matched package triggers substitution. "
+            "Default CRITICAL — lower thresholds surface a growing fraction of "
+            "CVSS-v4-only advisories as noise."
+        ),
+    )
+    osv_api_url: str = Field(default="https://api.osv.dev/v1/query")
+    osv_timeout_seconds: float = Field(default=5.0, gt=0.0)
+    osv_fail_mode: _FAIL_MODE_LITERAL = Field(
+        default="warn",
+        description="Behavior when OSV is unreachable: block | allow | warn.",
+    )
+    max_concurrent_lookups: int = Field(default=10, ge=1)
+    cache_ttl_seconds: int = Field(default=3600, ge=0)
+    negative_cache_ttl_seconds: int = Field(default=300, ge=0)
+    block_lockfile_installs: bool = Field(
+        default=True,
+        description=(
+            "Substitute lockfile installs (npm ci, pip install -r requirements.txt) "
+            "with a dry-run-only command so the LLM can review resolved versions."
+        ),
+    )
+    explicit_blocklist: tuple[str, ...] = Field(
+        default=(),
+        description=(
+            "Versions to block unconditionally. Format: '<ecosystem>:<name>:<version>' (e.g. 'PyPI:litellm:1.59.0')."
+        ),
+    )
+    bash_tool_names: tuple[str, ...] = Field(default=("Bash",))
+
+    @field_validator("bash_tool_names", "explicit_blocklist", mode="before")
+    @classmethod
+    def _coerce_tuple(cls, value: Any) -> tuple[str, ...]:
+        """Accept list input (from YAML) and normalise to a tuple."""
+        if value is None:
+            return ()
+        if isinstance(value, str):
+            return (value,)
+        if isinstance(value, (list, tuple)):
+            return tuple(str(v) for v in value)
+        return value
+
+    @property
+    def severity_threshold_enum(self) -> Severity:
+        """Parsed severity threshold enum."""
+        return Severity.from_label(self.severity_threshold)
+
+
+_INSTALL_CMD_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b(?P<mgr>pip|pip3|uv|poetry|pipenv|conda|npm|yarn|pnpm|bun)\s+"
+    r"(?:pip\s+)?"  # handles `uv pip install`
+    r"(?P<verb>install|add|i|ci|update|upgrade)\b"
+    r"(?P<args>[^&|;><\n]*)",
+    re.IGNORECASE,
+)
+_PYPI_MGRS: Final[frozenset[str]] = frozenset({"pip", "pip3", "uv", "poetry", "pipenv", "conda"})
+_NPM_MGRS: Final[frozenset[str]] = frozenset({"npm", "yarn", "pnpm", "bun"})
+_LOCKFILE_FLAGS: Final[frozenset[str]] = frozenset({"--frozen-lockfile", "--ci", "--no-lockfile-update"})
+
+
+@dataclass(frozen=True)
+class InstallMatch:
+    """One install command detected inside a Bash tool_use string."""
+
+    manager: str
+    verb: str
+    args: str
+    packages: tuple[PackageRef, ...]
+    is_lockfile: bool
+
+
+def _ecosystem_for(manager: str) -> str | None:
+    m = manager.lower()
+    if m in _PYPI_MGRS:
+        return "PyPI"
+    if m in _NPM_MGRS:
+        return "npm"
+    return None
+
+
+def _split_pip_specifier(raw: str) -> tuple[str, str | None]:
+    """Split ``requests==2.31.0`` into ("requests", "2.31.0")."""
+    bracket_start = raw.find("[")
+    bracket_end = raw.find("]") if bracket_start != -1 else -1
+    if bracket_start != -1 and bracket_end != -1:
+        raw = raw[:bracket_start] + raw[bracket_end + 1 :]
+    for op in ("===", "==", ">=", "<=", "!=", "~=", ">", "<"):
+        if op in raw:
+            name, _, version = raw.partition(op)
+            return name.strip(), version.strip() or None
+    return raw.strip(), None
+
+
+def _split_npm_specifier(raw: str) -> tuple[str, str | None]:
+    """Split ``left-pad@1.3.0`` / ``@scope/pkg@1.0`` into name and version."""
+    if raw.startswith("@"):
+        at = raw.find("@", 1)
+        if at == -1:
+            return raw, None
+        return raw[:at], _normalise_exact_version(raw[at + 1 :])
+    if "@" in raw:
+        name, _, version = raw.partition("@")
+        return name, _normalise_exact_version(version)
+    return raw, None
+
+
+def _normalise_exact_version(version: str) -> str | None:
+    """Return ``version`` if it looks like an exact pin, else ``None``."""
+    version = version.strip()
+    if not version or version in {"latest", "next", "beta", "alpha", "rc", "canary"}:
+        return None
+    if version[0] in "^~<>=!|*x" or " " in version:
+        return None
+    return version
+
+
+def _looks_like_installable_token(token: str) -> bool:
+    """Filter out tokens that obviously aren't package specifiers."""
+    if not token or token.startswith(("-", ".", "/")) or "://" in token:
+        return False
+    return not token.endswith((".tar.gz", ".whl", ".zip", ".tgz", ".txt"))
+
+
+def _is_lockfile_install(manager: str, verb: str, args: str) -> bool:
+    """Detect lockfile-style installs with no argv-named packages."""
+    m = manager.lower()
+    v = verb.lower()
+    if m == "npm" and v == "ci":
+        return True
+    if m in {"pip", "pip3", "uv"}:
+        tokens = args.split()
+        for i, token in enumerate(tokens):
+            if token in {"-r", "--requirement"} or token.startswith("--requirement="):
+                return True
+            if i == 0 and token.endswith(".txt"):
+                return True
+    if m in {"yarn", "pnpm", "bun"} and v == "install":
+        if any(t in _LOCKFILE_FLAGS for t in args.split()):
+            return True
+    return False
+
+
+def extract_install_commands(text: str) -> list[InstallMatch]:
+    """Regex-scan ``text`` for install commands. Deliberately loose."""
+    matches: list[InstallMatch] = []
+    for match in _INSTALL_CMD_RE.finditer(text):
+        manager = match.group("mgr")
+        ecosystem = _ecosystem_for(manager)
+        if ecosystem is None:
+            continue
+        verb = match.group("verb")
+        args = match.group("args") or ""
+        lockfile = _is_lockfile_install(manager, verb, args)
+        packages: list[PackageRef] = []
+        if not lockfile:
+            for raw in args.split():
+                if not _looks_like_installable_token(raw):
+                    continue
+                if ecosystem == "PyPI":
+                    name, version = _split_pip_specifier(raw)
+                else:
+                    name, version = _split_npm_specifier(raw)
+                if name:
+                    packages.append(PackageRef(ecosystem=ecosystem, name=name, version=version))
+        matches.append(
+            InstallMatch(manager=manager, verb=verb, args=args, packages=tuple(packages), is_lockfile=lockfile)
+        )
+    return matches
+
+
+def extract_install_packages(text: str) -> list[PackageRef]:
+    """Flatten ``extract_install_commands`` to a list of package refs."""
+    return [pkg for m in extract_install_commands(text) for pkg in m.packages]
+
+
+_SHARED_HTTP_CLIENT: httpx.AsyncClient | None = None
+
+
+def _get_shared_http_client() -> httpx.AsyncClient:
+    """Return (creating lazily) the module-level httpx.AsyncClient."""
+    global _SHARED_HTTP_CLIENT
+    if _SHARED_HTTP_CLIENT is None:
+        _SHARED_HTTP_CLIENT = httpx.AsyncClient(
+            timeout=httpx.Timeout(10.0, connect=5.0),
+            limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
+        )
+    return _SHARED_HTTP_CLIENT
+
+
+class OSVClient:
+    """Minimal async client for the OSV.dev v1 query endpoint."""
+
+    def __init__(
+        self,
+        api_url: str = "https://api.osv.dev/v1/query",
+        timeout_seconds: float = 5.0,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        """Initialize with endpoint URL, timeout, and optional injected client."""
+        self._api_url = api_url
+        self._timeout = timeout_seconds
+        self._client = http_client
+
+    async def query(self, package: PackageRef) -> list[VulnInfo]:
+        """Look up vulnerabilities for a single package.
+
+        Raises ``httpx.HTTPError`` on transport errors or non-2xx responses.
+        """
+        body: dict[str, Any] = {"package": {"name": package.name, "ecosystem": package.ecosystem}}
+        if package.version:
+            body["version"] = package.version
+        client = self._client or _get_shared_http_client()
+        response = await client.post(self._api_url, json=body, timeout=self._timeout)
+        response.raise_for_status()
+        return _parse_osv_response(response.json())
+
+
+def _parse_osv_response(payload: Any) -> list[VulnInfo]:
+    """Turn the OSV query JSON into ``VulnInfo`` records."""
+    if not isinstance(payload, dict):
+        return []
+    raw_vulns = payload.get("vulns") or []
+    if not isinstance(raw_vulns, list):
+        return []
+    return [
+        VulnInfo(id=str(entry.get("id", "")), severity=_extract_max_severity(entry))
+        for entry in raw_vulns
+        if isinstance(entry, dict)
+    ]
+
+
+def _extract_max_severity(entry: dict[str, Any]) -> Severity:
+    """Pull the highest severity from one OSV vuln entry.
+
+    Unparseable vectors (CVSS v4, future formats) are NOT promoted; we fall
+    through to any qualitative label. With the default threshold at CRITICAL,
+    this biases toward occasional false-negatives over noisy false-positives
+    that would train the LLM to ignore advisories.
+    """
+    max_sev = Severity.UNKNOWN
+    for sev in entry.get("severity") or []:
+        if not isinstance(sev, dict):
+            continue
+        raw_score = sev.get("score")
+        score = _parse_cvss_score(raw_score)
+        if score is not None:
+            candidate = Severity.from_cvss_score(score)
+            if candidate > max_sev:
+                max_sev = candidate
+        elif isinstance(raw_score, str) and raw_score.strip().upper().startswith("CVSS:"):
+            logger.info(
+                "unparseable CVSS vector for OSV entry %s: %s",
+                entry.get("id", "<unknown>"),
+                raw_score,
+            )
+    db_specific = entry.get("database_specific")
+    if isinstance(db_specific, dict):
+        label_sev = Severity.from_label(db_specific.get("severity"))
+        if label_sev > max_sev:
+            max_sev = label_sev
+    for affected in entry.get("affected") or []:
+        if not isinstance(affected, dict):
+            continue
+        aff_db = affected.get("database_specific")
+        if isinstance(aff_db, dict):
+            label_sev = Severity.from_label(aff_db.get("severity"))
+            if label_sev > max_sev:
+                max_sev = label_sev
+    return max_sev
+
+
+def _parse_cvss_score(raw: Any) -> float | None:
+    """Extract the numeric score from an OSV ``severity[].score`` entry."""
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if not isinstance(raw, str):
+        return None
+    stripped = raw.strip()
+    try:
+        return float(stripped)
+    except ValueError:
+        pass
+    if stripped.upper().startswith("CVSS:3"):
+        return _cvss3_base_score(stripped)
+    return None
+
+
+# CVSS v3 base metric values (CVSS 3.0 and 3.1 spec).
+_CVSS3_AV: Final[dict[str, float]] = {"N": 0.85, "A": 0.62, "L": 0.55, "P": 0.2}
+_CVSS3_AC: Final[dict[str, float]] = {"L": 0.77, "H": 0.44}
+_CVSS3_PR_UNCHANGED: Final[dict[str, float]] = {"N": 0.85, "L": 0.62, "H": 0.27}
+_CVSS3_PR_CHANGED: Final[dict[str, float]] = {"N": 0.85, "L": 0.68, "H": 0.5}
+_CVSS3_UI: Final[dict[str, float]] = {"N": 0.85, "R": 0.62}
+_CVSS3_CIA: Final[dict[str, float]] = {"H": 0.56, "L": 0.22, "N": 0.0}
+
+
+def _cvss3_base_score(vector: str) -> float | None:
+    """Compute the CVSS v3.x base score from a vector string."""
+    metrics: dict[str, str] = {}
+    for part in vector.split("/")[1:]:
+        if ":" in part:
+            key, _, value = part.partition(":")
+            metrics[key.strip().upper()] = value.strip().upper()
+    required = ("AV", "AC", "PR", "UI", "S", "C", "I", "A")
+    if not all(m in metrics for m in required):
+        return None
+    scope = metrics["S"]
+    try:
+        av = _CVSS3_AV[metrics["AV"]]
+        ac = _CVSS3_AC[metrics["AC"]]
+        ui = _CVSS3_UI[metrics["UI"]]
+        pr_table = _CVSS3_PR_CHANGED if scope == "C" else _CVSS3_PR_UNCHANGED
+        pr = pr_table[metrics["PR"]]
+        conf = _CVSS3_CIA[metrics["C"]]
+        integ = _CVSS3_CIA[metrics["I"]]
+        avail = _CVSS3_CIA[metrics["A"]]
+    except KeyError:
+        return None
+    isc_base = 1 - (1 - conf) * (1 - integ) * (1 - avail)
+    if scope == "C":
+        impact = 7.52 * (isc_base - 0.029) - 3.25 * pow(isc_base - 0.02, 15)
+    else:
+        impact = 6.42 * isc_base
+    if impact <= 0:
+        return 0.0
+    exploitability = 8.22 * av * ac * pr * ui
+    raw = impact + exploitability
+    if scope == "C":
+        raw *= 1.08
+    return _cvss_roundup(min(raw, 10.0))
+
+
+def _cvss_roundup(value: float) -> float:
+    """CVSS specification roundup: round up to the nearest 0.1."""
+    int_input = round(value * 100_000)
+    if int_input % 10_000 == 0:
+        return int_input / 100_000
+    return (int_input // 10_000 + 1) / 10
+
+
+_URL_CREDENTIAL_RE: Final[re.Pattern[str]] = re.compile(r"([a-zA-Z][a-zA-Z0-9+.\-]*://)[^/@\s]+:[^/@\s]+@")
+_SENSITIVE_FLAG_VALUE_RE: Final[re.Pattern[str]] = re.compile(
+    r"(--(?:token|password|api[-_]key|auth|secret|header)[=\s])(\S+)",
+    re.IGNORECASE,
+)
+
+
+def redact_credentials(text: str) -> str:
+    """Strip embedded credentials from a command or URL."""
+    text = _URL_CREDENTIAL_RE.sub(r"\1<redacted>@", text)
+    return _SENSITIVE_FLAG_VALUE_RE.sub(r"\1<redacted>", text)
+
+
+_ORIGINAL_CMD_CLIP = 200
+_OSV_URL_TEMPLATE: Final[str] = "https://osv.dev/vulnerability/{vuln_id}"
+
+
+def _clip(text: str, limit: int) -> str:
+    """Truncate ``text`` to ``limit`` chars with an ellipsis marker."""
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _shell_escape_single_quoted(text: str) -> str:
+    r"""Escape ``text`` for embedding inside a bash single-quoted string.
+
+    Inside single quotes bash treats every character literally except the
+    single quote itself. Replace each ``'`` with ``'\''``.
+    """
+    return text.replace("'", "'\\''")
+
+
+_DRY_RUN_COMMANDS: Final[dict[tuple[str, str], str]] = {
+    ("npm", "ci"): "npm ci --dry-run",
+    ("yarn", "install"): "yarn install --mode=skip-build",
+    ("pnpm", "install"): "pnpm install --lockfile-only",
+    ("bun", "install"): "bun install --dry-run",
+    ("pip", "install"): "pip install --dry-run -r requirements.txt",
+    ("pip3", "install"): "pip install --dry-run -r requirements.txt",
+    ("uv", "install"): "uv pip install --dry-run -r requirements.txt",
+}
+
+
+def _dry_run_for(manager: str, verb: str) -> str:
+    """Return a dry-run command string for a recognised lockfile manager."""
+    return _DRY_RUN_COMMANDS.get((manager.lower(), verb.lower()), f"{manager.lower()} --help")
+
+
+def _format_blocked_lines(original_command: str, results: list[PackageCheckResult], threshold: Severity) -> list[str]:
+    """Build the human-readable body of a blocked-command error message."""
+    redacted = _clip(redact_credentials(original_command), _ORIGINAL_CMD_CLIP)
+    lines = [
+        "LUTHIEN BLOCKED: supply-chain gate refused to run this command.",
+        f"Original command: {redacted}",
+        "",
+        "Reason: one or more packages in this install match a known advisory at "
+        f"severity {threshold.label} or higher, or appear on the explicit blocklist.",
+    ]
+    triggered = [r for r in results if r.triggers(threshold)]
+    if triggered:
+        lines += ["", "Flagged packages:"]
+        for result in triggered:
+            ver = f"@{result.package.version}" if result.package.version else ""
+            if result.blocklisted:
+                lines.append(f"- {result.package.name}{ver} ({result.package.ecosystem}): explicit blocklist match")
+                continue
+            lines.append(f"- {result.package.name}{ver} ({result.package.ecosystem}) [{result.max_severity.label}]")
+            for vuln in result.triggering_vulns(threshold)[:3]:
+                lines.append(f"    {vuln.id} [{vuln.severity.label}] {_OSV_URL_TEMPLATE.format(vuln_id=vuln.id)}")
+    lines += [
+        "",
+        "This is a best-effort gate for cooperative LLMs. To proceed intentionally, "
+        "pin a patched version or name a package with no matching advisory.",
+    ]
+    return lines
+
+
+def build_blocked_command(original_command: str, results: list[PackageCheckResult], threshold: Severity) -> str:
+    """Build the ``sh -c`` replacement command emitted when a package matches.
+
+    Every string we emit is under our control: OSV vuln IDs, package names,
+    ecosystems, CVE/severity labels, and an osv.dev URL. We never include
+    the OSV ``summary`` field (untrusted text).
+    """
+    body = "\n".join(_format_blocked_lines(original_command, results, threshold))
+    escaped = _shell_escape_single_quoted(body)
+    return f"sh -c 'printf \"%s\\n\" '\"'\"'{escaped}'\"'\"' >&2; exit 42'"
+
+
+_LOCKFILE_ADVISORY = (
+    "LUTHIEN: lockfile installs are held by the supply-chain gate. The dry-run "
+    "output above lists every resolved package version. Please review it, then "
+    "re-run by naming the specific packages explicitly (e.g. 'npm install "
+    "pkg@1.2.3 other@4.5.6') so each version can be checked against OSV."
+)
+
+
+def build_lockfile_review_command(original_command: str, manager: str, verb: str) -> str:
+    """Build the lockfile dry-run substitute command (Option B)."""
+    dry_run_cmd = _dry_run_for(manager, verb)
+    redacted = _clip(redact_credentials(original_command), _ORIGINAL_CMD_CLIP)
+    escaped_original = _shell_escape_single_quoted(redacted)
+    escaped_advisory = _shell_escape_single_quoted(_LOCKFILE_ADVISORY)
+    return (
+        "sh -c '"
+        f'printf "LUTHIEN lockfile review (substituting dry-run for: %s)\\n" '
+        f"'\"'\"'{escaped_original}'\"'\"' >&2; "
+        f"{dry_run_cmd} 2>&1; "
+        f"printf \"\\n%s\\n\" '\"'\"'{escaped_advisory}'\"'\"' >&2; "
+        "exit 42'"
+    )
+
+
+__all__ = [
+    "InstallMatch",
+    "OSVClient",
+    "PackageCheckResult",
+    "PackageRef",
+    "Severity",
+    "SupplyChainGateConfig",
+    "VulnInfo",
+    "build_blocked_command",
+    "build_lockfile_review_command",
+    "extract_install_commands",
+    "extract_install_packages",
+    "redact_credentials",
+]

--- a/src/luthien_proxy/policies/supply_chain_gate_utils.py
+++ b/src/luthien_proxy/policies/supply_chain_gate_utils.py
@@ -55,20 +55,69 @@ class Severity(IntEnum):
         return self.name
 
 
+_ECOSYSTEM_WIRE_FORM: Final[dict[str, str]] = {"pypi": "PyPI", "npm": "npm"}
+
+
+def _canonical_ecosystem(ecosystem: str) -> str:
+    """Lowercased, normalized ecosystem slug used for all internal comparisons."""
+    return ecosystem.strip().lower()
+
+
+def _canonicalize_package(ecosystem: str, name: str) -> str:
+    """Normalize a package name per ecosystem rules for matching.
+
+    PyPI uses PEP 503 (case-insensitive, ``[-_.]+`` collapsed to ``-``).
+    npm is case-insensitive for matching (scopes included) and preserves the
+    ``@scope/name`` shape. Unknown ecosystems fall back to ``.lower()``.
+    """
+    eco = _canonical_ecosystem(ecosystem)
+    stripped = name.strip()
+    if eco == "pypi":
+        return re.sub(r"[-_.]+", "-", stripped).lower()
+    return stripped.lower()
+
+
+def _osv_wire_ecosystem(ecosystem: str) -> str:
+    """Translate a canonical ecosystem slug to OSV's wire-form string."""
+    return _ECOSYSTEM_WIRE_FORM.get(_canonical_ecosystem(ecosystem), ecosystem)
+
+
 @dataclass(frozen=True)
 class PackageRef:
-    """A reference to a single package in a specific ecosystem."""
+    """A reference to a single package in a specific ecosystem.
+
+    ``ecosystem`` and ``name`` are auto-canonicalized on construction:
+    ecosystem is lowercased; ``name`` is normalized per PEP 503 for PyPI or
+    lowercased for npm. The original ``display_name`` is preserved for error
+    messages. Equality is over the canonical fields, so case-variant
+    duplicates collapse.
+    """
 
     ecosystem: str
     name: str
     version: str | None = None
+    display_name: str = field(default="", compare=False)
+
+    def __post_init__(self) -> None:
+        """Auto-canonicalize ecosystem/name and fall back display_name to the input."""
+        canon_eco = _canonical_ecosystem(self.ecosystem)
+        canon_name = _canonicalize_package(canon_eco, self.name)
+        original_display = self.display_name or self.name
+        object.__setattr__(self, "ecosystem", canon_eco)
+        object.__setattr__(self, "name", canon_name)
+        object.__setattr__(self, "display_name", original_display)
+
+    @property
+    def osv_ecosystem(self) -> str:
+        """OSV wire-form ecosystem (e.g., ``PyPI``) for this package."""
+        return _osv_wire_ecosystem(self.ecosystem)
 
     def cache_key(self) -> str:
         """Key used for caching this package's OSV lookup result."""
-        return f"osv:{self.ecosystem}:{self.name}:{self.version or '*'}"
+        return f"osv:{self.osv_ecosystem}:{self.name}:{self.version or '*'}"
 
     def blocklist_key(self) -> str | None:
-        """Canonical key for matching against the explicit_blocklist."""
+        """Canonical key (lowercased ecosystem) for matching against the blocklist."""
         return f"{self.ecosystem}:{self.name}:{self.version}" if self.version else None
 
 
@@ -148,12 +197,15 @@ class SupplyChainGateConfig(BaseModel):
     explicit_blocklist: tuple[str, ...] = Field(
         default=(),
         description=(
-            "Versions to block unconditionally. Format: '<ecosystem>:<name>:<version>' (e.g. 'PyPI:litellm:1.59.0')."
+            "Versions to block unconditionally. Format: '<ecosystem>:<name>:<version>' "
+            "(e.g. 'PyPI:litellm:1.59.0'). Matching is case-insensitive and PEP 503 "
+            "normalized for PyPI names; both the blocklist entry and the command's "
+            "package name are canonicalized before comparison."
         ),
     )
     bash_tool_names: tuple[str, ...] = Field(default=("Bash",))
 
-    @field_validator("bash_tool_names", "explicit_blocklist", mode="before")
+    @field_validator("bash_tool_names", mode="before")
     @classmethod
     def _coerce_tuple(cls, value: Any) -> tuple[str, ...]:
         """Accept list input (from YAML) and normalise to a tuple."""
@@ -164,6 +216,38 @@ class SupplyChainGateConfig(BaseModel):
         if isinstance(value, (list, tuple)):
             return tuple(str(v) for v in value)
         return value
+
+    @field_validator("explicit_blocklist", mode="before")
+    @classmethod
+    def _normalize_blocklist(cls, value: Any) -> tuple[str, ...]:
+        """Canonicalize each blocklist entry to lowercase ecosystem + PEP 503 name.
+
+        Input tolerates any casing of ecosystem (``PyPI``/``pypi``) and any
+        casing/punctuation of name. The stored form uses the canonical
+        ecosystem slug and canonical package name, so membership tests just
+        call :meth:`PackageRef.blocklist_key` on the extracted package.
+        """
+        if value is None:
+            return ()
+        if isinstance(value, str):
+            raw_entries: list[str] = [value]
+        elif isinstance(value, (list, tuple)):
+            raw_entries = [str(v) for v in value]
+        else:
+            return value
+        canonical: list[str] = []
+        for entry in raw_entries:
+            parts = entry.split(":")
+            if len(parts) != 3:
+                # Malformed — keep as-is so the user sees it in logs rather
+                # than silently dropping.
+                canonical.append(entry)
+                continue
+            eco_raw, name_raw, ver_raw = parts
+            canon_eco = _canonical_ecosystem(eco_raw)
+            canon_name = _canonicalize_package(canon_eco, name_raw)
+            canonical.append(f"{canon_eco}:{canon_name}:{ver_raw.strip()}")
+        return tuple(canonical)
 
     @property
     def severity_threshold_enum(self) -> Severity:
@@ -178,20 +262,50 @@ _INSTALL_CMD_RE: Final[re.Pattern[str]] = re.compile(
     r"(?P<args>[^&|;><\n]*)",
     re.IGNORECASE,
 )
+_LINE_CONTINUATION_RE: Final[re.Pattern[str]] = re.compile(r"\\\n[ \t]*")
 _PYPI_MGRS: Final[frozenset[str]] = frozenset({"pip", "pip3", "uv", "poetry", "pipenv", "conda"})
 _NPM_MGRS: Final[frozenset[str]] = frozenset({"npm", "yarn", "pnpm", "bun"})
-_LOCKFILE_FLAGS: Final[frozenset[str]] = frozenset({"--frozen-lockfile", "--ci", "--no-lockfile-update"})
+_LOCKFILE_FLAGS: Final[frozenset[str]] = frozenset({"--frozen-lockfile", "--ci", "--no-lockfile-update", "--immutable"})
+
+# Commands that execute their arguments inside a sandboxed environment that does
+# NOT affect the user's host. We deliberately refuse to recurse into the wrapped
+# command — the brief says v3 is a cooperative gate, not adversarial-robust. If
+# the inner install matters, the sandbox itself (or an OSV-Scanner pre-step)
+# should catch it. Note: ``sudo`` and ``env`` are NOT wrappers in this sense;
+# they run on the host and must still be extracted.
+_WRAPPER_COMMANDS: Final[frozenset[str]] = frozenset(
+    {
+        "docker",
+        "podman",
+        "nerdctl",
+        "kubectl",
+        "oc",
+        "ssh",
+        "nsenter",
+        "nix-shell",
+        "tox",
+        "nox",
+        "vagrant",
+    }
+)
 
 
 @dataclass(frozen=True)
 class InstallMatch:
-    """One install command detected inside a Bash tool_use string."""
+    """One install command detected inside a Bash tool_use string.
+
+    ``requirement_file``/``constraint_file`` capture ``-r`` / ``-c`` args from
+    lockfile-style pip invocations so the dry-run substitute can reference the
+    original filenames rather than hardcoded ``requirements.txt``.
+    """
 
     manager: str
     verb: str
     args: str
     packages: tuple[PackageRef, ...]
     is_lockfile: bool
+    requirement_file: str | None = None
+    constraint_file: str | None = None
 
 
 def _ecosystem_for(manager: str) -> str | None:
@@ -246,36 +360,118 @@ def _looks_like_installable_token(token: str) -> bool:
     return not token.endswith((".tar.gz", ".whl", ".zip", ".tgz", ".txt"))
 
 
-def _is_lockfile_install(manager: str, verb: str, args: str) -> bool:
-    """Detect lockfile-style installs with no argv-named packages."""
+def _extract_pip_requirement_files(args: str) -> tuple[str | None, str | None]:
+    """Pull ``-r <FILE>`` and ``-c <FILE>`` pairs from a pip args string.
+
+    Returns ``(requirement_file, constraint_file)``. Only the first of each is
+    captured — the dry-run substitute forwards them verbatim so the LLM sees
+    a preview of the exact file it asked to install.
+    """
+    tokens = args.split()
+    req: str | None = None
+    con: str | None = None
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token in {"-r", "--requirement"} and i + 1 < len(tokens):
+            req = req or tokens[i + 1]
+            i += 2
+            continue
+        if token.startswith("--requirement="):
+            req = req or token.split("=", 1)[1]
+            i += 1
+            continue
+        if token in {"-c", "--constraint"} and i + 1 < len(tokens):
+            con = con or tokens[i + 1]
+            i += 2
+            continue
+        if token.startswith("--constraint="):
+            con = con or token.split("=", 1)[1]
+            i += 1
+            continue
+        i += 1
+    return req, con
+
+
+def _detect_lockfile(manager: str, verb: str, args: str) -> tuple[bool, str | None, str | None]:
+    """Detect lockfile-style installs and capture any -r/-c pip args.
+
+    Returns ``(is_lockfile, requirement_file, constraint_file)``. Bare
+    ``pip install`` (no ``-r``/``-c``) is NOT treated as a lockfile install.
+    """
     m = manager.lower()
     v = verb.lower()
     if m == "npm" and v == "ci":
-        return True
+        return True, None, None
     if m in {"pip", "pip3", "uv"}:
-        tokens = args.split()
-        for i, token in enumerate(tokens):
-            if token in {"-r", "--requirement"} or token.startswith("--requirement="):
-                return True
-            if i == 0 and token.endswith(".txt"):
-                return True
-    if m in {"yarn", "pnpm", "bun"} and v == "install":
+        req, con = _extract_pip_requirement_files(args)
+        if req is not None or con is not None:
+            return True, req, con
+        return False, None, None
+    if m in {"yarn", "pnpm"} and v == "install":
         if any(t in _LOCKFILE_FLAGS for t in args.split()):
+            return True, None, None
+        # yarn/pnpm default `install` is lockfile-driven if no package specs.
+        if not any(_looks_like_installable_token(t) for t in args.split()):
+            return True, None, None
+        return False, None, None
+    if m == "bun" and v == "install":
+        if any(t in _LOCKFILE_FLAGS for t in args.split()):
+            return True, None, None
+    return False, None, None
+
+
+def _leading_command_words(text: str) -> list[str]:
+    """Return the first word of each pipeline segment in ``text``.
+
+    Pipeline separators are ``&&``, ``||``, ``|``, ``;``. Used to detect
+    wrapper commands like ``docker run`` regardless of where they appear in
+    a chain (e.g. ``cd /tmp && docker run ...``).
+    """
+    segments = re.split(r"&&|\|\||[|;]", text)
+    words: list[str] = []
+    for seg in segments:
+        stripped = seg.strip()
+        if not stripped:
+            continue
+        first = stripped.split(None, 1)[0]
+        words.append(first.lower())
+    return words
+
+
+def _is_wrapper_command(text: str) -> bool:
+    """Return True if any pipeline segment starts with a sandbox wrapper."""
+    for word in _leading_command_words(text):
+        if word in _WRAPPER_COMMANDS:
             return True
     return False
 
 
+def _normalize_line_continuations(text: str) -> str:
+    """Fold backslash-newline line continuations into single spaces."""
+    return _LINE_CONTINUATION_RE.sub(" ", text)
+
+
 def extract_install_commands(text: str) -> list[InstallMatch]:
-    """Regex-scan ``text`` for install commands. Deliberately loose."""
+    """Regex-scan ``text`` for install commands. Deliberately loose.
+
+    Returns an empty list when ``text`` starts with a sandbox wrapper (docker,
+    kubectl, ssh, ...) — the install executes inside an isolated environment
+    that does not affect the host, and we intentionally do not recurse into
+    the wrapped command.
+    """
+    normalized = _normalize_line_continuations(text)
+    if _is_wrapper_command(normalized):
+        return []
     matches: list[InstallMatch] = []
-    for match in _INSTALL_CMD_RE.finditer(text):
+    for match in _INSTALL_CMD_RE.finditer(normalized):
         manager = match.group("mgr")
         ecosystem = _ecosystem_for(manager)
         if ecosystem is None:
             continue
         verb = match.group("verb")
         args = match.group("args") or ""
-        lockfile = _is_lockfile_install(manager, verb, args)
+        lockfile, req_file, con_file = _detect_lockfile(manager, verb, args)
         packages: list[PackageRef] = []
         if not lockfile:
             for raw in args.split():
@@ -288,7 +484,15 @@ def extract_install_commands(text: str) -> list[InstallMatch]:
                 if name:
                     packages.append(PackageRef(ecosystem=ecosystem, name=name, version=version))
         matches.append(
-            InstallMatch(manager=manager, verb=verb, args=args, packages=tuple(packages), is_lockfile=lockfile)
+            InstallMatch(
+                manager=manager,
+                verb=verb,
+                args=args,
+                packages=tuple(packages),
+                is_lockfile=lockfile,
+                requirement_file=req_file,
+                constraint_file=con_file,
+            )
         )
     return matches
 
@@ -331,7 +535,7 @@ class OSVClient:
 
         Raises ``httpx.HTTPError`` on transport errors or non-2xx responses.
         """
-        body: dict[str, Any] = {"package": {"name": package.name, "ecosystem": package.ecosystem}}
+        body: dict[str, Any] = {"package": {"name": package.name, "ecosystem": package.osv_ecosystem}}
         if package.version:
             body["version"] = package.version
         client = self._client or _get_shared_http_client()
@@ -496,20 +700,49 @@ def _shell_escape_single_quoted(text: str) -> str:
     return text.replace("'", "'\\''")
 
 
-_DRY_RUN_COMMANDS: Final[dict[tuple[str, str], str]] = {
-    ("npm", "ci"): "npm ci --dry-run",
-    ("yarn", "install"): "yarn install --mode=skip-build",
-    ("pnpm", "install"): "pnpm install --lockfile-only",
-    ("bun", "install"): "bun install --dry-run",
-    ("pip", "install"): "pip install --dry-run -r requirements.txt",
-    ("pip3", "install"): "pip install --dry-run -r requirements.txt",
-    ("uv", "install"): "uv pip install --dry-run -r requirements.txt",
-}
+def _sh_single_quote(text: str) -> str:
+    """Wrap ``text`` in single quotes, escaping embedded single quotes."""
+    return "'" + text.replace("'", "'\\''") + "'"
 
 
-def _dry_run_for(manager: str, verb: str) -> str:
-    """Return a dry-run command string for a recognised lockfile manager."""
-    return _DRY_RUN_COMMANDS.get((manager.lower(), verb.lower()), f"{manager.lower()} --help")
+# Managers whose native dry-run mode resolves the lockfile WITHOUT touching
+# disk. These enter the lockfile-dry-run substitution path.
+_REAL_DRY_RUN_MANAGERS: Final[frozenset[str]] = frozenset({"npm", "pip", "pip3", "uv", "bun"})
+
+# Managers with no true dry-run mode. yarn's ``--mode=skip-build`` still writes
+# to disk; pnpm's ``--lockfile-only`` rewrites the lockfile. These enter the
+# explain-and-refuse path instead of a fake dry-run.
+_NO_DRY_RUN_MANAGERS: Final[frozenset[str]] = frozenset({"yarn", "pnpm"})
+
+
+def _pip_dry_run_invocation(manager: str, requirement_file: str | None, constraint_file: str | None) -> str:
+    """Build a pip/uv dry-run command that threads the original -r/-c args."""
+    base = "uv pip install --dry-run" if manager.lower() == "uv" else f"{manager.lower()} install --dry-run"
+    parts = [base]
+    if requirement_file:
+        parts += ["-r", _sh_single_quote(requirement_file)]
+    if constraint_file:
+        parts += ["-c", _sh_single_quote(constraint_file)]
+    return " ".join(parts)
+
+
+def _dry_run_for(
+    manager: str,
+    verb: str,
+    requirement_file: str | None = None,
+    constraint_file: str | None = None,
+) -> str:
+    """Return a dry-run command for a manager with true dry-run support."""
+    m = manager.lower()
+    v = verb.lower()
+    if m == "npm" and v == "ci":
+        return "npm ci --dry-run"
+    if m == "bun" and v == "install":
+        return "bun install --dry-run"
+    if m in {"pip", "pip3", "uv"}:
+        return _pip_dry_run_invocation(m, requirement_file, constraint_file)
+    # Should not happen — callers gate on _REAL_DRY_RUN_MANAGERS.
+    return f"{m} --help"
 
 
 def _format_blocked_lines(original_command: str, results: list[PackageCheckResult], threshold: Severity) -> list[str]:
@@ -541,16 +774,29 @@ def _format_blocked_lines(original_command: str, results: list[PackageCheckResul
     return lines
 
 
+def _build_sh_c_wrapper(inner_script: str) -> str:
+    """Wrap a shell script in ``sh -c '...'``, escaping single quotes.
+
+    ``inner_script`` is a literal shell command (or sequence of commands
+    separated by ``;``) that will run when the substitute is executed. The
+    outer wrapper re-escapes every single quote in ``inner_script`` so it
+    survives the outer shell's quote-stripping pass. The emitted wrapper
+    uses ``sh -c`` rather than ``bash -c`` because it must run on any POSIX
+    shell the user's agent happens to invoke.
+    """
+    return f"sh -c {_sh_single_quote(inner_script)}"
+
+
 def build_blocked_command(original_command: str, results: list[PackageCheckResult], threshold: Severity) -> str:
-    """Build the ``sh -c`` replacement command emitted when a package matches.
+    """Build the bash replacement command emitted when a package matches.
 
     Every string we emit is under our control: OSV vuln IDs, package names,
     ecosystems, CVE/severity labels, and an osv.dev URL. We never include
     the OSV ``summary`` field (untrusted text).
     """
     body = "\n".join(_format_blocked_lines(original_command, results, threshold))
-    escaped = _shell_escape_single_quoted(body)
-    return f"sh -c 'printf \"%s\\n\" '\"'\"'{escaped}'\"'\"' >&2; exit 42'"
+    inner = f"printf '%s\\n' {_sh_single_quote(body)} >&2; exit 42"
+    return _build_sh_c_wrapper(inner)
 
 
 _LOCKFILE_ADVISORY = (
@@ -560,20 +806,73 @@ _LOCKFILE_ADVISORY = (
     "pkg@1.2.3 other@4.5.6') so each version can be checked against OSV."
 )
 
+_LOCKFILE_EXPLAIN_REFUSE_ADVISORY = (
+    "LUTHIEN BLOCKED: yarn/pnpm lockfile installs cannot be safely previewed "
+    "by Luthien because these tools do not support a true dry-run mode that "
+    "resolves the lockfile without writing to disk. To proceed safely:\n"
+    "  1. Review the lockfile diff manually,\n"
+    "  2. Or convert to explicit per-package installs that Luthien can vet,\n"
+    "  3. Or set block_lockfile_installs=false in the policy config to opt out "
+    "(NOT recommended)."
+)
 
-def build_lockfile_review_command(original_command: str, manager: str, verb: str) -> str:
-    """Build the lockfile dry-run substitute command (Option B)."""
-    dry_run_cmd = _dry_run_for(manager, verb)
+
+def build_lockfile_dry_run_command(
+    original_command: str,
+    manager: str,
+    verb: str,
+    requirement_file: str | None = None,
+    constraint_file: str | None = None,
+) -> str:
+    """Build a lockfile dry-run substitute for managers with real dry-run mode.
+
+    Only npm, pip/pip3, uv, and bun have a native dry-run that resolves the
+    lockfile without touching disk. For pip the ``-r``/``-c`` file names are
+    threaded through verbatim so the LLM previews the exact file it asked to
+    install, not a hardcoded ``requirements.txt``.
+    """
+    if manager.lower() not in _REAL_DRY_RUN_MANAGERS:
+        raise ValueError(f"build_lockfile_dry_run_command does not support manager={manager!r}")
+    dry_run_cmd = _dry_run_for(manager, verb, requirement_file, constraint_file)
     redacted = _clip(redact_credentials(original_command), _ORIGINAL_CMD_CLIP)
-    escaped_original = _shell_escape_single_quoted(redacted)
-    escaped_advisory = _shell_escape_single_quoted(_LOCKFILE_ADVISORY)
-    return (
-        "sh -c '"
-        f'printf "LUTHIEN lockfile review (substituting dry-run for: %s)\\n" '
-        f"'\"'\"'{escaped_original}'\"'\"' >&2; "
+    header = f"LUTHIEN lockfile review (substituting dry-run for: {redacted})"
+    inner = (
+        f"printf '%s\\n' {_sh_single_quote(header)} >&2; "
         f"{dry_run_cmd} 2>&1; "
-        f"printf \"\\n%s\\n\" '\"'\"'{escaped_advisory}'\"'\"' >&2; "
-        "exit 42'"
+        f"printf '\\n%s\\n' {_sh_single_quote(_LOCKFILE_ADVISORY)} >&2; "
+        "exit 42"
+    )
+    return _build_sh_c_wrapper(inner)
+
+
+def build_lockfile_explain_refuse_command(original_command: str, manager: str, verb: str) -> str:
+    """Build an explain-and-refuse substitute for yarn/pnpm lockfile installs.
+
+    These managers have no real dry-run mode — ``yarn install --mode=skip-build``
+    still writes to disk, ``pnpm install --lockfile-only`` rewrites the
+    lockfile. Rather than pretend, we print an explanation, list remediation
+    options, and exit 42 without running anything.
+    """
+    if manager.lower() not in _NO_DRY_RUN_MANAGERS:
+        raise ValueError(f"build_lockfile_explain_refuse_command does not support manager={manager!r}")
+    redacted = _clip(redact_credentials(original_command), _ORIGINAL_CMD_CLIP)
+    # Assemble the body once and let _sh_single_quote handle all escaping.
+    body = f"{_LOCKFILE_EXPLAIN_REFUSE_ADVISORY}\nOriginal command: {redacted}"
+    inner = f"printf '%s\\n' {_sh_single_quote(body)} >&2; exit 42"
+    return _build_sh_c_wrapper(inner)
+
+
+def build_lockfile_substitute(match: InstallMatch, original_command: str) -> str:
+    """Dispatch to the correct lockfile substitute for ``match``'s manager."""
+    mgr = match.manager.lower()
+    if mgr in _NO_DRY_RUN_MANAGERS:
+        return build_lockfile_explain_refuse_command(original_command, match.manager, match.verb)
+    return build_lockfile_dry_run_command(
+        original_command,
+        match.manager,
+        match.verb,
+        requirement_file=match.requirement_file,
+        constraint_file=match.constraint_file,
     )
 
 
@@ -586,7 +885,9 @@ __all__ = [
     "SupplyChainGateConfig",
     "VulnInfo",
     "build_blocked_command",
-    "build_lockfile_review_command",
+    "build_lockfile_dry_run_command",
+    "build_lockfile_explain_refuse_command",
+    "build_lockfile_substitute",
     "extract_install_commands",
     "extract_install_packages",
     "redact_credentials",

--- a/tests/luthien_proxy/unit_tests/policies/test_supply_chain_gate_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_supply_chain_gate_policy.py
@@ -1,0 +1,784 @@
+"""Unit tests for SupplyChainGatePolicy.
+
+These tests focus on the integration between the policy hooks, the mocked
+OSV client, and the streaming output shape. The regex/severity helpers have
+their own dedicated test module.
+
+Critical streaming correctness tests live in ``TestStreamingShape``. These
+are the tests that would have caught PR #536's non-monotonic-index bug, and
+they are mandatory regression guards for the command-substitution design.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, cast
+
+import pytest
+from anthropic.lib.streaming import MessageStreamEvent
+from anthropic.types import (
+    InputJSONDelta,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    TextBlock,
+    TextDelta,
+    ToolUseBlock,
+)
+
+from luthien_proxy.policies.supply_chain_gate_policy import (
+    SupplyChainGatePolicy,
+    _dedupe_packages,
+    _extract_bash_command,
+    _extract_command_from_json,
+    _GateState,
+    _rewrite_command_in_input_json,
+)
+from luthien_proxy.policies.supply_chain_gate_utils import (
+    OSVClient,
+    PackageRef,
+    Severity,
+    SupplyChainGateConfig,
+    VulnInfo,
+)
+from luthien_proxy.policy_core.policy_context import PolicyContext
+
+# =============================================================================
+# Fakes & helpers
+# =============================================================================
+
+
+class _FakeOSVClient(OSVClient):
+    """In-memory OSV client. Maps cache_key -> list[VulnInfo] or raises."""
+
+    def __init__(
+        self,
+        responses: dict[str, list[VulnInfo]] | None = None,
+        raise_for: set[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self._responses = responses or {}
+        self._raise_for = raise_for or set()
+        self.calls: list[PackageRef] = []
+        self.call_started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.release.set()
+        self.concurrent_high_water = 0
+        self._in_flight = 0
+        self._lock = asyncio.Lock()
+
+    async def query(self, package: PackageRef) -> list[VulnInfo]:
+        self.calls.append(package)
+        async with self._lock:
+            self._in_flight += 1
+            if self._in_flight > self.concurrent_high_water:
+                self.concurrent_high_water = self._in_flight
+        self.call_started.set()
+        try:
+            await self.release.wait()
+            if package.name in self._raise_for:
+                raise RuntimeError(f"OSV down for {package.name}")
+            return list(self._responses.get(package.cache_key(), []))
+        finally:
+            async with self._lock:
+                self._in_flight -= 1
+
+
+def _make_policy(
+    osv: OSVClient | None = None,
+    config: dict[str, Any] | None = None,
+) -> SupplyChainGatePolicy:
+    cfg = SupplyChainGateConfig.model_validate(config or {})
+    return SupplyChainGatePolicy(config=cfg, osv_client=osv or _FakeOSVClient())
+
+
+def _make_context() -> PolicyContext:
+    return PolicyContext.for_testing(transaction_id="test-txn")
+
+
+def _critical(name: str) -> VulnInfo:
+    return VulnInfo(id=f"GHSA-{name}", severity=Severity.CRITICAL)
+
+
+def _medium(name: str) -> VulnInfo:
+    return VulnInfo(id=f"GHSA-{name}-med", severity=Severity.MEDIUM)
+
+
+def _tool_start(index: int, tool_id: str = "t1", name: str = "Bash") -> RawContentBlockStartEvent:
+    return RawContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=ToolUseBlock(type="tool_use", id=tool_id, name=name, input={}),
+    )
+
+
+def _text_start(index: int) -> RawContentBlockStartEvent:
+    return RawContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=TextBlock(type="text", text=""),
+    )
+
+
+def _input_delta(index: int, partial_json: str) -> RawContentBlockDeltaEvent:
+    return RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=InputJSONDelta(type="input_json_delta", partial_json=partial_json),
+    )
+
+
+def _text_delta(index: int, text: str) -> RawContentBlockDeltaEvent:
+    return RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=TextDelta(type="text_delta", text=text),
+    )
+
+
+def _block_stop(index: int) -> RawContentBlockStopEvent:
+    return RawContentBlockStopEvent(type="content_block_stop", index=index)
+
+
+async def _run_stream(
+    policy: SupplyChainGatePolicy,
+    events: list[MessageStreamEvent],
+    context: PolicyContext,
+) -> list[MessageStreamEvent]:
+    out: list[MessageStreamEvent] = []
+    for event in events:
+        out.extend(await policy.on_anthropic_stream_event(event, context))
+    return out
+
+
+# =============================================================================
+# Module-level helpers
+# =============================================================================
+
+
+class TestModuleHelpers:
+    def test_extract_bash_command_variants(self):
+        assert _extract_bash_command({"command": "ls"}) == "ls"
+        assert _extract_bash_command({}) is None
+        assert _extract_bash_command("ls") is None
+        assert _extract_bash_command({"command": 5}) is None
+
+    def test_extract_command_from_json_variants(self):
+        assert _extract_command_from_json('{"command": "ls"}') == "ls"
+        assert _extract_command_from_json("") is None
+        assert _extract_command_from_json("{not json") is None
+
+    def test_dedupe_packages(self):
+        pkgs = [
+            PackageRef("PyPI", "requests", "2.31.0"),
+            PackageRef("PyPI", "requests", "2.31.0"),
+            PackageRef("PyPI", "flask", None),
+        ]
+        assert _dedupe_packages(pkgs) == [
+            PackageRef("PyPI", "requests", "2.31.0"),
+            PackageRef("PyPI", "flask", None),
+        ]
+
+    def test_dedupe_preserves_distinct_versions(self):
+        pkgs = [
+            PackageRef("PyPI", "requests", "2.31.0"),
+            PackageRef("PyPI", "requests", "2.30.0"),
+        ]
+        assert _dedupe_packages(pkgs) == pkgs
+
+    def test_rewrite_command_in_input_json(self):
+        out = _rewrite_command_in_input_json('{"command": "pip install foo", "timeout": 30}', "new")
+        assert json.loads(out) == {"command": "new", "timeout": 30}
+
+    def test_rewrite_command_malformed_fallback(self):
+        out = _rewrite_command_in_input_json("not json", "new")
+        assert json.loads(out) == {"command": "new"}
+
+
+# =============================================================================
+# Init / config
+# =============================================================================
+
+
+class TestInit:
+    def test_default_config(self):
+        policy = SupplyChainGatePolicy()
+        assert policy._threshold is Severity.CRITICAL
+        assert "Bash" in policy._bash_tool_names
+        assert policy.short_policy_name == "SupplyChainGate"
+
+    def test_custom_threshold_and_blocklist(self):
+        policy = _make_policy(config={"severity_threshold": "medium", "explicit_blocklist": ["PyPI:foo:1.0"]})
+        assert policy._threshold is Severity.MEDIUM
+        assert "PyPI:foo:1.0" in policy._blocklist
+
+    def test_freeze_configured_state_passes(self):
+        _make_policy().freeze_configured_state()
+
+
+# =============================================================================
+# Non-streaming on_anthropic_response
+# =============================================================================
+
+
+class TestNonStreamingResponse:
+    @pytest.mark.asyncio
+    async def test_passthrough_when_no_tool_use(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {"content": [{"type": "text", "text": "hi"}]}
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+        assert osv.calls == []
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_non_install_command(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "echo hi"}},
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+        assert osv.calls == []
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_no_advisory(self):
+        osv = _FakeOSVClient(responses={"osv:PyPI:requests:2.31.0": []})
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install requests==2.31.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+        assert len(osv.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_substitutes_critical_package(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.59.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install litellm==1.59.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is not response
+        assert len(result["content"]) == 1  # no new blocks added
+        tool_use = result["content"][0]
+        assert tool_use["type"] == "tool_use"
+        assert tool_use["id"] == "t1"
+        new_command = tool_use["input"]["command"]
+        assert new_command.startswith("sh -c '")
+        assert "LUTHIEN BLOCKED" in new_command
+        assert "litellm" in new_command
+        assert "GHSA-LITELLM" in new_command
+        # The new command is the failing sh script — not the original install.
+        # The original command will appear inside the diagnostic message body
+        # (so the LLM knows what it tried to run), but not as the runnable command.
+        assert "exit 42" in new_command
+
+    @pytest.mark.asyncio
+    async def test_skips_below_threshold(self):
+        osv = _FakeOSVClient(responses={"osv:PyPI:flask:3.0.0": [_medium("FLASK")]})
+        policy = _make_policy(osv)  # default threshold CRITICAL
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install flask==3.0.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+
+    @pytest.mark.asyncio
+    async def test_threshold_lowered_to_medium(self):
+        osv = _FakeOSVClient(responses={"osv:PyPI:flask:3.0.0": [_medium("FLASK")]})
+        policy = _make_policy(osv, {"severity_threshold": "medium"})
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install flask==3.0.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert "LUTHIEN BLOCKED" in result["content"][0]["input"]["command"]
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_bash_tool(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.59.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Read",
+                    "input": {"command": "pip install litellm==1.59.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+        assert osv.calls == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["warn", "allow"])
+    async def test_warn_and_allow_modes_pass_through_on_osv_error(self, mode: str):
+        osv = _FakeOSVClient(raise_for={"litellm"})
+        policy = _make_policy(osv, {"osv_fail_mode": mode})
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install litellm==1.59.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+
+    @pytest.mark.asyncio
+    async def test_block_mode_substitutes_on_osv_error(self):
+        osv = _FakeOSVClient(raise_for={"litellm"})
+        policy = _make_policy(osv, {"osv_fail_mode": "block"})
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install litellm==1.59.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert "LUTHIEN BLOCKED" in result["content"][0]["input"]["command"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_blocklist_substitutes_without_osv(self):
+        osv = _FakeOSVClient()  # empty — would normally allow
+        policy = _make_policy(
+            osv,
+            {
+                "explicit_blocklist": ["PyPI:litellm:1.59.0"],
+                "severity_threshold": "critical",
+            },
+        )
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install litellm==1.59.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        substituted = result["content"][0]["input"]["command"]
+        assert "LUTHIEN BLOCKED" in substituted
+        assert "explicit blocklist" in substituted
+
+    @pytest.mark.asyncio
+    async def test_lockfile_install_substituted_with_dry_run(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)  # block_lockfile_installs default True
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "npm ci"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        substituted = result["content"][0]["input"]["command"]
+        assert "sh -c" in substituted
+        assert "npm ci --dry-run" in substituted
+        assert "LUTHIEN" in substituted
+        # Short-circuits OSV: no packages parsed from `npm ci`.
+        assert osv.calls == []
+
+    @pytest.mark.asyncio
+    async def test_lockfile_passthrough_when_disabled(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv, {"block_lockfile_installs": False})
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "npm ci"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert result is response
+
+
+# =============================================================================
+# STREAMING — CRITICAL CORRECTNESS TESTS
+# =============================================================================
+
+
+class TestStreamingShape:
+    """Mandatory regression tests for the stream-shape invariant.
+
+    These tests verify the stream output respects the Anthropic protocol:
+      - content_block_start indices are strictly monotonic
+      - the number of content_block_start events equals the upstream count
+      - tool_use blocks keep their original index when rewritten
+    """
+
+    @pytest.mark.asyncio
+    async def test_flagged_tool_use_preserves_block_index(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.59.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        events = [
+            _tool_start(0),
+            _input_delta(0, '{"command": "pip install litellm==1.59.0"}'),
+            _block_stop(0),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        starts = [e for e in out if isinstance(e, RawContentBlockStartEvent)]
+        assert len(starts) == 1
+        assert starts[0].index == 0
+
+    @pytest.mark.asyncio
+    async def test_flagged_tool_use_preserves_block_count(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.59.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        events = [
+            _tool_start(0),
+            _input_delta(0, '{"command": "pip install litellm==1.59.0"}'),
+            _block_stop(0),
+        ]
+        upstream_start_count = sum(1 for e in events if isinstance(e, RawContentBlockStartEvent))
+        out = await _run_stream(policy, events, ctx)
+        emitted_start_count = sum(1 for e in out if isinstance(e, RawContentBlockStartEvent))
+        assert emitted_start_count == upstream_start_count
+
+    @pytest.mark.asyncio
+    async def test_two_flagged_tool_uses_preserve_indices(self):
+        osv = _FakeOSVClient(
+            responses={
+                "osv:PyPI:litellm:1.59.0": [_critical("LITELLM")],
+                "osv:npm:axios:1.6.8": [_critical("AXIOS")],
+            },
+        )
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _tool_start(0, tool_id="t0"),
+            _input_delta(0, '{"command": "pip install litellm==1.59.0"}'),
+            _block_stop(0),
+            _text_start(1),
+            _text_delta(1, "here you go"),
+            _block_stop(1),
+            _tool_start(2, tool_id="t2"),
+            _input_delta(2, '{"command": "npm install axios@1.6.8"}'),
+            _block_stop(2),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        starts = [e for e in out if isinstance(e, RawContentBlockStartEvent)]
+        # One start per upstream block.
+        assert [s.index for s in starts] == [0, 1, 2]
+        # Monotonic.
+        indices = [e.index for e in out if hasattr(e, "index")]
+        assert indices == sorted(indices)
+        # Text block at index 1 is untouched (rendered as TextBlock).
+        assert any(isinstance(e, RawContentBlockStartEvent) and isinstance(e.content_block, TextBlock) for e in out)
+
+    @pytest.mark.asyncio
+    async def test_monotonic_block_start_across_mixed_stream(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.59.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _text_start(0),
+            _text_delta(0, "thinking..."),
+            _block_stop(0),
+            _tool_start(1, tool_id="flagged"),
+            _input_delta(1, '{"command": "pip install litellm==1.59.0"}'),
+            _block_stop(1),
+            _text_start(2),
+            _text_delta(2, "okay"),
+            _block_stop(2),
+            _tool_start(3, tool_id="unflagged"),
+            _input_delta(3, '{"command": "echo hi"}'),
+            _block_stop(3),
+            _text_start(4),
+            _text_delta(4, "done"),
+            _block_stop(4),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        starts = [e.index for e in out if isinstance(e, RawContentBlockStartEvent)]
+        assert starts == [0, 1, 2, 3, 4]
+        assert starts == sorted(starts)
+
+    @pytest.mark.asyncio
+    async def test_flagged_tool_use_rewrites_command_field(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.59.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _tool_start(0),
+            _input_delta(0, '{"command": "pip install litellm==1.59.0"}'),
+            _block_stop(0),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        deltas = [e for e in out if isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, InputJSONDelta)]
+        assert len(deltas) == 1
+        partial = deltas[0].delta.partial_json  # type: ignore[union-attr]
+        assert "sh -c" in partial
+        assert "LUTHIEN BLOCKED" in partial
+        # The original command's first token `pip` must not remain as a
+        # runnable command. It can appear in the redacted-original quoted
+        # display line, so we assert the runnable command is overwritten
+        # (the `command` JSON value begins with sh -c).
+        parsed = json.loads(partial)
+        assert parsed["command"].startswith("sh -c")
+
+
+# =============================================================================
+# STREAMING — buffering + tool_use shape
+# =============================================================================
+
+
+class TestStreamingBasics:
+    @pytest.mark.asyncio
+    async def test_passthrough_text_block(self):
+        policy = _make_policy()
+        ctx = _make_context()
+        event = _text_start(0)
+        out = await policy.on_anthropic_stream_event(event, ctx)  # type: ignore[arg-type]
+        assert out == [event]
+
+    @pytest.mark.asyncio
+    async def test_non_bash_tool_passthrough(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        event = _tool_start(0, name="Read")
+        out = await policy.on_anthropic_stream_event(event, ctx)  # type: ignore[arg-type]
+        assert out == [event]
+        assert osv.calls == []
+
+    @pytest.mark.asyncio
+    async def test_buffers_bash_tool_use_until_stop(self):
+        osv = _FakeOSVClient(responses={"osv:PyPI:requests:2.31.0": []})
+        policy = _make_policy(osv)
+        ctx = _make_context()
+
+        out_start = await policy.on_anthropic_stream_event(_tool_start(0), ctx)  # type: ignore[arg-type]
+        assert out_start == []
+
+        out_delta = await policy.on_anthropic_stream_event(
+            _input_delta(0, '{"command": "pip install requests==2.31.0"}'),
+            ctx,  # type: ignore[arg-type]
+        )
+        assert out_delta == []
+
+        out_stop = await policy.on_anthropic_stream_event(_block_stop(0), ctx)  # type: ignore[arg-type]
+        assert len(out_stop) == 3
+        types = [type(e).__name__ for e in out_stop]
+        assert types == [
+            "RawContentBlockStartEvent",
+            "RawContentBlockDeltaEvent",
+            "RawContentBlockStopEvent",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_unflagged_tool_use_preserves_command(self):
+        osv = _FakeOSVClient(responses={"osv:PyPI:requests:2.31.0": []})
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        events = [
+            _tool_start(0),
+            _input_delta(0, '{"command": "pip install requests==2.31.0"}'),
+            _block_stop(0),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        delta = next(e for e in out if isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, InputJSONDelta))
+        parsed = json.loads(delta.delta.partial_json)  # type: ignore[union-attr]
+        assert parsed["command"] == "pip install requests==2.31.0"
+
+    @pytest.mark.asyncio
+    async def test_stream_complete_flushes_orphan(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        await policy.on_anthropic_stream_event(_tool_start(0), ctx)  # type: ignore[arg-type]
+        await policy.on_anthropic_stream_event(
+            _input_delta(0, '{"command": "echo hi"}'),
+            ctx,  # type: ignore[arg-type]
+        )
+        # No stop event arrived.
+        emissions = await policy.on_anthropic_stream_complete(ctx)
+        assert len(emissions) == 3  # start + delta + stop
+        # State cleared.
+        state = ctx.get_request_state(policy, _GateState, _GateState)
+        assert state.buffered_tool_uses == {}
+
+    @pytest.mark.asyncio
+    async def test_stream_complete_empty(self):
+        policy = _make_policy()
+        ctx = _make_context()
+        assert await policy.on_anthropic_stream_complete(ctx) == []
+
+    @pytest.mark.asyncio
+    async def test_streaming_policy_complete_pops_state(self):
+        policy = _make_policy()
+        ctx = _make_context()
+        ctx.get_request_state(policy, _GateState, _GateState)
+        await policy.on_anthropic_streaming_policy_complete(ctx)
+        assert ctx.pop_request_state(policy, _GateState) is None
+
+    @pytest.mark.asyncio
+    async def test_partial_json_chunks_accumulate(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.59.0": [_critical("L")]},
+        )
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _tool_start(0),
+            _input_delta(0, '{"comm'),
+            _input_delta(0, 'and": "pip install lit'),
+            _input_delta(0, 'ellm==1.59.0"}'),
+            _block_stop(0),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        # Critical vuln flagged → substituted.
+        delta = next(e for e in out if isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, InputJSONDelta))
+        parsed = json.loads(delta.delta.partial_json)  # type: ignore[union-attr]
+        assert parsed["command"].startswith("sh -c")
+
+
+# =============================================================================
+# Concurrency, dedupe, cache
+# =============================================================================
+
+
+class TestConcurrentLookups:
+    @pytest.mark.asyncio
+    async def test_semaphore_caps_concurrency(self):
+        osv = _FakeOSVClient()
+        osv.release.clear()
+        policy = _make_policy(osv, {"max_concurrent_lookups": 2})
+        ctx = _make_context()
+        task = asyncio.create_task(policy._rewrite_if_needed("pip install a==1 b==1 c==1 d==1 e==1", ctx))
+        await osv.call_started.wait()
+        await asyncio.sleep(0.05)
+        osv.release.set()
+        await task
+        assert osv.concurrent_high_water <= 2
+        assert len(osv.calls) == 5
+
+    @pytest.mark.asyncio
+    async def test_dedupes_before_lookup(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        ctx = _make_context()
+        await policy._rewrite_if_needed("pip install requests==2.31.0 requests==2.31.0", ctx)
+        assert len(osv.calls) == 1
+
+
+class _StubPolicyCache:
+    """Minimal in-memory PolicyCache stand-in for tests."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, Any] = {}
+        self.get_calls = 0
+        self.put_calls = 0
+
+    async def get(self, key: str) -> Any:
+        self.get_calls += 1
+        return self.store.get(key)
+
+    async def put(self, key: str, value: Any, ttl_seconds: int) -> None:
+        self.put_calls += 1
+        self.store[key] = value
+
+
+def _ctx_with_cache(cache: _StubPolicyCache) -> PolicyContext:
+    return PolicyContext.for_testing(
+        transaction_id="test-txn",
+        policy_cache_factory=lambda _name: cast(Any, cache),
+    )
+
+
+class TestCache:
+    @pytest.mark.asyncio
+    async def test_cache_miss_then_hit(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.59.0": [_critical("L")]},
+        )
+        policy = _make_policy(osv)
+        cache = _StubPolicyCache()
+        ctx = _ctx_with_cache(cache)
+
+        await policy._rewrite_if_needed("pip install litellm==1.59.0", ctx)
+        assert len(osv.calls) == 1
+        assert cache.put_calls == 1
+
+        await policy._rewrite_if_needed("pip install litellm==1.59.0", ctx)
+        assert len(osv.calls) == 1  # cached
+        assert cache.get_calls >= 2
+
+    @pytest.mark.asyncio
+    async def test_error_cached_negatively(self):
+        osv = _FakeOSVClient(raise_for={"litellm"})
+        policy = _make_policy(osv)
+        cache = _StubPolicyCache()
+        ctx = _ctx_with_cache(cache)
+
+        await policy._rewrite_if_needed("pip install litellm==1.59.0", ctx)
+        key = PackageRef("PyPI", "litellm", "1.59.0").cache_key()
+        assert cache.store[key].get("error") is not None
+
+        await policy._rewrite_if_needed("pip install litellm==1.59.0", ctx)
+        assert len(osv.calls) == 1  # served from negative cache

--- a/tests/luthien_proxy/unit_tests/policies/test_supply_chain_gate_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_supply_chain_gate_policy.py
@@ -211,7 +211,8 @@ class TestInit:
     def test_custom_threshold_and_blocklist(self):
         policy = _make_policy(config={"severity_threshold": "medium", "explicit_blocklist": ["PyPI:foo:1.0"]})
         assert policy._threshold is Severity.MEDIUM
-        assert "PyPI:foo:1.0" in policy._blocklist
+        # Stored in canonical form.
+        assert "pypi:foo:1.0" in policy._blocklist
 
     def test_freeze_configured_state_passes(self):
         _make_policy().freeze_configured_state()
@@ -782,3 +783,214 @@ class TestCache:
 
         await policy._rewrite_if_needed("pip install litellm==1.59.0", ctx)
         assert len(osv.calls) == 1  # served from negative cache
+
+
+# =============================================================================
+# Major #1 — unexpected-delta at buffered index flushes cleanly
+# =============================================================================
+
+
+class TestBufferedBlockFlushOnUnexpectedDelta:
+    @pytest.mark.asyncio
+    async def test_text_delta_at_buffered_tool_use_flushes_block(self):
+        # Construct a fake stream where a tool_use is buffered (content_block_start
+        # was swallowed) and then an unexpected TextDelta arrives at the same
+        # index. Downstream must see the flushed content_block_start before the
+        # unexpected delta — otherwise the delta is orphaned.
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        ctx = _make_context()
+
+        start_out = await policy.on_anthropic_stream_event(_tool_start(0), ctx)  # type: ignore[arg-type]
+        assert start_out == []  # buffered — nothing emitted yet
+
+        # Accumulate some input_json first so we have state to flush.
+        await policy.on_anthropic_stream_event(
+            _input_delta(0, '{"command": "pip install foo'),
+            ctx,  # type: ignore[arg-type]
+        )
+
+        # Unexpected delta type at the buffered index.
+        text_event = _text_delta(0, "oops")
+        out = await policy.on_anthropic_stream_event(text_event, ctx)  # type: ignore[arg-type]
+
+        # Expected: [flushed start, flushed accumulated json, unexpected delta]
+        assert len(out) == 3
+        assert isinstance(out[0], RawContentBlockStartEvent)
+        assert isinstance(out[1], RawContentBlockDeltaEvent)
+        assert out[2] is text_event
+
+        # Future events at this index must pass through without buffering.
+        post_event = _text_delta(0, "more")
+        out2 = await policy.on_anthropic_stream_event(post_event, ctx)  # type: ignore[arg-type]
+        assert out2 == [post_event]
+
+        # And the state dictionary no longer holds the block.
+        state = ctx.get_request_state(policy, _GateState, _GateState)
+        assert 0 not in state.buffered_tool_uses
+
+
+# =============================================================================
+# Fatal #4 — wrapper commands
+# =============================================================================
+
+
+class TestWrapperCommandIntegration:
+    @pytest.mark.asyncio
+    async def test_docker_run_does_not_trigger_osv_lookup(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.59.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "docker run --rm python:3.11 pip install litellm==1.59.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        # Wrapper suppresses extraction — no substitution, no OSV call.
+        assert result is response
+        assert osv.calls == []
+
+    @pytest.mark.asyncio
+    async def test_sudo_still_substitutes(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.59.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "sudo pip install litellm==1.59.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert "LUTHIEN BLOCKED" in result["content"][0]["input"]["command"]
+
+
+# =============================================================================
+# Fatal #5 — line continuation normalization
+# =============================================================================
+
+
+class TestLineContinuationIntegration:
+    @pytest.mark.asyncio
+    async def test_continuation_still_triggers_substitution(self):
+        osv = _FakeOSVClient(
+            responses={"osv:PyPI:litellm:1.59.0": [_critical("LITELLM")]},
+        )
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install \\\n  litellm==1.59.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        assert "LUTHIEN BLOCKED" in result["content"][0]["input"]["command"]
+        assert len(osv.calls) == 1
+        assert osv.calls[0].name == "litellm"
+
+
+# =============================================================================
+# Fatal #1 — lockfile dry-run threads the filename
+# =============================================================================
+
+
+class TestLockfileDryRunFilenameThreading:
+    @pytest.mark.asyncio
+    async def test_dev_requirements_filename_in_substitute(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install -r dev-requirements.txt"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        substituted = result["content"][0]["input"]["command"]
+        assert "dev-requirements.txt" in substituted
+        # No spurious bare `requirements.txt` argument.
+        assert "'requirements.txt'" not in substituted
+
+    @pytest.mark.asyncio
+    async def test_yarn_uses_explain_refuse_not_dry_run(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv)
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "yarn install --frozen-lockfile"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        substituted = result["content"][0]["input"]["command"]
+        # Fatal #2: yarn must not emit a fake --mode=skip-build dry-run.
+        assert "--mode=skip-build" not in substituted
+        assert "LUTHIEN BLOCKED" in substituted or "cannot be safely previewed" in substituted
+
+
+# =============================================================================
+# Fatal #3 — blocklist canonicalization through the policy
+# =============================================================================
+
+
+class TestBlocklistCanonicalizationPolicy:
+    @pytest.mark.asyncio
+    async def test_pypi_case_variant_matches_blocklist(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv, {"explicit_blocklist": ["PyPI:Pillow:10.0.0"]})
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install pillow==10.0.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        substituted = result["content"][0]["input"]["command"]
+        assert "LUTHIEN BLOCKED" in substituted
+        assert "explicit blocklist" in substituted
+
+    @pytest.mark.asyncio
+    async def test_npm_scoped_case_variant_matches_blocklist(self):
+        osv = _FakeOSVClient()
+        policy = _make_policy(osv, {"explicit_blocklist": ["npm:@MyScope/Pkg:1.0"]})
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "npm install @myscope/pkg@1.0"},
+                },
+            ],
+        }
+        result = await policy.on_anthropic_response(response, _make_context())  # type: ignore[arg-type]
+        substituted = result["content"][0]["input"]["command"]
+        assert "LUTHIEN BLOCKED" in substituted

--- a/tests/luthien_proxy/unit_tests/policies/test_supply_chain_gate_utils.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_supply_chain_gate_utils.py
@@ -1,0 +1,605 @@
+"""Unit tests for SupplyChainGatePolicy utility helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from luthien_proxy.policies.supply_chain_gate_utils import (
+    InstallMatch,
+    OSVClient,
+    PackageCheckResult,
+    PackageRef,
+    Severity,
+    SupplyChainGateConfig,
+    VulnInfo,
+    _cvss3_base_score,
+    _extract_max_severity,
+    _parse_cvss_score,
+    _shell_escape_single_quoted,
+    build_blocked_command,
+    build_lockfile_review_command,
+    extract_install_commands,
+    extract_install_packages,
+    redact_credentials,
+)
+
+# =============================================================================
+# Severity
+# =============================================================================
+
+
+class TestSeverity:
+    def test_from_label_known(self):
+        assert Severity.from_label("HIGH") is Severity.HIGH
+        assert Severity.from_label("critical") is Severity.CRITICAL
+        assert Severity.from_label("low") is Severity.LOW
+
+    def test_from_label_unknown(self):
+        assert Severity.from_label(None) is Severity.UNKNOWN
+        assert Severity.from_label("") is Severity.UNKNOWN
+        assert Severity.from_label("bogus") is Severity.UNKNOWN
+
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            (9.5, Severity.CRITICAL),
+            (9.0, Severity.CRITICAL),
+            (7.5, Severity.HIGH),
+            (7.0, Severity.HIGH),
+            (4.0, Severity.MEDIUM),
+            (1.0, Severity.LOW),
+            (0.0, Severity.UNKNOWN),
+        ],
+    )
+    def test_from_cvss_score(self, score: float, expected: Severity):
+        assert Severity.from_cvss_score(score) is expected
+
+    def test_ordering(self):
+        assert Severity.CRITICAL > Severity.HIGH > Severity.MEDIUM > Severity.LOW > Severity.UNKNOWN
+
+
+# =============================================================================
+# Config validation
+# =============================================================================
+
+
+class TestConfig:
+    def test_defaults(self):
+        cfg = SupplyChainGateConfig()
+        # Default threshold is CRITICAL to avoid spammy false-positive blocks.
+        assert cfg.severity_threshold == "critical"
+        assert cfg.severity_threshold_enum is Severity.CRITICAL
+        assert cfg.osv_fail_mode == "warn"
+        assert cfg.block_lockfile_installs is True
+        assert cfg.explicit_blocklist == ()
+        assert cfg.bash_tool_names == ("Bash",)
+
+    def test_list_fields_coerced_to_tuple(self):
+        cfg = SupplyChainGateConfig.model_validate(
+            {
+                "bash_tool_names": ["Bash", "Terminal"],
+                "explicit_blocklist": ["PyPI:litellm:1.59.0", "npm:axios:1.6.8"],
+            }
+        )
+        assert cfg.bash_tool_names == ("Bash", "Terminal")
+        assert cfg.explicit_blocklist == ("PyPI:litellm:1.59.0", "npm:axios:1.6.8")
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [("severity_threshold", "HIH"), ("osv_fail_mode", "shrug")],
+    )
+    def test_literal_fields_reject_bad_values(self, field: str, value: str):
+        with pytest.raises(ValueError):
+            SupplyChainGateConfig.model_validate({field: value})
+
+    def test_medium_threshold(self):
+        cfg = SupplyChainGateConfig.model_validate({"severity_threshold": "medium"})
+        assert cfg.severity_threshold_enum is Severity.MEDIUM
+
+
+# =============================================================================
+# PackageRef
+# =============================================================================
+
+
+class TestPackageRef:
+    def test_cache_key(self):
+        assert PackageRef("PyPI", "requests", "2.31.0").cache_key() == "osv:PyPI:requests:2.31.0"
+        assert PackageRef("npm", "axios", None).cache_key() == "osv:npm:axios:*"
+
+    def test_blocklist_key(self):
+        assert PackageRef("PyPI", "litellm", "1.59.0").blocklist_key() == "PyPI:litellm:1.59.0"
+        assert PackageRef("npm", "axios", None).blocklist_key() is None
+
+
+# =============================================================================
+# extract_install_packages — regex happy paths (managers)
+# =============================================================================
+
+
+class TestExtractInstallManagers:
+    """Happy-path parsing for each supported package manager."""
+
+    @pytest.mark.parametrize(
+        "cmd,expected",
+        [
+            ("pip install requests==2.31.0", PackageRef("PyPI", "requests", "2.31.0")),
+            ("pip install flask", PackageRef("PyPI", "flask", None)),
+            ("pip3 install numpy==1.26.0", PackageRef("PyPI", "numpy", "1.26.0")),
+            ("uv pip install foo==1.0", PackageRef("PyPI", "foo", "1.0")),
+            ("uv add requests==2.31.0", PackageRef("PyPI", "requests", "2.31.0")),
+            ("poetry add django==5.0", PackageRef("PyPI", "django", "5.0")),
+            ("pipenv install flask==3.0.0", PackageRef("PyPI", "flask", "3.0.0")),
+            ("conda install numpy", PackageRef("PyPI", "numpy", None)),
+            ("npm install axios@1.6.8", PackageRef("npm", "axios", "1.6.8")),
+            ("npm install left-pad", PackageRef("npm", "left-pad", None)),
+            ("npm install @scope/pkg@1.2.3", PackageRef("npm", "@scope/pkg", "1.2.3")),
+            ("yarn add react@18.2.0", PackageRef("npm", "react", "18.2.0")),
+            ("pnpm add typescript@5.4.0", PackageRef("npm", "typescript", "5.4.0")),
+            ("bun add react@18.2.0", PackageRef("npm", "react", "18.2.0")),
+            ("npm i axios@1.6.8", PackageRef("npm", "axios", "1.6.8")),
+            ("PIP INSTALL Requests==2.31.0", PackageRef("PyPI", "Requests", "2.31.0")),
+        ],
+    )
+    def test_manager_happy_path(self, cmd: str, expected: PackageRef):
+        assert extract_install_packages(cmd) == [expected]
+
+
+# =============================================================================
+# extract_install_packages — filtering and edge cases
+# =============================================================================
+
+
+class TestExtractInstallFiltering:
+    def test_multiple_packages(self):
+        pkgs = extract_install_packages("pip install requests==2.31.0 flask==3.0.0 numpy")
+        assert pkgs == [
+            PackageRef("PyPI", "requests", "2.31.0"),
+            PackageRef("PyPI", "flask", "3.0.0"),
+            PackageRef("PyPI", "numpy", None),
+        ]
+
+    def test_pip_extras_stripped(self):
+        assert extract_install_packages("pip install requests[security]==2.31.0") == [
+            PackageRef("PyPI", "requests", "2.31.0"),
+        ]
+
+    def test_flags_skipped(self):
+        assert extract_install_packages("pip install --no-deps requests==2.31.0") == [
+            PackageRef("PyPI", "requests", "2.31.0"),
+        ]
+
+    def test_pip_upgrade_multiple_unversioned(self):
+        assert extract_install_packages("pip install -U pip setuptools wheel") == [
+            PackageRef("PyPI", "pip", None),
+            PackageRef("PyPI", "setuptools", None),
+            PackageRef("PyPI", "wheel", None),
+        ]
+
+    def test_pip_range_stops_at_gt(self):
+        # Args regex terminates at '>' so `flask>=2.0` is truncated to `flask`.
+        assert extract_install_packages("pip install flask>=2.0") == [
+            PackageRef("PyPI", "flask", None),
+        ]
+
+    @pytest.mark.parametrize(
+        "spec,expected_version",
+        [("axios@^1.6.8", None), ("axios@latest", None), ("axios@1.6.8", "1.6.8")],
+    )
+    def test_npm_version_normalisation(self, spec: str, expected_version: str | None):
+        pkgs = extract_install_packages(f"npm install {spec}")
+        assert pkgs == [PackageRef("npm", "axios", expected_version)]
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "pip install ./local-package",
+            "pip install /opt/my-package",
+            "pip install https://example.com/pkg.whl",
+            "pip install pkg.tar.gz",
+            "pip install pkg.whl",
+            "pip install pkg.zip",
+            "pip install -r requirements.txt",
+            "echo hello",
+            "ls -la",
+        ],
+    )
+    def test_no_packages_extracted(self, cmd: str):
+        assert extract_install_packages(cmd) == []
+
+    def test_args_stop_at_chain_operator(self):
+        pkgs = extract_install_packages("pip install requests==2.31.0 && echo done")
+        assert pkgs == [PackageRef("PyPI", "requests", "2.31.0")]
+
+
+# =============================================================================
+# Lockfile install detection
+# =============================================================================
+
+
+class TestLockfileDetection:
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "npm ci",
+            "yarn install --frozen-lockfile",
+            "pnpm install --frozen-lockfile",
+            "pip install -r requirements.txt",
+            "pip install --requirement requirements.txt",
+            "uv pip install -r requirements.txt",
+        ],
+    )
+    def test_is_lockfile(self, cmd: str):
+        matches = extract_install_commands(cmd)
+        assert len(matches) == 1
+        assert matches[0].is_lockfile is True
+        assert matches[0].packages == ()
+
+    @pytest.mark.parametrize("cmd", ["npm install express", "yarn add react@18.2.0"])
+    def test_is_not_lockfile(self, cmd: str):
+        matches = extract_install_commands(cmd)
+        assert len(matches) == 1
+        assert matches[0].is_lockfile is False
+
+    def test_install_match_shape(self):
+        matches = extract_install_commands("npm install axios@1.6.8")
+        assert len(matches) == 1
+        match = matches[0]
+        assert isinstance(match, InstallMatch)
+        assert match.manager == "npm"
+        assert match.verb == "install"
+        assert match.packages == (PackageRef("npm", "axios", "1.6.8"),)
+
+
+# =============================================================================
+# OSV severity extraction
+# =============================================================================
+
+
+class TestExtractMaxSeverity:
+    def test_cvss_v3_critical(self):
+        entry = {
+            "severity": [
+                {"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+            ],
+        }
+        assert _extract_max_severity(entry) is Severity.CRITICAL
+
+    def test_cvss_v3_medium(self):
+        entry = {
+            "severity": [
+                {"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"},
+            ],
+        }
+        assert _extract_max_severity(entry) is Severity.MEDIUM
+
+    def test_numeric_score(self):
+        entry = {"severity": [{"type": "CVSS_V3", "score": "7.5"}]}
+        assert _extract_max_severity(entry) is Severity.HIGH
+
+    def test_label_fallback(self):
+        entry = {"database_specific": {"severity": "CRITICAL"}}
+        assert _extract_max_severity(entry) is Severity.CRITICAL
+
+    def test_affected_db_specific(self):
+        entry = {"affected": [{"database_specific": {"severity": "HIGH"}}]}
+        assert _extract_max_severity(entry) is Severity.HIGH
+
+    def test_max_across_signals(self):
+        entry = {
+            "severity": [{"type": "CVSS_V3", "score": "4.0"}],
+            "database_specific": {"severity": "CRITICAL"},
+        }
+        assert _extract_max_severity(entry) is Severity.CRITICAL
+
+    def test_empty_entry(self):
+        assert _extract_max_severity({}) is Severity.UNKNOWN
+
+    def test_cvss_v4_without_label_is_unknown(self):
+        # v3 fix: do NOT promote unparseable vectors to HIGH.
+        entry = {"severity": [{"type": "CVSS_V4", "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N"}]}
+        assert _extract_max_severity(entry) is Severity.UNKNOWN
+
+    def test_cvss_v4_with_label_uses_label(self):
+        entry = {
+            "severity": [{"type": "CVSS_V4", "score": "CVSS:4.0/AV:N/AC:L"}],
+            "database_specific": {"severity": "CRITICAL"},
+        }
+        assert _extract_max_severity(entry) is Severity.CRITICAL
+
+    def test_cvss_v4_with_low_label_stays_low(self):
+        # A genuine LOW advisory must not accidentally become HIGH under
+        # default thresholds.
+        entry = {
+            "severity": [{"type": "CVSS_V4", "score": "CVSS:4.0/AV:N"}],
+            "database_specific": {"severity": "LOW"},
+        }
+        assert _extract_max_severity(entry) is Severity.LOW
+
+
+class TestParseCvssScore:
+    def test_numeric_forms(self):
+        assert _parse_cvss_score(7.5) == 7.5
+        assert _parse_cvss_score(10) == 10.0
+        assert _parse_cvss_score("7.5") == 7.5
+
+    def test_cvss_v3_vector(self):
+        score = _parse_cvss_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+        assert score is not None
+        assert score >= 9.0
+
+    def test_cvss_v4_not_parseable(self):
+        assert _parse_cvss_score("CVSS:4.0/AV:N") is None
+
+    def test_unparseable_inputs(self):
+        assert _parse_cvss_score("nonsense") is None
+        assert _parse_cvss_score(None) is None
+
+
+class TestCvss3BaseScore:
+    def test_critical_exact(self):
+        assert _cvss3_base_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H") == 9.8
+
+    def test_missing_or_malformed_metric_returns_none(self):
+        assert _cvss3_base_score("CVSS:3.1/AV:N/AC:L/PR:N") is None
+        assert _cvss3_base_score("CVSS:3.1/AV:X/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H") is None
+
+
+# =============================================================================
+# Redaction
+# =============================================================================
+
+
+class TestRedactCredentials:
+    def test_url_credentials(self):
+        redacted = redact_credentials("pip install --index-url https://user:secret@example.com/simple/ pkg")
+        assert "secret" not in redacted
+        assert "<redacted>@" in redacted
+
+    @pytest.mark.parametrize(
+        "text,secret",
+        [
+            ("pip install --token abc123xyz pkg", "abc123xyz"),
+            ("tool --password=topsecret", "topsecret"),
+        ],
+    )
+    def test_flag_values_redacted(self, text: str, secret: str):
+        redacted = redact_credentials(text)
+        assert secret not in redacted
+        assert "<redacted>" in redacted
+
+    def test_no_credentials(self):
+        text = "pip install requests==2.31.0"
+        assert redact_credentials(text) == text
+
+
+# =============================================================================
+# Blocked-command builders (shell escaping, content)
+# =============================================================================
+
+
+class TestShellEscape:
+    def test_no_quotes(self):
+        assert _shell_escape_single_quoted("hello world") == "hello world"
+
+    def test_single_quote(self):
+        # A single quote inside a single-quoted string becomes '\''
+        assert _shell_escape_single_quoted("it's") == "it'\\''s"
+
+    def test_backslash_untouched(self):
+        # Inside single quotes, backslashes are literal — no double-escaping.
+        assert _shell_escape_single_quoted("a\\b") == "a\\b"
+
+
+class TestBuildBlockedCommand:
+    def test_contains_sh_c_and_blocked_marker(self):
+        result = PackageCheckResult(
+            package=PackageRef("PyPI", "litellm", "1.59.0"),
+            vulns=[VulnInfo("GHSA-xxxx", Severity.CRITICAL)],
+        )
+        out = build_blocked_command(
+            "pip install litellm==1.59.0",
+            [result],
+            Severity.CRITICAL,
+        )
+        assert out.startswith("sh -c '")
+        assert out.endswith("exit 42'")
+        assert "LUTHIEN BLOCKED" in out
+
+    def test_includes_package_cve_and_severity(self):
+        result = PackageCheckResult(
+            package=PackageRef("PyPI", "litellm", "1.59.0"),
+            vulns=[VulnInfo("GHSA-abcd-1234", Severity.CRITICAL)],
+        )
+        out = build_blocked_command(
+            "pip install litellm==1.59.0",
+            [result],
+            Severity.CRITICAL,
+        )
+        assert "litellm" in out
+        assert "1.59.0" in out
+        assert "GHSA-abcd-1234" in out
+        assert "CRITICAL" in out
+        # OSV URL link we fully control.
+        assert "osv.dev/vulnerability/GHSA-abcd-1234" in out
+
+    def test_redacts_credentials_in_original(self):
+        result = PackageCheckResult(
+            package=PackageRef("PyPI", "litellm", "1.59.0"),
+            vulns=[VulnInfo("GHSA-x", Severity.CRITICAL)],
+        )
+        out = build_blocked_command(
+            "pip install --token topsecret litellm==1.59.0",
+            [result],
+            Severity.CRITICAL,
+        )
+        assert "topsecret" not in out
+
+    def test_explicit_blocklist_label(self):
+        result = PackageCheckResult(
+            package=PackageRef("npm", "axios", "1.6.8"),
+            vulns=[],
+            blocklisted=True,
+        )
+        out = build_blocked_command(
+            "npm install axios@1.6.8",
+            [result],
+            Severity.CRITICAL,
+        )
+        assert "axios" in out
+        assert "explicit blocklist" in out
+
+    def test_does_not_leak_osv_summary(self):
+        # VulnInfo no longer carries a summary field — regression guard.
+        result = PackageCheckResult(
+            package=PackageRef("PyPI", "litellm", "1.59.0"),
+            vulns=[VulnInfo("GHSA-xxxx", Severity.CRITICAL)],
+        )
+        out = build_blocked_command(
+            "pip install litellm==1.59.0",
+            [result],
+            Severity.CRITICAL,
+        )
+        assert "untrusted" not in out
+        # No "summary:" key leak.
+        assert "summary" not in out.lower()
+
+
+class TestBuildLockfileReviewCommand:
+    def test_npm_ci_shape(self):
+        out = build_lockfile_review_command("npm ci", "npm", "ci")
+        assert out.startswith("sh -c '")
+        assert "npm ci --dry-run" in out
+        assert "LUTHIEN" in out
+        assert "exit 42" in out
+
+    @pytest.mark.parametrize(
+        "original,manager,verb,expected_dry_run",
+        [
+            (
+                "yarn install --frozen-lockfile",
+                "yarn",
+                "install",
+                "yarn install --mode=skip-build",
+            ),
+            (
+                "pnpm install --frozen-lockfile",
+                "pnpm",
+                "install",
+                "pnpm install --lockfile-only",
+            ),
+            (
+                "pip install -r requirements.txt",
+                "pip",
+                "install",
+                "pip install --dry-run -r requirements.txt",
+            ),
+        ],
+    )
+    def test_other_manager_dry_run(self, original: str, manager: str, verb: str, expected_dry_run: str):
+        assert expected_dry_run in build_lockfile_review_command(original, manager, verb)
+
+
+# =============================================================================
+# OSV client (no network; uses dummy httpx client)
+# =============================================================================
+
+
+class _DummyResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _DummyClient:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+        self.calls: list[dict] = []
+
+    async def post(self, url: str, json: dict, timeout: float) -> _DummyResponse:
+        self.calls.append(json)
+        return _DummyResponse(self._payload)
+
+
+@pytest.mark.asyncio
+async def test_osv_client_versioned_query():
+    client = _DummyClient({"vulns": []})
+    osv = OSVClient(http_client=client)  # type: ignore[arg-type]
+    await osv.query(PackageRef("PyPI", "requests", "2.31.0"))
+    assert client.calls[0] == {
+        "package": {"name": "requests", "ecosystem": "PyPI"},
+        "version": "2.31.0",
+    }
+
+
+@pytest.mark.asyncio
+async def test_osv_client_unversioned_query():
+    client = _DummyClient({"vulns": []})
+    osv = OSVClient(http_client=client)  # type: ignore[arg-type]
+    await osv.query(PackageRef("npm", "axios", None))
+    assert client.calls[0] == {"package": {"name": "axios", "ecosystem": "npm"}}
+
+
+@pytest.mark.asyncio
+async def test_osv_client_parses_vulns():
+    payload = {
+        "vulns": [
+            {
+                "id": "GHSA-xxxx",
+                "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}],
+            }
+        ]
+    }
+    client = _DummyClient(payload)
+    osv = OSVClient(http_client=client)  # type: ignore[arg-type]
+    vulns = await osv.query(PackageRef("PyPI", "thing", "1.0"))
+    assert len(vulns) == 1
+    assert vulns[0].id == "GHSA-xxxx"
+    assert vulns[0].severity is Severity.CRITICAL
+
+
+# =============================================================================
+# PackageCheckResult
+# =============================================================================
+
+
+class TestPackageCheckResult:
+    def test_triggers_by_severity(self):
+        crit = PackageCheckResult(
+            package=PackageRef("PyPI", "foo", "1.0"),
+            vulns=[VulnInfo("G", Severity.CRITICAL)],
+        )
+        assert crit.triggers(Severity.HIGH) is True
+        assert crit.triggers(Severity.CRITICAL) is True
+
+        med = PackageCheckResult(
+            package=PackageRef("PyPI", "foo", "1.0"),
+            vulns=[VulnInfo("G", Severity.MEDIUM)],
+        )
+        assert med.triggers(Severity.HIGH) is False
+
+    def test_blocklisted_triggers_regardless(self):
+        result = PackageCheckResult(
+            package=PackageRef("PyPI", "foo", "1.0"),
+            vulns=[],
+            blocklisted=True,
+        )
+        assert result.triggers(Severity.CRITICAL) is True
+
+    def test_max_severity_empty(self):
+        result = PackageCheckResult(package=PackageRef("PyPI", "foo", "1.0"))
+        assert result.max_severity is Severity.UNKNOWN
+
+    def test_triggering_vulns_filters_below_threshold(self):
+        result = PackageCheckResult(
+            package=PackageRef("PyPI", "foo", "1.0"),
+            vulns=[VulnInfo("G1", Severity.LOW), VulnInfo("G2", Severity.CRITICAL)],
+        )
+        triggering = result.triggering_vulns(Severity.HIGH)
+        assert len(triggering) == 1
+        assert triggering[0].id == "G2"

--- a/tests/luthien_proxy/unit_tests/policies/test_supply_chain_gate_utils.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_supply_chain_gate_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 
 from luthien_proxy.policies.supply_chain_gate_utils import (
@@ -12,12 +14,17 @@ from luthien_proxy.policies.supply_chain_gate_utils import (
     Severity,
     SupplyChainGateConfig,
     VulnInfo,
+    _canonical_ecosystem,
+    _canonicalize_package,
     _cvss3_base_score,
     _extract_max_severity,
+    _is_wrapper_command,
+    _normalize_line_continuations,
     _parse_cvss_score,
     _shell_escape_single_quoted,
     build_blocked_command,
-    build_lockfile_review_command,
+    build_lockfile_dry_run_command,
+    build_lockfile_explain_refuse_command,
     extract_install_commands,
     extract_install_packages,
     redact_credentials,
@@ -82,7 +89,9 @@ class TestConfig:
             }
         )
         assert cfg.bash_tool_names == ("Bash", "Terminal")
-        assert cfg.explicit_blocklist == ("PyPI:litellm:1.59.0", "npm:axios:1.6.8")
+        # Blocklist entries are stored in canonical form (lowercase ecosystem +
+        # PEP 503 name) so membership tests work regardless of user casing.
+        assert cfg.explicit_blocklist == ("pypi:litellm:1.59.0", "npm:axios:1.6.8")
 
     @pytest.mark.parametrize(
         "field,value",
@@ -104,12 +113,67 @@ class TestConfig:
 
 class TestPackageRef:
     def test_cache_key(self):
+        # cache_key uses the OSV wire-form ecosystem so OSV responses cache
+        # consistently regardless of how the PackageRef was spelled on input.
         assert PackageRef("PyPI", "requests", "2.31.0").cache_key() == "osv:PyPI:requests:2.31.0"
+        assert PackageRef("pypi", "requests", "2.31.0").cache_key() == "osv:PyPI:requests:2.31.0"
         assert PackageRef("npm", "axios", None).cache_key() == "osv:npm:axios:*"
 
-    def test_blocklist_key(self):
-        assert PackageRef("PyPI", "litellm", "1.59.0").blocklist_key() == "PyPI:litellm:1.59.0"
+    def test_blocklist_key_uses_canonical_form(self):
+        # blocklist_key uses lowercase ecosystem + PEP 503 name so the
+        # explicit blocklist matches regardless of user casing/punctuation.
+        assert PackageRef("PyPI", "litellm", "1.59.0").blocklist_key() == "pypi:litellm:1.59.0"
+        assert PackageRef("pypi", "litellm", "1.59.0").blocklist_key() == "pypi:litellm:1.59.0"
         assert PackageRef("npm", "axios", None).blocklist_key() is None
+
+    def test_canonicalization_collapses_case_variants(self):
+        # Fatal #3: PyPI names collapse per PEP 503.
+        a = PackageRef("PyPI", "Pillow", "10.0.0")
+        b = PackageRef("pypi", "pillow", "10.0.0")
+        assert a == b
+        assert a.name == "pillow"
+        assert a.display_name == "Pillow"
+        # Punctuation variants also collapse.
+        c = PackageRef("PyPI", "Pillow_Image", "1.0")
+        d = PackageRef("PyPI", "pillow-image", "1.0")
+        assert c == d
+        assert c.name == "pillow-image"
+
+    def test_npm_name_lowercased(self):
+        # npm is case-insensitive for matching; both scoped and unscoped.
+        assert PackageRef("npm", "Axios", "1.6.8") == PackageRef("npm", "axios", "1.6.8")
+        assert PackageRef("npm", "@MyScope/Pkg", "1.0") == PackageRef("npm", "@myscope/pkg", "1.0")
+        # Scope and name both lowercased.
+        assert PackageRef("npm", "@MyScope/Pkg", "1.0").name == "@myscope/pkg"
+
+    def test_osv_ecosystem_wire_form(self):
+        assert PackageRef("pypi", "x", "1").osv_ecosystem == "PyPI"
+        assert PackageRef("PyPI", "x", "1").osv_ecosystem == "PyPI"
+        assert PackageRef("npm", "x", "1").osv_ecosystem == "npm"
+
+    def test_display_name_preserved(self):
+        # The original display name is preserved separately for error messages.
+        ref = PackageRef("PyPI", "Pillow", "10.0.0")
+        assert ref.display_name == "Pillow"
+
+
+class TestCanonicalizationHelpers:
+    def test_canonical_ecosystem(self):
+        assert _canonical_ecosystem("PyPI") == "pypi"
+        assert _canonical_ecosystem("NPM") == "npm"
+        assert _canonical_ecosystem("  pypi  ") == "pypi"
+
+    def test_canonicalize_pypi_pep503(self):
+        assert _canonicalize_package("pypi", "Pillow") == "pillow"
+        assert _canonicalize_package("PyPI", "Pillow_Image") == "pillow-image"
+        assert _canonicalize_package("pypi", "Pillow.Image") == "pillow-image"
+        assert _canonicalize_package("pypi", "requests--security") == "requests-security"
+
+    def test_canonicalize_npm(self):
+        assert _canonicalize_package("npm", "Axios") == "axios"
+        assert _canonicalize_package("npm", "@MyScope/Pkg") == "@myscope/pkg"
+        # Non-PEP503 punctuation stays (npm preserves ``-``/``_``).
+        assert _canonicalize_package("npm", "left-pad") == "left-pad"
 
 
 # =============================================================================
@@ -249,6 +313,166 @@ class TestLockfileDetection:
         assert match.manager == "npm"
         assert match.verb == "install"
         assert match.packages == (PackageRef("npm", "axios", "1.6.8"),)
+
+    def test_pip_captures_requirement_file(self):
+        # Fatal #1: the dry-run must thread the original filename.
+        matches = extract_install_commands("pip install -r dev-requirements.txt")
+        assert len(matches) == 1
+        assert matches[0].is_lockfile is True
+        assert matches[0].requirement_file == "dev-requirements.txt"
+        assert matches[0].constraint_file is None
+
+    def test_pip_captures_constraint_file(self):
+        matches = extract_install_commands("pip install -r foo.txt -c constraints.txt")
+        assert len(matches) == 1
+        assert matches[0].requirement_file == "foo.txt"
+        assert matches[0].constraint_file == "constraints.txt"
+
+    def test_pip_long_form_requirement(self):
+        matches = extract_install_commands("pip install --requirement=bar.txt")
+        assert len(matches) == 1
+        assert matches[0].is_lockfile is True
+        assert matches[0].requirement_file == "bar.txt"
+
+    def test_bare_pip_install_is_not_lockfile(self):
+        # Fatal #1: `pip install` with no -r/-c is NOT a lockfile install.
+        # It also has no extractable packages, so it yields no flagged match.
+        matches = extract_install_commands("pip install")
+        # Either zero matches (no packages, no lockfile) or one match with
+        # is_lockfile=False and empty packages — both are acceptable here.
+        for m in matches:
+            assert m.is_lockfile is False
+
+
+# =============================================================================
+# Fatal #4 — wrapper command suppression
+# =============================================================================
+
+
+class TestWrapperCommands:
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "docker run --rm python:3.11 pip install requests==2.31.0",
+            "docker exec -it container pip install requests==2.31.0",
+            "podman run --rm img pip install foo",
+            "nerdctl run img npm install axios@1.6.8",
+            "kubectl exec deploy/foo -- pip install bar",
+            "oc exec pod -- pip install bar",
+            "ssh host pip install bar",
+            "nsenter -t 1 -m pip install bar",
+            'nix-shell -p python3Packages.requests --run "pip install bar"',
+            "tox -e py311 -- pip install bar",
+            "nox -s test -- pip install bar",
+            "vagrant ssh -c 'pip install bar'",
+        ],
+    )
+    def test_wrapper_suppresses_extraction(self, cmd: str):
+        # Fatal #4: wrapper commands run the install in a sandboxed env
+        # that does not affect the host. Return zero matches.
+        assert extract_install_commands(cmd) == []
+        assert extract_install_packages(cmd) == []
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "sudo pip install requests==2.31.0",
+            "env FOO=bar pip install requests==2.31.0",
+            "pip install requests==2.31.0",
+        ],
+    )
+    def test_sudo_and_env_are_not_wrappers(self, cmd: str):
+        # sudo/env run the install on the host — still extracted.
+        pkgs = extract_install_packages(cmd)
+        assert pkgs == [PackageRef("PyPI", "requests", "2.31.0")]
+
+    def test_wrapper_in_chained_segment(self):
+        # Chain: `cd /tmp && docker run ...` — the docker segment should
+        # suppress. This is a cooperative-case assumption; we're not trying
+        # to be adversarial-robust.
+        assert extract_install_commands("cd /tmp && docker run --rm img pip install foo") == []
+
+    def test_is_wrapper_command_detects_leading_word(self):
+        assert _is_wrapper_command("docker run img pip install foo") is True
+        assert _is_wrapper_command("sudo pip install foo") is False
+        assert _is_wrapper_command("pip install foo") is False
+
+
+# =============================================================================
+# Fatal #5 — line continuation normalization
+# =============================================================================
+
+
+class TestLineContinuations:
+    def test_normalize_joins_lines(self):
+        # Backslash-newline and any trailing whitespace on the next line
+        # collapse into a single space (the space before the backslash is
+        # preserved).
+        assert _normalize_line_continuations("pip install \\\n  requests") == "pip install  requests"
+
+    def test_single_continuation(self):
+        # Fatal #5: `pip install \\\n  requests==2.31.0` used to capture `\`
+        # as the package name. After normalization it extracts the real pkg.
+        pkgs = extract_install_packages("pip install \\\n  requests==2.31.0")
+        assert pkgs == [PackageRef("PyPI", "requests", "2.31.0")]
+
+    def test_multiple_continuations(self):
+        cmd = "pip install \\\n  pkg-a==1.0 \\\n  pkg-b==2.0"
+        pkgs = extract_install_packages(cmd)
+        assert pkgs == [
+            PackageRef("PyPI", "pkg-a", "1.0"),
+            PackageRef("PyPI", "pkg-b", "2.0"),
+        ]
+
+    def test_no_continuation_still_works(self):
+        pkgs = extract_install_packages("pip install requests==2.31.0")
+        assert pkgs == [PackageRef("PyPI", "requests", "2.31.0")]
+
+
+# =============================================================================
+# Fatal #3 — explicit blocklist canonicalization
+# =============================================================================
+
+
+class TestBlocklistCanonicalization:
+    def test_config_canonicalizes_pypi_names(self):
+        cfg = SupplyChainGateConfig.model_validate({"explicit_blocklist": ["PyPI:Pillow:10.0.0"]})
+        # Stored canonical form: lowercase ecosystem + PEP 503 name.
+        assert "pypi:pillow:10.0.0" in cfg.explicit_blocklist
+
+    def test_config_canonicalizes_punctuation(self):
+        cfg = SupplyChainGateConfig.model_validate({"explicit_blocklist": ["PyPI:pillow_image:1.0"]})
+        assert "pypi:pillow-image:1.0" in cfg.explicit_blocklist
+
+    def test_config_canonicalizes_npm_scoped(self):
+        cfg = SupplyChainGateConfig.model_validate({"explicit_blocklist": ["npm:@MyScope/Pkg:1.0"]})
+        assert "npm:@myscope/pkg:1.0" in cfg.explicit_blocklist
+
+    def test_config_accepts_lowercase_ecosystem(self):
+        cfg = SupplyChainGateConfig.model_validate({"explicit_blocklist": ["pypi:requests:2.0"]})
+        assert "pypi:requests:2.0" in cfg.explicit_blocklist
+
+    def test_packageref_blocklist_key_matches_canonical_entry(self):
+        # End-to-end: a PyPI:Pillow:10.0.0 blocklist entry matches a
+        # `pip install pillow==10.0.0` extracted package.
+        cfg = SupplyChainGateConfig.model_validate({"explicit_blocklist": ["PyPI:Pillow:10.0.0"]})
+        extracted = extract_install_packages("pip install pillow==10.0.0")[0]
+        assert extracted.blocklist_key() in cfg.explicit_blocklist
+
+    def test_packageref_blocklist_key_matches_punctuation_variant(self):
+        cfg = SupplyChainGateConfig.model_validate({"explicit_blocklist": ["pypi:pillow-image:1.0"]})
+        extracted = extract_install_packages("pip install Pillow_Image==1.0")[0]
+        assert extracted.blocklist_key() in cfg.explicit_blocklist
+
+    def test_packageref_blocklist_key_matches_npm_scoped_variant(self):
+        cfg = SupplyChainGateConfig.model_validate({"explicit_blocklist": ["npm:@MyScope/Pkg:1.0"]})
+        extracted = extract_install_packages("npm install @myscope/pkg@1.0")[0]
+        assert extracted.blocklist_key() in cfg.explicit_blocklist
+
+    def test_packageref_blocklist_key_matches_npm_case_variant(self):
+        cfg = SupplyChainGateConfig.model_validate({"explicit_blocklist": ["npm:axios:1.6.8"]})
+        extracted = extract_install_packages("npm install Axios@1.6.8")[0]
+        assert extracted.blocklist_key() in cfg.explicit_blocklist
 
 
 # =============================================================================
@@ -465,39 +689,207 @@ class TestBuildBlockedCommand:
         assert "summary" not in out.lower()
 
 
-class TestBuildLockfileReviewCommand:
+class TestBuildLockfileDryRunCommand:
     def test_npm_ci_shape(self):
-        out = build_lockfile_review_command("npm ci", "npm", "ci")
+        out = build_lockfile_dry_run_command("npm ci", "npm", "ci")
         assert out.startswith("sh -c '")
         assert "npm ci --dry-run" in out
         assert "LUTHIEN" in out
         assert "exit 42" in out
 
-    @pytest.mark.parametrize(
-        "original,manager,verb,expected_dry_run",
-        [
-            (
-                "yarn install --frozen-lockfile",
-                "yarn",
-                "install",
-                "yarn install --mode=skip-build",
-            ),
-            (
-                "pnpm install --frozen-lockfile",
-                "pnpm",
-                "install",
-                "pnpm install --lockfile-only",
-            ),
-            (
-                "pip install -r requirements.txt",
-                "pip",
-                "install",
-                "pip install --dry-run -r requirements.txt",
-            ),
-        ],
-    )
-    def test_other_manager_dry_run(self, original: str, manager: str, verb: str, expected_dry_run: str):
-        assert expected_dry_run in build_lockfile_review_command(original, manager, verb)
+    def test_pip_defaults_to_no_requirement_file(self):
+        # Fatal #1: pip install with no -r/-c must NOT produce a bogus
+        # hardcoded `-r requirements.txt`. Bare pip install shouldn't reach
+        # this path at all — but if a caller mis-uses the API, the output
+        # should just be `pip install --dry-run`, not `... -r requirements.txt`.
+        out = build_lockfile_dry_run_command("pip install", "pip", "install")
+        assert "requirements.txt" not in out
+        assert "pip install --dry-run" in out
+
+    def test_pip_threads_requirement_filename(self):
+        # Fatal #1: the dry-run must reference the ORIGINAL filename,
+        # not a hardcoded `requirements.txt`.
+        out = build_lockfile_dry_run_command(
+            "pip install -r dev-requirements.txt",
+            "pip",
+            "install",
+            requirement_file="dev-requirements.txt",
+        )
+        assert "dev-requirements.txt" in out
+        # No spurious bare reference to `requirements.txt`.
+        assert "requirements.txt" in out  # substring of dev-requirements.txt
+        # More precise check: no invocation uses bare `-r requirements.txt`.
+        assert "'requirements.txt'" not in out
+
+    def test_pip_threads_constraint_filename(self):
+        out = build_lockfile_dry_run_command(
+            "pip install -r dev-requirements.txt -c constraints.txt",
+            "pip",
+            "install",
+            requirement_file="dev-requirements.txt",
+            constraint_file="constraints.txt",
+        )
+        assert "dev-requirements.txt" in out
+        assert "constraints.txt" in out
+        assert "-c" in out
+
+    def test_uv_pip_prefix(self):
+        out = build_lockfile_dry_run_command(
+            "uv pip install -r requirements.txt",
+            "uv",
+            "install",
+            requirement_file="requirements.txt",
+        )
+        assert "uv pip install --dry-run" in out
+
+    def test_raises_on_yarn(self):
+        # yarn has no real dry-run; caller must use explain-refuse instead.
+        with pytest.raises(ValueError):
+            build_lockfile_dry_run_command("yarn install", "yarn", "install")
+
+    def test_raises_on_pnpm(self):
+        with pytest.raises(ValueError):
+            build_lockfile_dry_run_command("pnpm install", "pnpm", "install")
+
+
+class TestBuildLockfileExplainRefuseCommand:
+    def test_yarn_shape(self):
+        out = build_lockfile_explain_refuse_command("yarn install --frozen-lockfile", "yarn", "install")
+        assert out.startswith("sh -c '")
+        assert "exit 42" in out
+
+    def test_pnpm_shape(self):
+        out = build_lockfile_explain_refuse_command("pnpm install --frozen-lockfile", "pnpm", "install")
+        assert out.startswith("sh -c '")
+
+    def test_raises_on_npm(self):
+        with pytest.raises(ValueError):
+            build_lockfile_explain_refuse_command("npm ci", "npm", "ci")
+
+
+# =============================================================================
+# SUBPROCESS EXECUTION TESTS — Major #2
+#
+# Every builder function that emits a bash substitute gets run through a real
+# bash to verify it parses and behaves correctly. Substring-only tests hid
+# Fatals #1 and #2 in earlier reviews.
+# =============================================================================
+
+
+def _run_bash(script: str, cwd: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True, cwd=cwd, timeout=10)
+
+
+class TestSubprocessExecution:
+    def test_blocked_command_runs_and_exits_42(self):
+        result = PackageCheckResult(
+            package=PackageRef("PyPI", "litellm", "1.59.0"),
+            vulns=[VulnInfo("GHSA-xxxx", Severity.CRITICAL)],
+        )
+        sub = build_blocked_command("pip install litellm==1.59.0", [result], Severity.CRITICAL)
+        proc = _run_bash(sub)
+        assert proc.returncode == 42
+        assert "LUTHIEN BLOCKED" in proc.stderr
+        assert "litellm" in proc.stderr
+        assert "GHSA-xxxx" in proc.stderr
+        assert proc.stdout == ""
+
+    def test_blocked_command_ignores_attacker_metachars(self, tmp_path):
+        # Classic quote-breakout injection: the original command contains
+        # unbalanced quotes, shell metacharacters, and would execute arbitrary
+        # commands if the builder naively interpolated the original text.
+        result = PackageCheckResult(
+            package=PackageRef("PyPI", "foo", "1.0"),
+            vulns=[VulnInfo("GHSA-x", Severity.CRITICAL)],
+        )
+        marker = tmp_path / "LUTHIEN_PUNCH_TEST"
+        attacker_cmd = f"pip install 'foo'; touch {marker}; echo 'hi"
+        sub = build_blocked_command(attacker_cmd, [result], Severity.CRITICAL)
+        proc = _run_bash(sub)
+        assert proc.returncode == 42
+        assert not marker.exists(), "attacker metacharacters should not execute"
+
+    def test_blocked_command_handles_embedded_single_quotes(self):
+        # Stress the shell-escape path — the builder must survive CVE IDs or
+        # package names that contain single quotes (rare but possible in
+        # hand-crafted blocklist entries).
+        result = PackageCheckResult(
+            package=PackageRef("npm", "weird'name", "1.0"),
+            vulns=[VulnInfo("GHSA-y'all", Severity.CRITICAL)],
+        )
+        sub = build_blocked_command("npm install weird'name@1.0", [result], Severity.CRITICAL)
+        proc = _run_bash(sub)
+        assert proc.returncode == 42
+        assert "LUTHIEN BLOCKED" in proc.stderr
+
+    def test_npm_ci_dry_run_parses_and_exits_42(self, tmp_path):
+        # Stub out the real npm invocation with ``true`` (no-op) so the test
+        # doesn't need npm installed. The rest of the wrapper runs and we
+        # assert the wrapper's own exit-42 semantics survive.
+        sub = build_lockfile_dry_run_command("npm ci", "npm", "ci")
+        stubbed = sub.replace("npm ci --dry-run", "true")
+        proc = _run_bash(stubbed)
+        assert proc.returncode == 42
+        assert "LUTHIEN" in proc.stderr
+
+    def test_pip_dry_run_runs_with_custom_filename(self, tmp_path):
+        sub = build_lockfile_dry_run_command(
+            "pip install -r dev-requirements.txt",
+            "pip",
+            "install",
+            requirement_file="dev-requirements.txt",
+        )
+        # Stub out the pip call (pip may not be available). Replace the
+        # entire pip invocation including its args with a no-op so quoting
+        # stays balanced. We slice at ``pip install --dry-run`` and keep the
+        # ``;`` terminator.
+        before, _, after = sub.partition("pip install --dry-run")
+        # Skip past the args until the next ``; printf`` that starts the
+        # advisory printf. The inner script only has one ``; printf '\\n`` so
+        # we can split on that.
+        _, sep, rest = after.partition("; printf")
+        stubbed = f"{before}true{sep}{rest}"
+        proc = _run_bash(stubbed)
+        assert proc.returncode == 42
+        assert "LUTHIEN" in proc.stderr
+
+    def test_pip_dry_run_with_constraint_filename(self):
+        sub = build_lockfile_dry_run_command(
+            "pip install -r dev-requirements.txt -c constraints.txt",
+            "pip",
+            "install",
+            requirement_file="dev-requirements.txt",
+            constraint_file="constraints.txt",
+        )
+        before, _, after = sub.partition("pip install --dry-run")
+        _, sep, rest = after.partition("; printf")
+        stubbed = f"{before}true{sep}{rest}"
+        proc = _run_bash(stubbed)
+        assert proc.returncode == 42
+
+    def test_yarn_explain_refuse_runs_and_exits_42(self):
+        sub = build_lockfile_explain_refuse_command("yarn install --frozen-lockfile", "yarn", "install")
+        proc = _run_bash(sub)
+        assert proc.returncode == 42
+        combined = proc.stderr.lower()
+        assert "yarn" in combined or "pnpm" in combined or "lockfile" in combined
+        assert "cannot be safely previewed" in proc.stderr or "LUTHIEN BLOCKED" in proc.stderr
+
+    def test_pnpm_explain_refuse_runs_and_exits_42(self):
+        sub = build_lockfile_explain_refuse_command("pnpm install --frozen-lockfile", "pnpm", "install")
+        proc = _run_bash(sub)
+        assert proc.returncode == 42
+        assert "LUTHIEN BLOCKED" in proc.stderr
+
+    def test_yarn_explain_refuse_does_not_write_to_disk(self, tmp_path):
+        # An explain-refuse must NOT execute yarn. If it did, yarn would try
+        # to read package.json or write yarn.lock. Run inside an empty tmp_path
+        # and verify nothing was created.
+        before = sorted(p.name for p in tmp_path.iterdir())
+        sub = build_lockfile_explain_refuse_command("yarn install", "yarn", "install")
+        _run_bash(sub, cwd=str(tmp_path))
+        after = sorted(p.name for p in tmp_path.iterdir())
+        assert before == after, f"explain-refuse must not touch disk, got: {after}"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Third attempt at a Luthien supply-chain policy after PRs #522 and #536 were closed. The load-bearing design change from #536 is the **intervention shape**: command substitution instead of content injection.

When the gate detects a bash install of a flagged package, it rewrites the tool_use's ``input.command`` field in place to a ``sh -c 'printf ...; exit 42'`` that the client runs instead. The tool_use block keeps its original stream index so no new content blocks are emitted and stream indices remain monotonic.

## Closed predecessors

- #522 — grew into a 4,800-line adversarial shell parser
- #536 — correct scope but wrong intervention shape: content injection at ``index + 1000`` broke monotonic stream indices and required papering over untrusted OSV summary text with a ``⟨untrusted⟩`` delimiter

## Why command substitution

- Stream indices stay monotonic; no broken-client class of bug
- Execution is actually blocked (the original install never runs)
- Zero untrusted OSV text reaches the LLM — the error message is built entirely from values we control (OSV vuln IDs, package names, CVE labels, an osv.dev URL)
- Cooperative LLMs relay the failure through their normal error-reporting path on the next turn

## Non-goals (explicit)

- Adversarial parsing of ``sh -c \"$(base64 -d ...)\"``, ``eval``, chain operators, wrapper stripping, script-and-source, etc.
- Emitting new content blocks / advisory text blocks of any kind
- Scanning incoming ``tool_result`` messages for already-installed vulnerable versions (this v3 is subsumed by the lockfile dry-run strategy plus the outgoing gate)

## Lockfile strategy

Option B (ship this first): ``npm ci``, ``pip install -r requirements.txt``, ``yarn/pnpm install --frozen-lockfile``, etc. are always substituted with a dry-run-only command that shows the resolved package set, then exits non-zero. The LLM re-invokes with explicit package names on the next turn, and each version flows through the normal OSV gate.

Option A (future enhancement): pipe the dry-run output back through the policy on the subsequent request so the gate can auto-scan resolved versions without needing the LLM to re-invoke.

Controlled by ``block_lockfile_installs: bool = True`` — set to False to pass lockfile commands through unchanged.

## Key design decisions (vs #536)

- **Default threshold CRITICAL**, not HIGH. Combined with the CVSS v4 fix below, this avoids training the LLM to ignore spammy advisories.
- **CVSS v4 / unparseable vectors NOT promoted to HIGH.** We fall through to the qualitative ``database_specific.severity`` label. Unparseable vectors are logged at INFO so we can detect if the fallback is missing real advisories in practice.
- **No untrusted OSV summary text is emitted.** ``VulnInfo`` does not even carry the ``summary`` field — regression guard baked into the test suite.
- **No incoming-request tool_result scanner.** The ``_last_message_only`` scanner in #536 was easy to confuse; the outgoing gate plus the lockfile dry-run covers the important cases.
- **``explicit_blocklist``** supports pinned versions that bypass OSV and the severity threshold (e.g. ``PyPI:litellm:1.59.0``, ``npm:axios:1.6.8``) for cases where OSV is slow to publish.

## Streaming correctness tests (mandatory)

The ``TestStreamingShape`` class in ``test_supply_chain_gate_policy.py`` contains the regression guards that would have caught #536's non-monotonic-index bug:

- ``test_flagged_tool_use_preserves_block_index``
- ``test_flagged_tool_use_preserves_block_count``
- ``test_two_flagged_tool_uses_preserve_indices``
- ``test_monotonic_block_start_across_mixed_stream``
- ``test_flagged_tool_use_rewrites_command_field``

## Test plan

- [x] Unit tests pass (``uv run pytest tests/luthien_proxy/unit_tests/policies/test_supply_chain_gate_policy.py tests/luthien_proxy/unit_tests/policies/test_supply_chain_gate_utils.py``) — 138 passed
- [x] ``./scripts/dev_checks.sh`` — clean
- [x] All streaming correctness tests present and passing
- [ ] Manual smoke test against a live gateway with the gate enabled and a synthetic CRITICAL vuln in the cache
- [ ] Verify the sh -c substitution actually runs and exits 42 under bash

## Deviations from the brief

- **Source line count is ~1020, over the 900 target.** The CVSS v3 parser + lookup tables (brief-mandated), the threat-model docstring on the policy (brief-mandated), and the shell-escaping helpers for the blocked-command builder together make up the overage. The code-only (non-docstring, non-blank) line count is closer to 435.
- **Test count is 96 source-level test functions (138 after parametrize expansion).** The brief targets 60-90 with a 100 ceiling. I'm at 96 source functions, which is within the hard ceiling. Each manager-happy-path case and filtering case is cheap to maintain as a parametrize row and provides high-value regression coverage for the loose regex.

---
*Posted by Claude Code (claude-opus-4-6[1m])*