### PR TITLE
feat: gateway-wide policy scheduler

### DIFF
--- a/changelog.d/policy-scheduler.md
+++ b/changelog.d/policy-scheduler.md
@@ -1,0 +1,9 @@
+---
+category: Features
+pr: 543
+---
+
+**Gateway-wide policy scheduler**: Add a small scheduling primitive that lets policies register periodic background tasks via a new `BasePolicy.register_scheduled_tasks()` lifecycle hook. Tasks are owned by the gateway's asyncio loop, survive callback exceptions, and are cancelled cleanly on policy reload and gateway shutdown.
+  - New package `luthien_proxy.scheduler` with `Scheduler`, `ScheduledTaskConfig`, `RunningTask`, and `TaskStatus` primitives.
+  - New admin endpoint `GET /api/admin/scheduler/tasks` exposes per-task observability (last run, status, run/error counts, next run).
+  - Default no-op hook on `BasePolicy` so all existing policies are unaffected; `MultiSerialPolicy` recurses into sub-policies.

--- a/dev/OBJECTIVE.md
+++ b/dev/OBJECTIVE.md
@@ -1,1 +1,60 @@
+# Objective: Gateway-wide policy scheduler
 
+## Goal
+
+Add a gateway-level scheduling primitive that lets policies register periodic background tasks. Tasks run on the gateway's asyncio loop, are tracked centrally, and are cleanly cancelled on policy reload or process shutdown.
+
+## Motivation
+
+Several upcoming policies need to refresh shared state on a schedule rather than per-request. The immediate driver is the **supply-chain blocklist policy** (separate PR, branch `worktree-supply-chain-blocklist`), which polls OSV every few minutes for newly-published high-severity CVEs and maintains an in-memory blocklist consulted on every bash tool_use.
+
+The natural shape is "policies register periodic tasks at load time; the gateway owns the asyncio loop and the lifecycle." Without this primitive, each policy that wants periodic work has to spawn its own `asyncio.create_task` and manage its own cancellation, which doesn't compose, isn't observable centrally, and silently leaks tasks across policy reloads.
+
+## Acceptance check
+
+- A policy can register one or more periodic tasks via a new method on the policy lifecycle (e.g., `register_scheduled_tasks(scheduler) -> None`). Returning nothing or not implementing the method means no tasks (default behavior, backward compatible).
+- The scheduler accepts per-task config: `name`, `interval` (timedelta), `callback` (async callable), optional `jitter`, optional `run_immediately` (bool, default False).
+- Tasks are cancelled cleanly on policy reload (admin API) and on gateway shutdown. No orphaned tasks across reloads.
+- Failures inside a task callback are caught, logged with full context, and the task continues to run on the next interval. One bad poll does not kill the task.
+- A registered task is observable: at minimum the gateway exposes per-task metadata (last-run timestamp, last-run status, run count, error count) via the existing admin API or telemetry surface.
+- Unit tests confirm: registration, execution at the configured interval, cancellation on reload, exception isolation, jitter behavior.
+- Integration test confirms the scheduler interacts correctly with the existing policy lifecycle (load → schedule → reload → re-schedule → unload → cancel).
+- No new heavy dependencies. `apscheduler` is allowed only if hand-rolled `asyncio.create_task` + cancellation tracking proves materially worse — default is hand-rolled.
+
+## Non-goals
+
+- **Cron syntax.** Interval-based only ("every N seconds/minutes"). Cron is a follow-up if a future policy needs it.
+- **Distributed scheduling.** The scheduler runs in-process on each gateway instance. If two gateway instances are running, both schedule the same task — that's a known property of the in-process design and is acceptable for v1.
+- **Persistence of task state across restarts.** Tasks re-register on policy load and run from a clean slate. If a policy needs persistent state across restarts, it owns its own DB schema (the supply-chain blocklist policy is doing exactly this).
+- **A scheduler admin UI page.** A text/JSON endpoint is sufficient for v1; UI is a follow-up.
+- **Backpressure / coordination between tasks.** Each task runs on its own interval, independent of other tasks. If two tasks need to coordinate, they share state via the policy instance.
+
+## External contracts
+
+- The new `register_scheduled_tasks` method on the policy lifecycle. Once landed, every existing policy gains the (no-op) default behavior; new policies can opt in.
+- The admin API endpoint(s) for task observability. Whatever shape they take, they must follow the existing admin API conventions (auth, JSON shape, etc.).
+- The existing policy reload path. The scheduler must hook into reload cleanly without breaking any existing policy that does not use scheduled tasks.
+
+## Assumptions (falsifiable)
+
+- I assume the gateway's asyncio event loop is the right place for these tasks (i.e., the gateway is a long-running async process, not a per-request worker pool). If gateway becomes pre-fork or a worker-pool model, the scheduler design needs to choose a single owner instance.
+- I assume policy reloads happen via a discrete admin API call (not via filesystem watch or signal). The scheduler hooks into that explicit reload path.
+- I assume `asyncio.create_task` + cancellation tracking is sufficient for v1 needs. If a future task needs cron-style scheduling or missed-tick semantics, we revisit.
+
+## Dependencies / blockers
+
+None — this PR can land independently and is the prerequisite for the supply-chain blocklist PR.
+
+## Out-of-scope concerns to defer
+
+- The supply-chain blocklist policy itself.
+- Cron syntax.
+- Distributed coordination.
+- Scheduler admin UI page.
+- Per-task metrics dashboards.
+
+## Reference
+
+- Existing policy lifecycle hooks: `src/luthien_proxy/policy_core/` and `src/luthien_proxy/policies/`.
+- Existing admin API: `src/luthien_proxy/admin/`.
+- Project rules: repo `CLAUDE.md` at the repo root.

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -83,6 +83,27 @@ class PolicyListResponse(BaseModel):
     policies: list[PolicyClassInfo]
 
 
+class ScheduledTaskStatusResponse(BaseModel):
+    """One scheduled task as seen by the admin API."""
+
+    name: str
+    interval_seconds: float
+    jitter_seconds: float
+    run_count: int
+    error_count: int
+    last_run_at: str | None
+    last_run_status: str
+    last_error: str | None
+    next_run_at: str | None
+
+
+class ScheduledTasksResponse(BaseModel):
+    """List of currently-registered scheduled tasks."""
+
+    tasks: list[ScheduledTaskStatusResponse]
+    count: int
+
+
 class ChatRequest(BaseModel):
     """Request for testing chat through the proxy."""
 
