### PR TITLE
refactor(test): extract boot_sqlite_gateway helper for sqlite e2e fixtures

### DIFF
--- a/changelog.d/sqlite-gateway-boot-helper.md
+++ b/changelog.d/sqlite-gateway-boot-helper.md
@@ -1,0 +1,5 @@
+---
+category: Refactors
+---
+
+**Sqlite e2e gateway boot helper**: Extracted the in-process SQLite gateway boot/teardown logic into `tests/luthien_proxy/e2e_tests/sqlite/_boot.py::boot_sqlite_gateway`. Both `sqlite/conftest.py::sqlite_gateway_url` (session-scoped) and `sqlite/test_activity_stream.py::gateway_url` (module-scoped) now share the same code path — eliminating ~140 lines of near-identical scaffolding and the drift risk that caused #539 (a stale-settings-cache fix that had to be applied separately to each copy after #538 only patched one). Also closes a pre-existing `tmp_dir` leak in `test_activity_stream.py` teardown that the conftest copy already handled.

--- a/tests/luthien_proxy/e2e_tests/sqlite/_boot.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/_boot.py
@@ -1,0 +1,112 @@
+"""Shared boot helper for in-process SQLite-backed gateway fixtures.
+
+Both `sqlite/conftest.py::sqlite_gateway_url` and
+`sqlite/test_activity_stream.py::gateway_url` need to spin up the same
+in-process SQLite gateway pointed at a mock Anthropic server. This helper
+exists so they can't drift apart again — the divergence between the two
+copies is what made #539 necessary after #538 fixed only one of them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import socket
+import tempfile
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import uvicorn
+
+from luthien_proxy.main import create_app
+from luthien_proxy.settings import clear_settings_cache
+from luthien_proxy.utils.db import DatabasePool
+from luthien_proxy.utils.migration_check import check_migrations
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@contextmanager
+def boot_sqlite_gateway(
+    *,
+    api_key: str,
+    admin_key: str,
+    mock_anthropic_url: str,
+    tmp_prefix: str,
+    thread_name: str,
+) -> Iterator[str]:
+    """Spin up an in-process SQLite gateway pointed at a mock Anthropic server.
+
+    Yields the gateway base URL. On exit, stops the gateway thread, closes the
+    DB pool, removes the temp dir, restores env vars, and clears the cached
+    settings instance.
+
+    Why clear the settings cache: `get_settings()` is `@lru_cache`-wrapped, and
+    pytest fixture ordering means session/module-scoped fixtures run *before*
+    the function-scoped autouse cache clearer. Without an explicit clear here,
+    a stale `Settings` instance from an earlier import path can poison
+    `create_app()` so credential resolution fails. The teardown clear keeps
+    the helper hermetic — the next caller resolves against the restored env.
+    """
+    port = free_port()
+    tmp_dir = tempfile.mkdtemp(prefix=tmp_prefix)
+    db_path = os.path.join(tmp_dir, "test.db")
+    db_pool = DatabasePool(f"sqlite:///{db_path}")
+
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(check_migrations(db_pool))
+
+    old_env: dict[str, str | None] = {}
+    for k, v in {
+        "ANTHROPIC_BASE_URL": mock_anthropic_url,
+        "ANTHROPIC_API_KEY": "mock-key",
+    }.items():
+        old_env[k] = os.environ.get(k)
+        os.environ[k] = v
+
+    clear_settings_cache()
+    app = create_app(
+        api_key=api_key,
+        admin_key=admin_key,
+        db_pool=db_pool,
+        redis_client=None,
+        startup_policy_path="config/policy_config.yaml",
+        policy_source="db-fallback-file",
+    )
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True, name=thread_name)
+    thread.start()
+
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        raise RuntimeError(f"SQLite gateway ({thread_name}) did not start")
+
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+        loop.run_until_complete(db_pool.close())
+        loop.close()
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        for k, v in old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        clear_settings_cache()

--- a/tests/luthien_proxy/e2e_tests/sqlite/conftest.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/conftest.py
@@ -6,95 +6,24 @@ so test functions transparently hit the in-process SQLite gateway.
 Run:  uv run pytest -m sqlite_e2e tests/luthien_proxy/e2e_tests/sqlite/ -v --timeout=30
 """
 
