### PR TITLE
fix(test): make boot_sqlite_gateway cleanup robust to setup-time failures

### DIFF
--- a/changelog.d/sqlite-boot-helper-setup-leak.md
+++ b/changelog.d/sqlite-boot-helper-setup-leak.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**Sqlite e2e boot helper setup-time leak**: `boot_sqlite_gateway` (added in #541) only ran cleanup if execution reached `yield` — a raise from `check_migrations()`, `create_app()`, or the 10-second gateway-startup wait would leak the tmp_dir, env-var modifications, settings cache state, and (for the startup-wait case) the uvicorn thread. Rewrote the helper to use `contextlib.ExitStack`, registering each rollback as the matching resource is acquired, so any setup failure tears down only what was actually set up. Pre-existing in both pre-#541 fixture copies; centralizing them made it fixable in one place. Added regression tests in `tests/luthien_proxy/e2e_tests/sqlite/test_boot_helper.py` covering the `create_app` and `check_migrations` failure paths.

--- a/tests/luthien_proxy/e2e_tests/sqlite/_boot.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/_boot.py
@@ -17,7 +17,7 @@ import tempfile
 import threading
 import time
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 
 import uvicorn
 
@@ -44,9 +44,10 @@ def boot_sqlite_gateway(
 ) -> Iterator[str]:
     """Spin up an in-process SQLite gateway pointed at a mock Anthropic server.
 
-    Yields the gateway base URL. On exit, stops the gateway thread, closes the
-    DB pool, removes the temp dir, restores env vars, and clears the cached
-    settings instance.
+    Yields the gateway base URL. Cleanup runs on both normal exit and any
+    failure during setup — `ExitStack` registers each rollback as the matching
+    resource is acquired, so a raise from `check_migrations()`, `create_app()`,
+    or the gateway-startup wait still tears down everything that was set up.
 
     Why clear the settings cache: `get_settings()` is `@lru_cache`-wrapped, and
     pytest fixture ordering means session/module-scoped fixtures run *before*
@@ -56,57 +57,63 @@ def boot_sqlite_gateway(
     the helper hermetic — the next caller resolves against the restored env.
     """
     port = free_port()
-    tmp_dir = tempfile.mkdtemp(prefix=tmp_prefix)
-    db_path = os.path.join(tmp_dir, "test.db")
-    db_pool = DatabasePool(f"sqlite:///{db_path}")
 
-    loop = asyncio.new_event_loop()
-    loop.run_until_complete(check_migrations(db_pool))
+    with ExitStack() as stack:
+        tmp_dir = tempfile.mkdtemp(prefix=tmp_prefix)
+        stack.callback(shutil.rmtree, tmp_dir, ignore_errors=True)
 
-    old_env: dict[str, str | None] = {}
-    for k, v in {
-        "ANTHROPIC_BASE_URL": mock_anthropic_url,
-        "ANTHROPIC_API_KEY": "mock-key",
-    }.items():
-        old_env[k] = os.environ.get(k)
-        os.environ[k] = v
+        loop = asyncio.new_event_loop()
+        stack.callback(loop.close)
 
-    clear_settings_cache()
-    app = create_app(
-        api_key=api_key,
-        admin_key=admin_key,
-        db_pool=db_pool,
-        redis_client=None,
-        startup_policy_path="config/policy_config.yaml",
-        policy_source="db-fallback-file",
-    )
+        db_pool = DatabasePool(f"sqlite:///{os.path.join(tmp_dir, 'test.db')}")
+        stack.callback(lambda: loop.run_until_complete(db_pool.close()))
 
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
-    server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, daemon=True, name=thread_name)
-    thread.start()
+        loop.run_until_complete(check_migrations(db_pool))
 
-    deadline = time.monotonic() + 10
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-                break
-        except OSError:
-            time.sleep(0.1)
-    else:
-        raise RuntimeError(f"SQLite gateway ({thread_name}) did not start")
+        old_env: dict[str, str | None] = {k: os.environ.get(k) for k in ("ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY")}
 
-    try:
-        yield f"http://127.0.0.1:{port}"
-    finally:
-        server.should_exit = True
-        thread.join(timeout=5)
-        loop.run_until_complete(db_pool.close())
-        loop.close()
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-        for k, v in old_env.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
+        def restore_env() -> None:
+            for k, v in old_env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+        stack.callback(clear_settings_cache)
+        stack.callback(restore_env)
+
+        os.environ["ANTHROPIC_BASE_URL"] = mock_anthropic_url
+        os.environ["ANTHROPIC_API_KEY"] = "mock-key"
+
         clear_settings_cache()
+        app = create_app(
+            api_key=api_key,
+            admin_key=admin_key,
+            db_pool=db_pool,
+            redis_client=None,
+            startup_policy_path="config/policy_config.yaml",
+            policy_source="db-fallback-file",
+        )
+
+        config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+        server = uvicorn.Server(config)
+        thread = threading.Thread(target=server.run, daemon=True, name=thread_name)
+        thread.start()
+
+        def stop_server() -> None:
+            server.should_exit = True
+            thread.join(timeout=5)
+
+        stack.callback(stop_server)
+
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                    break
+            except OSError:
+                time.sleep(0.1)
+        else:
+            raise RuntimeError(f"SQLite gateway ({thread_name}) did not start")
+
+        yield f"http://127.0.0.1:{port}"