@@ -282,6 +303,37 @@ async def list_available_policies(
         for p in discovered
     ]
     return PolicyListResponse(policies=policies)
+
+
+@router.get("/scheduler/tasks", response_model=ScheduledTasksResponse)
+async def list_scheduled_tasks(
+    _: str = Depends(verify_admin_token),
+    manager: PolicyManager = Depends(get_policy_manager),
+):
+    """List scheduled tasks currently registered with the gateway scheduler.
+
+    Returns per-task observability (last run, status, run/error counts,
+    next run). Useful for confirming that policies that register periodic
+    work are actually ticking.
+
+    Requires admin authentication.
+    """
+    snapshots = manager.scheduler.task_status()
+    tasks = [
+        ScheduledTaskStatusResponse(
+            name=s.name,
+            interval_seconds=s.interval_seconds,
+            jitter_seconds=s.jitter_seconds,
+            run_count=s.run_count,
+            error_count=s.error_count,
+            last_run_at=s.last_run_at,
+            last_run_status=s.last_run_status,
+            last_error=s.last_error,
+            next_run_at=s.next_run_at,
+        )
+        for s in snapshots
+    ]
+    return ScheduledTasksResponse(tasks=tasks, count=len(tasks))
 
 
 @router.get("/models")

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -303,6 +303,9 @@ def create_app(
         yield
 
         # Shutdown
+        # Cancel scheduled policy tasks first so they can't race with
+        # resource teardown (DB pool close, Redis disconnect, etc.).
+        await _policy_manager.shutdown()
         if _telemetry_sender is not None:
             await _telemetry_sender.stop()
         await _credential_manager.close()

--- a/src/luthien_proxy/policies/multi_serial_policy.py
+++ b/src/luthien_proxy/policies/multi_serial_policy.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
     from luthien_proxy.llm.types.anthropic import AnthropicRequest, AnthropicResponse
     from luthien_proxy.policy_core.policy_context import PolicyContext
+    from luthien_proxy.scheduler import Scheduler
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +98,11 @@ class MultiSerialPolicy(BasePolicy, AnthropicExecutionInterface):
         for p in self._sub_policies:
             names.extend(p.active_policy_names())
         return names
+
+    def register_scheduled_tasks(self, scheduler: "Scheduler") -> None:
+        """Recurse into sub-policies so each can register its own tasks."""
+        for policy in self._sub_policies:
+            policy.register_scheduled_tasks(scheduler)
 
     def _validate_interface(self, interface: type, interface_name: str) -> None:
         """Raise TypeError if any sub-policy doesn't implement the required interface."""

--- a/src/luthien_proxy/policy_core/base_policy.py
+++ b/src/luthien_proxy/policy_core/base_policy.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from luthien_proxy.policy_core.policy_context import PolicyContext
+    from luthien_proxy.scheduler import Scheduler
     from luthien_proxy.types import RawHttpRequest
 
 T = TypeVar("T", bound=BaseModel)
@@ -81,6 +82,25 @@ class BasePolicy:
         NoOpPolicy overrides to return [].
         """
         return [self.short_policy_name]
+
+    def register_scheduled_tasks(self, scheduler: "Scheduler") -> None:
+        """Register periodic background tasks with the gateway scheduler.
+
+        Called once after the policy is loaded (and again after every
+        hot-swap reload). Default behavior is a no-op so existing policies
+        are unaffected. Policies that need periodic work override this and
+        call ``scheduler.schedule(ScheduledTaskConfig(...))`` one or more
+        times.
+
+        Tasks registered here are cancelled on policy reload and gateway
+        shutdown — they should be idempotent and must not rely on any
+        request-scoped state.
+
+        Multi-policies (e.g. ``MultiSerialPolicy``) recurse into their
+        sub-policies so each sub-policy can register its own tasks.
+        """
+        # Default no-op: most policies don't need scheduled tasks.
+        return None
 
     def get_config(self) -> dict[str, Any]:
         """Get the configuration for this policy instance.

--- a/src/luthien_proxy/policy_manager.py
+++ b/src/luthien_proxy/policy_manager.py
@@ -23,6 +23,7 @@ from redis.asyncio import Redis
 
 from luthien_proxy.config import _import_policy_class, _instantiate_policy, load_policy_from_yaml
 from luthien_proxy.policy_core.base_policy import BasePolicy
+from luthien_proxy.scheduler import Scheduler
 from luthien_proxy.utils import db
 from luthien_proxy.utils.constants import REDIS_LOCK_TIMEOUT_SECONDS
 
@@ -82,6 +83,7 @@ class PolicyManager:
         self.startup_policy_path = startup_policy_path
         self.policy_source = policy_source
         self._current_policy: BasePolicy | None = None
+        self._scheduler = Scheduler()
         self.lock_key = "luthien:policy:lock"
         self._local_lock = asyncio.Lock()
 
@@ -105,6 +107,7 @@ class PolicyManager:
             )
 
         self._current_policy = self._maybe_compose_dogfood(self._current_policy)
+        self._register_scheduled_tasks(self._current_policy)
 
     async def _initialize_from_file(self) -> None:
         """Load policy from YAML file and persist to DB."""
@@ -212,8 +215,15 @@ class PolicyManager:
                 # 2. Persist to DB
                 await self._persist_to_db(policy_class_ref, config, enabled_by)
 
-                # 3. Hot-swap in memory (compose dogfood if enabled)
+                # 3. Tear down the previous policy's scheduled tasks BEFORE
+                # swapping. Otherwise the old policy's periodic work keeps
+                # running against stale state after the hot-swap.
+                await self._scheduler.cancel_all()
+
+                # 4. Hot-swap in memory (compose dogfood if enabled) and
+                # re-register scheduled tasks for the new policy.
                 self._current_policy = self._maybe_compose_dogfood(new_policy)
+                self._register_scheduled_tasks(self._current_policy)
 
                 duration_ms = int((datetime.now() - start_time).total_seconds() * 1000)
 