-import asyncio
-import os
-import shutil
-import socket
-import tempfile
-import threading
-import time
-
 import pytest
-import uvicorn
-
-from luthien_proxy.main import create_app
-from luthien_proxy.settings import clear_settings_cache
-from luthien_proxy.utils.db import DatabasePool
-from luthien_proxy.utils.migration_check import check_migrations
+from tests.luthien_proxy.e2e_tests.sqlite._boot import boot_sqlite_gateway
 
 _API_KEY = "test-sqlite-key"
 _ADMIN_API_KEY = "test-sqlite-admin-key"
 
 
-def _free_port() -> int:
-    with socket.socket() as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
 @pytest.fixture(scope="session")
 def sqlite_gateway_url(mock_anthropic):
     """Start a SQLite-backed gateway on a random port. Returns the base URL."""
-    port = _free_port()
-    tmp_dir = tempfile.mkdtemp(prefix="luthien_sqlite_e2e_")
-    db_path = os.path.join(tmp_dir, "test.db")
-
-    db_pool = DatabasePool(f"sqlite:///{db_path}")
-
-    loop = asyncio.new_event_loop()
-    loop.run_until_complete(check_migrations(db_pool))
-
-    # Point LiteLLM at the mock Anthropic server (parent conftest starts it)
-    old_env = {}
-    mock_port = mock_anthropic.port
-    for k, v in {
-        "ANTHROPIC_BASE_URL": f"http://localhost:{mock_port}",
-        "ANTHROPIC_API_KEY": "mock-key",
-    }.items():
-        old_env[k] = os.environ.get(k)
-        os.environ[k] = v
-
-    # Flush cached settings so create_app() picks up the env vars set above.
-    # Without this, get_settings() may return a stale instance that lacks
-    # ANTHROPIC_API_KEY, causing credential resolution to fail.
-    clear_settings_cache()
-    app = create_app(
+    with boot_sqlite_gateway(
         api_key=_API_KEY,
         admin_key=_ADMIN_API_KEY,
-        db_pool=db_pool,
-        redis_client=None,
-        startup_policy_path="config/policy_config.yaml",
-        policy_source="db-fallback-file",
-    )
-
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
-    server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, daemon=True, name="sqlite-gateway")
-    thread.start()
-
-    deadline = time.monotonic() + 10
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-                break
-        except OSError:
-            time.sleep(0.1)
-    else:
-        raise RuntimeError("SQLite gateway did not start")
-
-    yield f"http://127.0.0.1:{port}"
-
-    server.should_exit = True
-    thread.join(timeout=5)
-    loop.run_until_complete(db_pool.close())
-    loop.close()
-    shutil.rmtree(tmp_dir, ignore_errors=True)
-    for k, v in old_env.items():
-        if v is None:
-            os.environ.pop(k, None)
-        else:
-            os.environ[k] = v
-    clear_settings_cache()
+        mock_anthropic_url=f"http://localhost:{mock_anthropic.port}",
+        tmp_prefix="luthien_sqlite_e2e_",
+        thread_name="sqlite-gateway",
+    ) as url:
+        yield url
 
 
 # --- Fixture overrides ---

--- a/tests/luthien_proxy/e2e_tests/sqlite/test_activity_stream.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/test_activity_stream.py
@@ -9,22 +9,12 @@ Run:  uv run pytest tests/luthien_proxy/e2e_tests/sqlite/test_activity_stream.py
 
 import asyncio
 import json
-import os
-import socket
-import tempfile
-import threading
-import time
 
 import httpx
 import pytest
-import uvicorn
 from tests.luthien_proxy.e2e_tests.mock_anthropic.responses import text_response
 from tests.luthien_proxy.e2e_tests.mock_anthropic.server import MockAnthropicServer
-
-from luthien_proxy.main import create_app
-from luthien_proxy.settings import clear_settings_cache
-from luthien_proxy.utils.db import DatabasePool
-from luthien_proxy.utils.migration_check import check_migrations
+from tests.luthien_proxy.e2e_tests.sqlite._boot import boot_sqlite_gateway, free_port
 
 pytestmark = pytest.mark.sqlite_e2e
 