--- a/tests/luthien_proxy/e2e_tests/sqlite/test_boot_helper.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/test_boot_helper.py
@@ -1,0 +1,78 @@
+"""Regression tests for boot_sqlite_gateway's setup-failure cleanup.
+
+These verify the contract added by the ExitStack rewrite: a raise from any
+setup step (check_migrations, create_app, the gateway-startup wait) must
+still tear down everything that was set up.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from tests.luthien_proxy.e2e_tests.sqlite import _boot
+from tests.luthien_proxy.e2e_tests.sqlite._boot import boot_sqlite_gateway
+
+pytestmark = pytest.mark.sqlite_e2e
+
+
+def _existing_tmp_dirs(prefix: str) -> set[str]:
+    import tempfile
+
+    root = tempfile.gettempdir()
+    return {name for name in os.listdir(root) if name.startswith(prefix)}
+
+
+def test_create_app_failure_cleans_up_tmp_dir_and_env(monkeypatch):
+    """If create_app raises, tmp_dir is removed and env vars are restored."""
+    prefix = "luthien_boot_helper_test_create_app_"
+
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://sentinel.invalid")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(
+        _boot,
+        "create_app",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    before = _existing_tmp_dirs(prefix)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with boot_sqlite_gateway(
+            api_key="k",
+            admin_key="a",
+            mock_anthropic_url="http://127.0.0.1:1",
+            tmp_prefix=prefix,
+            thread_name="boot-helper-test",
+        ):
+            pytest.fail("yield should not be reached")
+
+    after = _existing_tmp_dirs(prefix)
+    assert after == before, f"tmp_dir leaked: {after - before}"
+    assert os.environ["ANTHROPIC_BASE_URL"] == "http://sentinel.invalid"
+    assert "ANTHROPIC_API_KEY" not in os.environ
+
+
+def test_check_migrations_failure_cleans_up(monkeypatch):
+    """If check_migrations raises, tmp_dir is removed."""
+    prefix = "luthien_boot_helper_test_migrations_"
+
+    async def boom(_pool):
+        raise RuntimeError("migrations failed")
+
+    monkeypatch.setattr(_boot, "check_migrations", boom)
+
+    before = _existing_tmp_dirs(prefix)
+
+    with pytest.raises(RuntimeError, match="migrations failed"):
+        with boot_sqlite_gateway(
+            api_key="k",
+            admin_key="a",
+            mock_anthropic_url="http://127.0.0.1:1",
+            tmp_prefix=prefix,
+            thread_name="boot-helper-test",
+        ):
+            pytest.fail("yield should not be reached")
+
+    after = _existing_tmp_dirs(prefix)
+    assert after == before, f"tmp_dir leaked: {after - before}"


### PR DESCRIPTION
## Summary

Follow-up to #541 addressing the bot review's #1 observation. \`boot_sqlite_gateway\` only ran cleanup if execution reached \`yield\` — a raise from \`check_migrations()\`, \`create_app()\`, or the 10-second gateway-startup wait would leak the tmp_dir, env-var modifications, cleared settings cache, and (for the startup-wait case) the uvicorn thread itself.

Pre-existing in both pre-#541 fixture copies; centralizing them in #541 made it fixable in one place — exactly the value the dedup PR was supposed to unlock.

### Approach

Rewrote the helper using \`contextlib.ExitStack\`. Each rollback is registered as the matching resource is acquired:

| Setup step | Registered cleanup |
|---|---|
| \`tempfile.mkdtemp\` | \`shutil.rmtree(tmp_dir, ignore_errors=True)\` |
| \`asyncio.new_event_loop()\` | \`loop.close\` |
| \`DatabasePool(...)\` | \`loop.run_until_complete(db_pool.close())\` |
| capture \`old_env\` | \`restore_env\` + \`clear_settings_cache\` |
| \`thread.start()\` | \`server.should_exit = True; thread.join(timeout=5)\` |

Normal exit still runs the same cleanups in LIFO order: stop server → restore env → clear settings cache → close db pool → close loop → remove tmp_dir.

### Regression tests

Added \`tests/luthien_proxy/e2e_tests/sqlite/test_boot_helper.py\` with two tests:

- **\`test_create_app_failure_cleans_up_tmp_dir_and_env\`**: monkeypatches \`create_app\` to raise; asserts tmp_dir is removed, \`ANTHROPIC_BASE_URL\` is restored to its sentinel value, \`ANTHROPIC_API_KEY\` is unset.
- **\`test_check_migrations_failure_cleans_up\`**: monkeypatches \`check_migrations\` to raise; asserts tmp_dir is removed.

These run under the \`sqlite_e2e\` marker so they live in the same tier as the helper they exercise.

## Test plan

- [x] \`uv run pytest -m sqlite_e2e tests/luthien_proxy/e2e_tests/sqlite/ -v --timeout=60\` → 44 passed (42 existing + 2 new)
- [x] \`./scripts/dev_checks.sh\` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)