@@ -307,6 +317,31 @@ class PolicyManager:
         if not self._current_policy:
             raise RuntimeError("No policy loaded")
         return self._current_policy
+
+    @property
+    def scheduler(self) -> Scheduler:
+        """Return the gateway-wide scheduler owned by this manager."""
+        return self._scheduler
+
+    async def shutdown(self) -> None:
+        """Cancel all scheduled tasks. Called from the gateway lifespan exit."""
+        await self._scheduler.cancel_all()
+
+    def _register_scheduled_tasks(self, policy: BasePolicy) -> None:
+        """Ask the policy to register its scheduled tasks with the scheduler.
+
+        Wraps the call so a misbehaving policy can't crash the load path —
+        if it raises, we log and continue with an empty scheduler rather
+        than bricking the gateway.
+        """
+        try:
+            policy.register_scheduled_tasks(self._scheduler)
+        except Exception as exc:
+            logger.error(
+                f"Policy {policy.__class__.__name__}.register_scheduled_tasks raised {exc!r}; "
+                "continuing with any tasks that were successfully registered before the error",
+                exc_info=True,
+            )
 
     @asynccontextmanager
     async def _acquire_lock(self, timeout: int = REDIS_LOCK_TIMEOUT_SECONDS):

--- a/src/luthien_proxy/scheduler/__init__.py
+++ b/src/luthien_proxy/scheduler/__init__.py
@@ -1,0 +1,28 @@
+"""Gateway-wide scheduling primitive for policy background tasks.
+
+Policies that need periodic work (e.g. refreshing shared state) register
+tasks with the :class:`Scheduler` via the
+:meth:`BasePolicy.register_scheduled_tasks` lifecycle hook. The gateway
+owns the asyncio loop and the task lifecycle: tasks are cancelled on
+policy reload and gateway shutdown so nothing leaks across hot-swaps.
+
+The scheduler is deliberately small. It does not implement cron, missed
+tick semantics, distributed coordination, or cross-restart state. If a
+future policy needs any of those, revisit the design — but the default
+expectation is "a policy asks for a coroutine to run every N seconds,
+and the gateway makes it happen reliably."
+"""
+
+from luthien_proxy.scheduler.service import Scheduler
+from luthien_proxy.scheduler.types import (
+    RunningTask,
+    ScheduledTaskConfig,
+    TaskStatus,
+)
+
+__all__ = [
+    "Scheduler",
+    "ScheduledTaskConfig",
+    "RunningTask",
+    "TaskStatus",
+]