@@ -32,16 +22,9 @@ _API_KEY = "test-activity-key"
 _ADMIN_KEY = "test-activity-admin-key"
 
 
-def _free_port() -> int:
-    with socket.socket() as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
-
-
 @pytest.fixture(scope="module")
 def mock_server():
-    mock_port = _free_port()
-    server = MockAnthropicServer(port=mock_port)
+    server = MockAnthropicServer(port=free_port())
     server.start()
     yield server
     server.stop()
@@ -50,63 +33,14 @@ def mock_server():
 @pytest.fixture(scope="module")
 def gateway_url(mock_server):
     """Boot an in-process SQLite gateway with no Redis."""
-    port = _free_port()
-    tmp_dir = tempfile.mkdtemp(prefix="luthien_activity_e2e_")
-    db_path = os.path.join(tmp_dir, "test.db")
-    db_pool = DatabasePool(f"sqlite:///{db_path}")
-
-    loop = asyncio.new_event_loop()
-    loop.run_until_complete(check_migrations(db_pool))
-
-    old_env = {}
-    for k, v in {
-        "ANTHROPIC_BASE_URL": f"http://127.0.0.1:{mock_server.port}",
-        "ANTHROPIC_API_KEY": "mock-key",
-    }.items():
-        old_env[k] = os.environ.get(k)
-        os.environ[k] = v
-
-    # Flush cached settings so create_app() picks up the env vars set above.
-    # Without this, get_settings() may return a stale instance that lacks
-    # ANTHROPIC_API_KEY, causing credential resolution to fail. Module-scoped
-    # fixtures run before function-scoped autouse fixtures can clear the cache.
-    clear_settings_cache()
-    app = create_app(
+    with boot_sqlite_gateway(
         api_key=_API_KEY,
         admin_key=_ADMIN_KEY,
-        db_pool=db_pool,
-        redis_client=None,
-        startup_policy_path="config/policy_config.yaml",
-        policy_source="db-fallback-file",
-    )
-
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
-    server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, daemon=True, name="activity-gateway")
-    thread.start()
-
-    deadline = time.monotonic() + 10
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-                break
-        except OSError:
-            time.sleep(0.1)
-    else:
-        raise RuntimeError("Gateway did not start")
-
-    yield f"http://127.0.0.1:{port}"
-
-    server.should_exit = True
-    thread.join(timeout=5)
-    loop.run_until_complete(db_pool.close())
-    loop.close()
-    for k, v in old_env.items():
-        if v is None:
-            os.environ.pop(k, None)
-        else:
-            os.environ[k] = v
-    clear_settings_cache()
+        mock_anthropic_url=f"http://127.0.0.1:{mock_server.port}",
+        tmp_prefix="luthien_activity_e2e_",
+        thread_name="activity-gateway",
+    ) as url:
+        yield url
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #538 / #539. Both reviewers flagged the ~80-line duplication between `sqlite/conftest.py::sqlite_gateway_url` (session-scoped) and `sqlite/test_activity_stream.py::gateway_url` (module-scoped). The drift between them is exactly what made #539 necessary after #538 fixed only one of them.

- Extract the shared boot/teardown logic into \`tests/luthien_proxy/e2e_tests/sqlite/_boot.py::boot_sqlite_gateway\` (a \`@contextmanager\`).
- Both fixtures now wrap it with a single \`with\` block, parameterized only by what actually differs: \`api_key\`, \`admin_key\`, \`mock_anthropic_url\`, \`tmp_prefix\`, \`thread_name\`.
- Closes a pre-existing \`tmp_dir\` leak in \`test_activity_stream.py\` teardown — the conftest copy was calling \`shutil.rmtree\`, the activity stream copy wasn't. Helper now does it once for both.

Net diff: **+132 / −152**, single source of truth, can't drift again. The helper docstring captures *why* the settings-cache clear has to happen inside the boot path (fixture-scope ordering vs the function-scoped autouse clearer) so the next reader doesn't have to re-derive it from the #538/#539 PR history.

## Test plan

- [x] \`uv run pytest -m sqlite_e2e tests/luthien_proxy/e2e_tests/sqlite/ -x -v --timeout=60\` → 42 passed
- [x] \`./scripts/dev_checks.sh\` passes
- [ ] Full sqlite_e2e tier passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)