--- a/src/luthien_proxy/scheduler/service.py
+++ b/src/luthien_proxy/scheduler/service.py
@@ -1,0 +1,226 @@
+"""Async scheduler that owns and supervises policy background tasks.
+
+The scheduler is a thin supervisor around :func:`asyncio.create_task`:
+
+* :meth:`Scheduler.schedule` wraps a :class:`ScheduledTaskConfig` in a
+  supervised asyncio task and registers it under ``config.name``.
+* Each supervised task runs a simple loop: optionally run once immediately,
+  then ``sleep(interval + jitter)``, run the callback, record the result,
+  repeat. Exceptions in the callback are caught and logged; one bad tick
+  never kills the task.
+* :meth:`Scheduler.cancel` / :meth:`Scheduler.cancel_all` cancel the
+  underlying task and wait for clean shutdown. They're idempotent and
+  safe to call from the policy reload path.
+
+The scheduler has no knowledge of policies — it just runs callables. The
+policy lifecycle integration (calling ``register_scheduled_tasks`` on
+load and ``cancel_all`` on reload/shutdown) lives in
+:mod:`luthien_proxy.policy_manager`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from datetime import datetime, timedelta, timezone
+
+from luthien_proxy.scheduler.types import RunningTask, ScheduledTaskConfig, TaskStatus
+
+logger = logging.getLogger(__name__)
+
+
+def _utcnow() -> datetime:
+    """Timezone-aware UTC "now" so ISO serialization is unambiguous."""
+    return datetime.now(timezone.utc)
+
+
+class Scheduler:
+    """Supervises periodic async tasks on the gateway event loop.
+
+    Not thread-safe: all public methods must be called from the asyncio
+    loop that owns the scheduler. That matches the gateway's single-loop
+    model (FastAPI lifespan → scheduler owned by PolicyManager).
+
+    Task names must be unique within a scheduler instance. Attempting to
+    schedule a task whose name is already registered raises ``ValueError``;
+    cancel the old one first or pick a new name.
+    """
+
+    def __init__(self) -> None:
+        """Construct an empty scheduler."""
+        self._tasks: dict[str, RunningTask] = {}
+
+    def schedule(self, config: ScheduledTaskConfig) -> RunningTask:
+        """Register and start a supervised task.
+
+        Args:
+            config: Declarative task config; see :class:`ScheduledTaskConfig`.
+
+        Returns:
+            The :class:`RunningTask` handle (mostly for tests; production
+            callers should treat the scheduler itself as the handle).
+
+        Raises:
+            ValueError: If a task with the same name is already scheduled.
+        """
+        if config.name in self._tasks:
+            raise ValueError(f"Scheduled task '{config.name}' is already registered")
+
+        # Build the bookkeeping handle first (the loop body needs a
+        # reference so it can update counters after each tick) and then
+        # mint the asyncio.Task and assign it back.
+        running = RunningTask(
+            config=config,
+            next_run_at=_utcnow() if config.run_immediately else _utcnow() + config.interval,
+        )
+        running.task = asyncio.create_task(
+            self._run_forever(running),
+            name=f"scheduler:{config.name}",
+        )
+        self._tasks[config.name] = running
+        logger.info(
+            "Scheduled task '%s' (interval=%ss, jitter=%ss, run_immediately=%s)",
+            config.name,
+            config.interval.total_seconds(),
+            config.jitter.total_seconds(),
+            config.run_immediately,
+        )
+        return running
+
+    async def cancel(self, name: str) -> bool:
+        """Cancel a scheduled task by name.
+
+        Args:
+            name: The task name passed to :meth:`schedule`.
+
+        Returns:
+            True if a task with that name was cancelled, False if no task
+            with that name was registered. Idempotent: calling twice on
+            the same name returns False on the second call.
+        """
+        running = self._tasks.pop(name, None)
+        if running is None:
+            return False
+        await self._cancel_task(running)
+        return True
+
+    async def cancel_all(self) -> None:
+        """Cancel every registered task and wait for clean shutdown.
+
+        Used by the policy reload path and gateway shutdown. Safe to call
+        on an empty scheduler — it's a no-op in that case. After the call
+        the scheduler is empty and can accept new schedules.
+        """
+        if not self._tasks:
+            return
+        to_cancel = list(self._tasks.values())
+        self._tasks.clear()
+        await asyncio.gather(
+            *(self._cancel_task(running) for running in to_cancel),
+            return_exceptions=True,
+        )
+
+    def task_status(self) -> list[TaskStatus]:
+        """Return observability snapshots for every registered task.
+
+        Snapshots are stable dicts safe to serialize. Ordering is
+        insertion order (i.e. registration order), which happens to match
+        the order a policy registers tasks in ``register_scheduled_tasks``.
+        """
+        return [running.snapshot() for running in self._tasks.values()]
+
+    def has_task(self, name: str) -> bool:
+        """Check whether a task with the given name is currently scheduled."""
+        return name in self._tasks
+
+    def __len__(self) -> int:
+        """Return the number of currently-registered tasks."""
+        return len(self._tasks)
+
+    # =========================================================================
+    # Internals
+    # =========================================================================
+
+    async def _run_forever(self, running: RunningTask) -> None:
+        """Loop body for a supervised task.
+
+        Runs until the asyncio task is cancelled. Callback exceptions are
+        caught per-iteration so one bad tick can never take the task down;
+        the scheduler logs the error, records it on the task status, and
+        continues with the next sleep cycle.
+        """
+        config = running.config
+        try:
+            if config.run_immediately:
+                await self._run_once(running)
+
+            while True:
+                delay = self._compute_delay(config)
+                running.next_run_at = _utcnow() + timedelta(seconds=delay)
+                await asyncio.sleep(delay)
+                await self._run_once(running)
+        except asyncio.CancelledError:
+            logger.debug("Scheduled task '%s' cancelled", config.name)
+            raise
+
+    async def _run_once(self, running: RunningTask) -> None:
+        """Invoke the callback once, updating counters and status."""
+        config = running.config
+        running.last_run_at = _utcnow()
+        try:
+            await config.callback()
+        except asyncio.CancelledError:
+            # Cancellation during the callback propagates; bookkeeping is
+            # left consistent (pending → whatever state it was in) and
+            # the outer loop re-raises.
+            raise
+        except Exception as exc:
+            running.error_count += 1
+            running.last_run_status = "error"
+            running.last_error = f"{type(exc).__name__}: {exc}"
+            logger.exception(
+                "Scheduled task '%s' raised %s (error #%d)",
+                config.name,
+                type(exc).__name__,
+                running.error_count,
+            )
+        else:
+            running.last_run_status = "success"
+            running.last_error = None
+        finally:
+            running.run_count += 1
+
+    @staticmethod
+    def _compute_delay(config: ScheduledTaskConfig) -> float:
+        """Compute the next sleep duration in seconds, applying jitter."""
+        interval_s = config.interval.total_seconds()
+        jitter_s = config.jitter.total_seconds()
+        if jitter_s <= 0:
+            return interval_s
+        offset = random.uniform(-jitter_s, jitter_s)
+        # __post_init__ guarantees jitter < interval, so this is positive.
+        return interval_s + offset
+
+    @staticmethod
+    async def _cancel_task(running: RunningTask) -> None:
+        """Cancel an asyncio task and swallow the expected CancelledError."""
+        task = running.task
+        if task is None or task.done():
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            # A task that died with an uncaught exception before cancel
+            # reached it is not a scheduler bug, but we still want to know.
+            logger.warning(
+                "Scheduled task '%s' exited with unexpected error during cancel: %r",
+                running.name,
+                exc,
+            )
+
+
+__all__ = ["Scheduler"]

--- a/src/luthien_proxy/scheduler/types.py
+++ b/src/luthien_proxy/scheduler/types.py
@@ -1,0 +1,136 @@
+"""Dataclasses for scheduled task configuration and observability.
+
+Three related types live here:
+
+* :class:`ScheduledTaskConfig` — the user-facing config a policy passes to
+  ``Scheduler.schedule()``.
+* :class:`RunningTask` — the scheduler-internal handle for a task that's
+  actively running. Holds the ``asyncio.Task`` plus mutable bookkeeping.
+* :class:`TaskStatus` — the read-only snapshot returned by the admin API.
+
+``RunningTask`` holds the mutable counters (last_run_at, run_count, …) so
+the scheduler can update them in place without rebuilding state every tick.
+``TaskStatus`` is the immutable snapshot for external consumers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Literal
+
+TaskRunStatus = Literal["pending", "success", "error"]
+
+
+@dataclass(frozen=True)
+class ScheduledTaskConfig:
+    """Declarative config for a periodic task.
+
+    Attributes:
+        name: Unique identifier for the task. Used as a dict key in the
+            scheduler and surfaced in observability; must be unique within
+            a single scheduler instance.
+        interval: How long to wait between runs. Measured from the end of
+            one run to the start of the next (not wall-clock ticks).
+        callback: The zero-arg async callable to invoke each tick.
+        jitter: Optional random offset added to each sleep, uniformly
+            sampled from ``[-jitter, +jitter]``. Must be non-negative and
+            strictly smaller than ``interval`` so the effective delay is
+            always positive.
+        run_immediately: If True, run the callback once at registration
+            time before entering the sleep loop. Useful for "warm up the
+            cache on policy load" patterns.
+    """
+
+    name: str
+    interval: timedelta
+    callback: Callable[[], Awaitable[None]]
+    jitter: timedelta = field(default_factory=lambda: timedelta(0))
+    run_immediately: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate config at construction time so policies fail loudly."""
+        if not self.name:
+            raise ValueError("ScheduledTaskConfig.name must be non-empty")
+        if self.interval <= timedelta(0):
+            raise ValueError(f"ScheduledTaskConfig.interval must be positive, got {self.interval}")
+        if self.jitter < timedelta(0):
+            raise ValueError(f"ScheduledTaskConfig.jitter must be non-negative, got {self.jitter}")
+        if self.jitter >= self.interval:
+            raise ValueError(
+                f"ScheduledTaskConfig.jitter ({self.jitter}) must be strictly less than "
+                f"interval ({self.interval}) to guarantee positive delays"
+            )
+
+
+@dataclass
+class RunningTask:
+    """Scheduler-internal handle for an actively-running task.
+
+    Holds mutable counters the scheduler updates after each tick. External
+    consumers should never see this directly — use :meth:`Scheduler.task_status`
+    which returns :class:`TaskStatus` snapshots.
+
+    ``task`` is typed Optional because we construct the handle before
+    minting the asyncio.Task (the loop body needs a reference to this
+    object), then assign it immediately after. Once the scheduler has
+    returned from ``schedule()``, ``task`` is guaranteed non-None.
+    """
+
+    config: ScheduledTaskConfig
+    task: asyncio.Task[None] | None = None
+    run_count: int = 0
+    error_count: int = 0
+    last_run_at: datetime | None = None
+    last_run_status: TaskRunStatus = "pending"
+    last_error: str | None = None
+    next_run_at: datetime | None = None
+
+    @property
+    def name(self) -> str:
+        """Shortcut for ``self.config.name``."""
+        return self.config.name
+
+    def snapshot(self) -> TaskStatus:
+        """Return an immutable observability snapshot."""
+        return TaskStatus(
+            name=self.config.name,
+            interval_seconds=self.config.interval.total_seconds(),
+            jitter_seconds=self.config.jitter.total_seconds(),
+            run_count=self.run_count,
+            error_count=self.error_count,
+            last_run_at=self.last_run_at.isoformat() if self.last_run_at else None,
+            last_run_status=self.last_run_status,
+            last_error=self.last_error,
+            next_run_at=self.next_run_at.isoformat() if self.next_run_at else None,
+        )
+
+
+@dataclass(frozen=True)
+class TaskStatus:
+    """Immutable observability snapshot for a scheduled task.
+
+    Returned by :meth:`Scheduler.task_status` and the admin API. All
+    timestamps are ISO-8601 strings so the payload is JSON-serializable
+    without custom encoders.
+    """
+
+    name: str
+    interval_seconds: float
+    jitter_seconds: float
+    run_count: int
+    error_count: int
+    last_run_at: str | None
+    last_run_status: TaskRunStatus
+    last_error: str | None
+    next_run_at: str | None
+
+
+__all__ = [
+    "ScheduledTaskConfig",
+    "RunningTask",
+    "TaskStatus",
+    "TaskRunStatus",
+]

--- a/tests/luthien_proxy/unit_tests/scheduler/test_admin_scheduler_route.py
+++ b/tests/luthien_proxy/unit_tests/scheduler/test_admin_scheduler_route.py
@@ -1,0 +1,72 @@
+"""Unit tests for GET /api/admin/scheduler/tasks."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from luthien_proxy.admin.routes import (
+    ScheduledTasksResponse,
+    list_scheduled_tasks,
+)
+from luthien_proxy.scheduler.types import TaskStatus
+
+AUTH_TOKEN = "test-admin-key"
+
+
+def _mock_manager(statuses: list[TaskStatus]):
+    manager = MagicMock()
+    manager.scheduler = MagicMock()
+    manager.scheduler.task_status = MagicMock(return_value=statuses)
+    return manager
+
+
+class TestListScheduledTasksRoute:
+    @pytest.mark.asyncio
+    async def test_empty_scheduler_returns_empty_list(self):
+        manager = _mock_manager([])
+        result = await list_scheduled_tasks(_=AUTH_TOKEN, manager=manager)
+        assert isinstance(result, ScheduledTasksResponse)
+        assert result.count == 0
+        assert result.tasks == []
+
+    @pytest.mark.asyncio
+    async def test_tasks_are_serialized_from_task_status_snapshots(self):
+        status = TaskStatus(
+            name="osv-poll",
+            interval_seconds=300.0,
+            jitter_seconds=10.0,
+            run_count=7,
+            error_count=1,
+            last_run_at="2026-04-10T12:00:00+00:00",
+            last_run_status="success",
+            last_error=None,
+            next_run_at="2026-04-10T12:05:00+00:00",
+        )
+        manager = _mock_manager([status])
+        result = await list_scheduled_tasks(_=AUTH_TOKEN, manager=manager)
+        assert result.count == 1
+        assert result.tasks[0].name == "osv-poll"
+        assert result.tasks[0].run_count == 7
+        assert result.tasks[0].error_count == 1
+        assert result.tasks[0].last_run_status == "success"
+        assert result.tasks[0].next_run_at == "2026-04-10T12:05:00+00:00"
+
+    @pytest.mark.asyncio
+    async def test_surfaces_error_tasks(self):
+        status = TaskStatus(
+            name="flaky",
+            interval_seconds=60.0,
+            jitter_seconds=0.0,
+            run_count=3,
+            error_count=2,
+            last_run_at="2026-04-10T12:00:00+00:00",
+            last_run_status="error",
+            last_error="RuntimeError: boom",
+            next_run_at="2026-04-10T12:01:00+00:00",
+        )
+        manager = _mock_manager([status])
+        result = await list_scheduled_tasks(_=AUTH_TOKEN, manager=manager)
+        assert result.tasks[0].last_run_status == "error"
+        assert result.tasks[0].last_error == "RuntimeError: boom"

--- a/tests/luthien_proxy/unit_tests/scheduler/test_policy_manager_scheduler.py
+++ b/tests/luthien_proxy/unit_tests/scheduler/test_policy_manager_scheduler.py
@@ -1,0 +1,191 @@
+"""Integration tests for Scheduler + PolicyManager lifecycle.
+
+These tests verify the policy-load → register → reload → cancel →
+re-register flow end to end, using the real PolicyManager with a mocked
+database. The point is that an existing policy picks up its scheduled
+tasks on load and loses them cleanly on reload.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from luthien_proxy.policies.noop_policy import NoOpPolicy
+from luthien_proxy.policy_core.base_policy import BasePolicy
+from luthien_proxy.policy_manager import PolicyManager
+from luthien_proxy.scheduler import ScheduledTaskConfig, Scheduler
+from luthien_proxy.settings import Settings
+
+
+@pytest.fixture(autouse=True)
+def _dogfood_mode_disabled():
+    """Keep scheduler tests deterministic regardless of environment."""
+    settings = Settings(dogfood_mode=False, database_url="", redis_url="", _env_file=None)  # type: ignore[call-arg]
+    with patch("luthien_proxy.settings.get_settings", return_value=settings):
+        yield
+
+
+class _ScheduledNoOpPolicy(BasePolicy):
+    """Test-only policy that registers a single periodic task."""
+
+    def __init__(self, task_name: str = "noop-ticker") -> None:
+        self._task_name = task_name
+        self.tick_count = 0
+
+    async def _tick(self) -> None:
+        self.tick_count += 1
+
+    def register_scheduled_tasks(self, scheduler: Scheduler) -> None:
+        scheduler.schedule(
+            ScheduledTaskConfig(
+                name=self._task_name,
+                interval=timedelta(seconds=60),  # long — we never want it
+                callback=self._tick,  # to actually run here
+            )
+        )
+
+
+def _make_db_mocks(*, fetchrow_return=None):
+    mock_pool = MagicMock()
+    mock_conn = AsyncMock()
+    mock_pool.get_pool = AsyncMock(return_value=mock_conn)
+    mock_conn.fetchrow = AsyncMock(return_value=fetchrow_return)
+    mock_conn.execute = AsyncMock()
+    return mock_pool, mock_conn
+
+
+def _scheduled_row():
+    return {
+        "policy_class_ref": (
+            "tests.luthien_proxy.unit_tests.scheduler.test_policy_manager_scheduler:_ScheduledNoOpPolicy"
+        ),
+        "config": {},
+    }
+
+
+class TestPolicyManagerSchedulerLifecycle:
+    """The scheduler belongs to PolicyManager and follows policy lifecycle."""
+
+    def test_manager_exposes_scheduler(self):
+        mgr = PolicyManager(db_pool=MagicMock(), redis_client=MagicMock())
+        assert isinstance(mgr.scheduler, Scheduler)
+        assert len(mgr.scheduler) == 0
+
+    @pytest.mark.asyncio
+    async def test_noop_policy_registers_no_tasks(self):
+        """Existing policies must be unaffected by the new lifecycle hook."""
+        mock_pool, _ = _make_db_mocks(
+            fetchrow_return={"policy_class_ref": "luthien_proxy.policies.noop_policy:NoOpPolicy", "config": {}}
+        )
+        mgr = PolicyManager(db_pool=mock_pool, redis_client=MagicMock(), policy_source="db")
+        try:
+            await mgr.initialize()
+            assert isinstance(mgr.current_policy, NoOpPolicy)
+            assert len(mgr.scheduler) == 0
+        finally:
+            await mgr.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_policy_with_tasks_registers_on_initialize(self):
+        mock_pool, _ = _make_db_mocks(fetchrow_return=_scheduled_row())
+        mgr = PolicyManager(db_pool=mock_pool, redis_client=MagicMock(), policy_source="db")
+        try:
+            await mgr.initialize()
+            assert len(mgr.scheduler) == 1
+            assert mgr.scheduler.has_task("noop-ticker")
+        finally:
+            await mgr.shutdown()
+        assert len(mgr.scheduler) == 0
+
+    @pytest.mark.asyncio
+    async def test_reload_cancels_old_and_registers_new_tasks(self):
+        """enable_policy should cancel the previous policy's tasks and register the new ones."""
+        mock_pool, _ = _make_db_mocks(fetchrow_return=_scheduled_row())
+        mgr = PolicyManager(db_pool=mock_pool, redis_client=None, policy_source="db")
+        await mgr.initialize()
+        try:
+            first_policy = mgr.current_policy
+            assert mgr.scheduler.has_task("noop-ticker")
+
+            # Swap to a NoOp policy — the old task should be cancelled.
+            result = await mgr.enable_policy(
+                policy_class_ref="luthien_proxy.policies.noop_policy:NoOpPolicy",
+                config={},
+                enabled_by="test",
+            )
+            assert result.success is True
+            assert isinstance(mgr.current_policy, NoOpPolicy)
+            assert mgr.current_policy is not first_policy
+            assert len(mgr.scheduler) == 0
+
+            # Swap back to the scheduled policy — new task should be registered.
+            result = await mgr.enable_policy(
+                policy_class_ref=(
+                    "tests.luthien_proxy.unit_tests.scheduler.test_policy_manager_scheduler:_ScheduledNoOpPolicy"
+                ),
+                config={},
+                enabled_by="test",
+            )
+            assert result.success is True
+            assert len(mgr.scheduler) == 1
+            assert mgr.scheduler.has_task("noop-ticker")
+        finally:
+            await mgr.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_all_tasks(self):
+        mock_pool, _ = _make_db_mocks(fetchrow_return=_scheduled_row())
+        mgr = PolicyManager(db_pool=mock_pool, redis_client=MagicMock(), policy_source="db")
+        await mgr.initialize()
+        assert len(mgr.scheduler) == 1
+        await mgr.shutdown()
+        assert len(mgr.scheduler) == 0
+        # Idempotent — calling twice is safe.
+        await mgr.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_register_failure_does_not_break_load(self):
+        """A policy whose register_scheduled_tasks raises must not brick the gateway."""
+
+        class _BrokenPolicy(BasePolicy):
+            def register_scheduled_tasks(self, scheduler: Scheduler) -> None:
+                raise RuntimeError("I am broken")
+
+        mgr = PolicyManager(db_pool=MagicMock(), redis_client=MagicMock())
+        # Call the internal helper directly — we just need to confirm it
+        # swallows the exception and logs it.
+        mgr._register_scheduled_tasks(_BrokenPolicy())
+        assert len(mgr.scheduler) == 0
+
+
+class TestMultiSerialRecursesIntoSubPolicies:
+    """MultiSerialPolicy.register_scheduled_tasks should recurse."""
+
+    @pytest.mark.asyncio
+    async def test_multi_serial_recurses(self):
+        from luthien_proxy.policies.multi_serial_policy import MultiSerialPolicy
+
+        class _A(BasePolicy):
+            def register_scheduled_tasks(self, scheduler: Scheduler) -> None:
+                scheduler.schedule(ScheduledTaskConfig(name="a", interval=timedelta(seconds=60), callback=_async_noop))
+
+        class _B(BasePolicy):
+            def register_scheduled_tasks(self, scheduler: Scheduler) -> None:
+                scheduler.schedule(ScheduledTaskConfig(name="b", interval=timedelta(seconds=60), callback=_async_noop))
+
+        multi = MultiSerialPolicy.from_instances([_A(), _B()])
+
+        scheduler = Scheduler()
+        try:
+            multi.register_scheduled_tasks(scheduler)
+            assert scheduler.has_task("a")
+            assert scheduler.has_task("b")
+        finally:
+            await scheduler.cancel_all()
+
+
+async def _async_noop() -> None:
+    return None

--- a/tests/luthien_proxy/unit_tests/scheduler/test_scheduler_service.py
+++ b/tests/luthien_proxy/unit_tests/scheduler/test_scheduler_service.py
@@ -1,0 +1,291 @@
+"""Unit tests for the gateway-wide policy scheduler."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from datetime import timedelta
+
+import pytest
+
+from luthien_proxy.scheduler import (
+    RunningTask,
+    ScheduledTaskConfig,
+    Scheduler,
+    TaskStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class CallRecorder:
+    """Async-callable that records invocation times and optionally raises."""
+
+    def __init__(self, *, raise_on: set[int] | None = None) -> None:
+        self.calls: list[float] = []
+        self._event = asyncio.Event()
+        self._target: int | None = None
+        self._raise_on = raise_on or set()
+
+    async def __call__(self) -> None:
+        # Timestamps are captured relative to the loop clock so tests can
+        # assert spacing between consecutive invocations.
+        self.calls.append(asyncio.get_event_loop().time())
+        n = len(self.calls)
+        if n in self._raise_on:
+            raise RuntimeError(f"callback failure #{n}")
+        if self._target is not None and n >= self._target:
+            self._event.set()
+
+    async def wait_for(self, count: int, timeout: float) -> None:
+        """Block until the callback has been invoked at least ``count`` times."""
+        self._target = count
+        if len(self.calls) >= count:
+            return
+        self._event.clear()
+        await asyncio.wait_for(self._event.wait(), timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# ScheduledTaskConfig validation
+# ---------------------------------------------------------------------------
+
+
+class TestScheduledTaskConfig:
+    def test_rejects_empty_name(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            ScheduledTaskConfig(name="", interval=timedelta(seconds=1), callback=_noop)
+
+    def test_rejects_nonpositive_interval(self):
+        with pytest.raises(ValueError, match="positive"):
+            ScheduledTaskConfig(name="t", interval=timedelta(seconds=0), callback=_noop)
+        with pytest.raises(ValueError, match="positive"):
+            ScheduledTaskConfig(name="t", interval=timedelta(seconds=-1), callback=_noop)
+
+    def test_rejects_negative_jitter(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            ScheduledTaskConfig(
+                name="t",
+                interval=timedelta(seconds=1),
+                callback=_noop,
+                jitter=timedelta(seconds=-0.1),
+            )
+
+    def test_rejects_jitter_ge_interval(self):
+        with pytest.raises(ValueError, match="strictly less than"):
+            ScheduledTaskConfig(
+                name="t",
+                interval=timedelta(seconds=1),
+                callback=_noop,
+                jitter=timedelta(seconds=1),
+            )
+
+
+async def _noop() -> None:
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Scheduler behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestScheduler:
+    async def test_schedules_and_reports_task(self):
+        scheduler = Scheduler()
+        cb = CallRecorder()
+        scheduler.schedule(
+            ScheduledTaskConfig(
+                name="t1",
+                interval=timedelta(milliseconds=20),
+                callback=cb,
+                run_immediately=True,
+            )
+        )
+        assert scheduler.has_task("t1")
+        assert len(scheduler) == 1
+
+        try:
+            await cb.wait_for(1, timeout=1.0)
+            assert cb.calls, "expected at least one invocation"
+        finally:
+            await scheduler.cancel_all()
+
+        assert len(scheduler) == 0
+
+    async def test_run_immediately_invokes_before_first_sleep(self):
+        scheduler = Scheduler()
+        cb = CallRecorder()
+        scheduler.schedule(
+            ScheduledTaskConfig(
+                name="t",
+                interval=timedelta(seconds=60),  # long interval so the
+                callback=cb,  # first call only comes
+                run_immediately=True,  # from run_immediately
+            )
+        )
+        try:
+            await cb.wait_for(1, timeout=1.0)
+            assert len(cb.calls) == 1
+        finally:
+            await scheduler.cancel_all()
+
+    async def test_repeats_on_interval(self):
+        scheduler = Scheduler()
+        cb = CallRecorder()
+        interval_s = 0.03
+        scheduler.schedule(
+            ScheduledTaskConfig(
+                name="t",
+                interval=timedelta(seconds=interval_s),
+                callback=cb,
+            )
+        )
+        try:
+            await cb.wait_for(3, timeout=1.0)
+            assert len(cb.calls) >= 3
+            # Spacing between consecutive calls should be at least interval;
+            # allow a generous slop for scheduler jitter.
+            spacings = [cb.calls[i + 1] - cb.calls[i] for i in range(len(cb.calls) - 1)]
+            assert all(s >= interval_s * 0.8 for s in spacings), spacings
+        finally:
+            await scheduler.cancel_all()
+
+    async def test_callback_exception_does_not_kill_task(self):
+        scheduler = Scheduler()
+        # Raise on the first call; subsequent calls should still happen.
+        cb = CallRecorder(raise_on={1})
+        scheduler.schedule(
+            ScheduledTaskConfig(
+                name="flaky",
+                interval=timedelta(milliseconds=20),
+                callback=cb,
+                run_immediately=True,
+            )
+        )
+        try:
+            await cb.wait_for(3, timeout=2.0)
+            status = next(s for s in scheduler.task_status() if s.name == "flaky")
+            assert status.error_count >= 1
+            assert status.run_count >= 3
+            # After the initial failure, subsequent successful runs clear
+            # the last_error and flip status back to success.
+            assert status.last_run_status == "success"
+            assert status.last_error is None
+        finally:
+            await scheduler.cancel_all()
+
+    async def test_cancel_stops_single_task(self):
+        scheduler = Scheduler()
+        cb = CallRecorder()
+        scheduler.schedule(
+            ScheduledTaskConfig(
+                name="t",
+                interval=timedelta(milliseconds=10),
+                callback=cb,
+                run_immediately=True,
+            )
+        )
+        await cb.wait_for(1, timeout=1.0)
+        cancelled = await scheduler.cancel("t")
+        assert cancelled is True
+        assert not scheduler.has_task("t")
+        # A second cancel is idempotent.
+        assert (await scheduler.cancel("t")) is False
+
+        # After cancellation, the callback should stop accumulating new
+        # invocations within a short window.
+        snapshot_count = len(cb.calls)
+        await asyncio.sleep(0.05)
+        assert len(cb.calls) == snapshot_count
+
+    async def test_cancel_unknown_returns_false(self):
+        scheduler = Scheduler()
+        assert (await scheduler.cancel("does-not-exist")) is False
+
+    async def test_cancel_all_clears_scheduler(self):
+        scheduler = Scheduler()
+        cb1 = CallRecorder()
+        cb2 = CallRecorder()
+        scheduler.schedule(ScheduledTaskConfig(name="a", interval=timedelta(milliseconds=10), callback=cb1))
+        scheduler.schedule(ScheduledTaskConfig(name="b", interval=timedelta(milliseconds=10), callback=cb2))
+        assert len(scheduler) == 2
+        await scheduler.cancel_all()
+        assert len(scheduler) == 0
+        # Safe to call on empty scheduler.
+        await scheduler.cancel_all()
+
+    async def test_duplicate_name_raises(self):
+        scheduler = Scheduler()
+        scheduler.schedule(ScheduledTaskConfig(name="dup", interval=timedelta(seconds=1), callback=_noop))
+        with pytest.raises(ValueError, match="already registered"):
+            scheduler.schedule(ScheduledTaskConfig(name="dup", interval=timedelta(seconds=1), callback=_noop))
+        await scheduler.cancel_all()
+
+    async def test_task_status_is_serializable(self):
+        scheduler = Scheduler()
+        cb = CallRecorder()
+        scheduler.schedule(
+            ScheduledTaskConfig(
+                name="serial",
+                interval=timedelta(milliseconds=20),
+                callback=cb,
+                run_immediately=True,
+            )
+        )
+        try:
+            await cb.wait_for(1, timeout=1.0)
+            statuses = scheduler.task_status()
+            assert len(statuses) == 1
+            s = statuses[0]
+            assert isinstance(s, TaskStatus)
+            assert s.name == "serial"
+            assert s.run_count >= 1
+            assert s.last_run_at is not None
+            # ISO-8601 strings should round-trip through fromisoformat.
+            from datetime import datetime
+
+            datetime.fromisoformat(s.last_run_at)
+        finally:
+            await scheduler.cancel_all()
+
+    async def test_schedule_returns_running_task(self):
+        scheduler = Scheduler()
+        running = scheduler.schedule(ScheduledTaskConfig(name="rt", interval=timedelta(seconds=1), callback=_noop))
+        assert isinstance(running, RunningTask)
+        assert running.name == "rt"
+        assert running.task is not None
+        await scheduler.cancel_all()
+
+
+# ---------------------------------------------------------------------------
+# Jitter distribution
+# ---------------------------------------------------------------------------
+
+
+class TestJitter:
+    def test_compute_delay_respects_bounds(self):
+        config = ScheduledTaskConfig(
+            name="j",
+            interval=timedelta(seconds=1),
+            callback=_noop,
+            jitter=timedelta(milliseconds=200),
+        )
+        rng = random.Random(12345)
+        # Patch the module-level random.uniform indirectly by seeding.
+        random.seed(rng.random())
+        for _ in range(500):
+            delay = Scheduler._compute_delay(config)
+            assert 0.8 <= delay <= 1.2
+
+    def test_compute_delay_zero_jitter(self):
+        config = ScheduledTaskConfig(
+            name="j",
+            interval=timedelta(seconds=2),
+            callback=_noop,
+        )
+        for _ in range(10):
+            assert Scheduler._compute_delay(config) == pytest.approx(2.0)


### PR DESCRIPTION
## Summary

Add a gateway-level scheduling primitive that lets policies register periodic background tasks. This is **PR A** of a two-PR stack; the consumer is the supply-chain blocklist policy (PR B, branch `worktree-supply-chain-blocklist`) which needs to poll OSV every few minutes.

The scheduler is intentionally small — a primitive, not a framework. Policies opt in via a new no-op `register_scheduled_tasks(scheduler)` lifecycle hook. The gateway owns the asyncio loop and the task lifecycle.

## Acceptance criteria

- Policies register tasks via `register_scheduled_tasks(scheduler) -> None` (default no-op; backward compatible with every existing policy).
- Scheduler accepts per-task config: `name`, `interval`, `callback`, `jitter`, `run_immediately`.
- Tasks are cancelled cleanly on policy reload (admin API) and gateway shutdown; no orphaned tasks.
- Callback exceptions are caught/logged/recorded; the task continues running on the next interval.
- Per-task observability (last run, last status, run count, error count, next run) exposed via `GET /api/admin/scheduler/tasks`.
- Unit tests cover: registration, interval execution, exception isolation, cancellation, jitter bounds.
- Integration test covers load → schedule → reload → re-schedule → unload → cancel.
- No new dependencies. Hand-rolled `asyncio.create_task` + cancellation tracking.

## Non-goals

- Cron syntax, distributed coordination, task-state persistence across restarts, admin UI page.

## Test plan

- [ ] `./scripts/dev_checks.sh` clean
- [ ] `uv run pytest tests/luthien_proxy/unit_tests --no-cov -q` — full unit suite passes, no regressions in existing policies

---
*Posted by Claude Code (claude-opus-4-6[1m])*