### PR TITLE
feat: supply chain blocklist policy

### DIFF
--- a/changelog.d/supply-chain-blocklist.md
+++ b/changelog.d/supply-chain-blocklist.md
@@ -1,0 +1,11 @@
+---
+category: Features
+pr: 544
+---
+
+**Supply-chain blocklist policy**: New best-effort gateway policy that blocks bash tool_use install commands for known-compromised package versions via a background OSV poller and in-memory lookup.
+  - Adds dual migrations for `supply_chain_blocklist` + `supply_chain_blocklist_cursor` tables.
+  - Request-time path is a tiny in-memory lookup (PEP 440 / semver range matching + literal substring backstop) — no OSV traffic in the hot path.
+  - Substitution is an `sh -c '... LUTHIEN BLOCKED ... exit 42'` rewrite of `tool_use.input.command`, same block index, no new content blocks.
+  - Depends on `worktree-policy-scheduler` (PR A) for the real scheduler primitive; this PR stubs `SchedulerProtocol` and a `register_scheduled_tasks` hook.
+  - Cooperative-LLM only. Not a security boundary against adversarial obfuscation. Lockfile installs explicitly out of scope — use OSV-Scanner in CI.

--- a/dev/OBJECTIVE.md
+++ b/dev/OBJECTIVE.md
@@ -1,1 +1,93 @@
+# Objective: Supply chain blocklist policy
 
+## Goal
+
+A Luthien gateway policy that blocks bash tool_use install commands for known-compromised package versions. The blocklist is built and refreshed by an in-process background task that polls OSV every few minutes for newly-published CRITICAL CVEs. The request-time check is a simple in-memory lookup with PEP 440 / semver range matching, plus a literal-substring backstop. On a hit, the policy rewrites the bash `tool_use.input.command` field in place to a `sh -c '... LUTHIEN BLOCKED ... exit 42'` substitute — the cooperative LLM sees a failed command in the next turn's tool_result and relays the CVE information to the user via its normal error-reporting path.
+
+## Motivation
+
+Recent real-world incidents (litellm, axios) published compromised package versions where the CVE was public but the registry hadn't yanked yet. During that window — often minutes to hours — a cooperative LLM running `pip install litellm` or `npm install axios@1.6.8` would innocently install the poisoned build. We want to catch this at the proxy layer (org-wide enforcement, not client-config dependent) with **minutes-resolution** freshness on new CVEs, because most of the policy's value is the delta between CVE publication and registry yank.
+
+## Background — three failed prior attempts
+
+This is the **fourth** design pass on the supply-chain problem. PRs #522, #536, and #540 are all closed.
+
+- **#522** (4,835 lines): adversarial shell parser. Seven /devil rounds of real bypasses. Closed.
+- **#536** (2,520 lines): "best-effort advisory" via content injection (new text blocks alongside the flagged tool_use). Killed by a streaming protocol violation (non-monotonic block indices) and a missed primary use case (`npm ci` not in regex).
+- **#540** (3,392 lines): command substitution + regex parsing of install commands. Three /devil rounds. Each round, the new layer the implementation added (parser → streaming → substitution-builder → wrapper-detection) shipped with its own crop of edge-case bugs at roughly the same density as the previous layer.
+
+The meta-pattern devil identified in round 3: *"the policy makes assumptions about how a string-form bash command will be emitted, those assumptions are narrower than the real distribution of LLM output."* Three rounds, three layers, same shape of failure. The edge-case load is downstream of the design choice (regex-parsing free-form bash strings).
+
+## The new design — why this one is different
+
+The fundamental shift: **OSV lookups happen out-of-band on a background schedule, not at request time.** The request-time path is a tiny in-memory lookup that does not need to parse arbitrary bash. This collapses most of #540's edge-case layers because they only existed to work around imperfect command parsing.
+
+- **Background task** (every 5 minutes, configurable, with jitter, via the scheduler primitive in PR `worktree-policy-scheduler`): query OSV's `/v1/query` REST API with a date filter for advisories published since `last_seen_at` with severity ≥ CRITICAL. Parse the affected version ranges and upsert into a `supply_chain_blocklist` table.
+- **Persistence**: `supply_chain_blocklist (ecosystem, canonical_name, affected_range, cve_id, severity, published_at, fetched_at)` plus a per-ecosystem `last_seen_at` tracking row. Schema is shipped as **dual migrations** (`migrations/postgres/NNN_*.sql` + `migrations/sqlite/NNN_*.sql`) and accessed exclusively through `PoolProtocol` in `src/luthien_proxy/utils/db.py`. No backend-specific code.
+- **In-memory state**: blocklist is loaded into a Python dict `(ecosystem, canonical_name) -> list[BlockedRange]` at policy startup with a single SELECT, and incrementally updated by the background task. Process restart re-loads from DB without re-fetching from OSV.
+- **Request-time check**: on bash tool_use, buffer the block, extract `name==version` / `name@version` literals via a loose regex, look each up against the in-memory blocklist with version-range matching:
+  - PyPI: PEP 440 specifier matching (use `packaging.specifiers.SpecifierSet`).
+  - npm: semver range matching (use a small dependency or hand-rolled).
+- **Backstop substring scan**: also check if any blocklisted *exact* `name==version` literal appears anywhere in the command string. Catches cases the regex misses (line continuations, exotic spacing, embedded in wrapper commands) without needing wrapper detection or other parser layers.
+- **Substitution shape**: rewrite `tool_use.input.command` in place to `sh -c '... LUTHIEN BLOCKED: <pkg> <version> matches <cve> (<severity>) ... exit 42'`. Same block, same index, no new content blocks. The streaming layer in #540 was correct — re-derive the same shape from scratch in this PR.
+
+## Acceptance check
+
+- `SupplyChainBlocklistPolicy` registers a periodic background task via the new scheduler (default interval 5 minutes, jitter ±60s).
+- The background task fetches OSV advisories with severity ≥ CRITICAL published since `last_seen_at`, parses affected ranges, and upserts them into the `supply_chain_blocklist` table. Failures are logged and the task continues on the next interval.
+- The blocklist table is created via dual migrations (postgres + sqlite) with matched numbering, validated by `tests/luthien_proxy/integration_tests/test_migration_sync.py`.
+- All persistence flows through `DatabasePool` / `PoolProtocol`. No direct asyncpg or aiosqlite imports in policy code.
+- At policy startup, the blocklist is loaded into in-memory state via a single SELECT.
+- At request time, the policy buffers bash tool_use blocks, extracts package literals, runs PEP 440 / semver range checks against the blocklist, **and** runs a literal-substring backstop scan, and substitutes the command on hit.
+- The substituted command is emitted at the **same block index** as the original tool_use. **Tests verify monotonic `content_block_start` indices and unchanged block counts** (the test class-of-bug that killed #536 must not recur).
+- Subprocess tests run the generated `sh -c` substitute through real `bash -c` and assert exit 42, stderr content, and absence of side effects (no temp file writes, attacker-quote metacharacter sandbox).
+- Lockfile installs (`npm ci`, `pip install -r requirements.txt`, `yarn install --frozen-lockfile`, etc.) are explicitly out of scope. The policy docstring states this and recommends OSV-Scanner in CI for lockfile coverage.
+- Module docstring explicitly states the policy is best-effort, cooperative-LLM only, and not a security boundary against adversarial obfuscation.
+- An end-to-end test simulates a fresh blocklist entry being added by the background task and a subsequent flagged install being substituted.
+
+## External contracts
+
+- **OSV REST API**: `https://api.osv.dev/v1/query` with date filter on `published`. Document the exact query shape and the response fields we depend on (`affected[].package.{ecosystem,name}`, `affected[].ranges`, `database_specific.severity`, `id`, `published`).
+- **`PoolProtocol` / `ConnectionProtocol`** in `src/luthien_proxy/utils/db.py`. Queries written in asyncpg style (`$1`, `$2` placeholders); SQLite translator handles backend differences.
+- **The scheduler primitive** from PR `worktree-policy-scheduler`. This PR depends on that one landing first, OR on the scheduler interface being stable enough to stub against.
+- **The Anthropic streaming protocol**: `content_block_start` indices must be monotonic across the emitted stream. The substitution must preserve the original block index and count. This is the invariant whose violation killed #536.
+- **PEP 440** for PyPI version specifier matching (`packaging.specifiers.SpecifierSet`).
+- **semver** for npm range matching.
+
+## Assumptions (falsifiable)
+
+- I assume OSV's `/v1/query` API supports a "published since" date filter or an equivalent way to fetch only newly-published advisories. If it does not, the background task strategy needs to fetch a larger window and dedupe in code, which is more bandwidth but still works.
+- I assume `database_specific.severity` is reliably populated for CRITICAL CVEs in OSV. If a meaningful fraction of CRITICAL CVEs ship without this label and only have CVSS vectors, the background task will need a CVSS parser at fetch time (still out-of-band — fine — but more code).
+- I assume PEP 440 and semver range matching are available via well-maintained Python libraries (`packaging` for the former; the latter may need `python-semver` or hand-rolled).
+- I assume the Anthropic API will not introduce new content_block_delta types that arrive at a buffered tool_use index between the start and stop events without warning. The `_handle_block_delta` flush logic in #540 handles this case; this PR re-derives that logic from scratch.
+- I assume `packaging` is already a transitive dep in the project (it is, via pip/setuptools). If not, it's a tiny add.
+
+## Non-goals
+
+- **Adversarial parser robustness.** Cooperative LLM only. Documented in module docstring.
+- **Lockfile resolution.** Out of scope; recommend OSV-Scanner in CI for projects that need lockfile coverage.
+- **Wrapper detection** (`docker run`, `sudo`, etc.). Not needed because the request-time check is a literal lookup against a small blocklist. False positives on `echo pip install foo` are acceptable because the substitution message ("pkg X is a known compromised version, here's the CVE") is the right thing to surface even in an echo context.
+- **CVSS v3 / v4 parsing at runtime.** The background task filters by severity at fetch time using OSV's labels.
+- **Request-time fail-modes for OSV unreachable.** The background task handles this; request-time uses cached state.
+- **Operator-curated explicit blocklist override.** Useful but a follow-up; track in Trello.
+- **Multi-instance coordination.** Each gateway instance polls independently. Known property; acceptable for v1.
+
+## Dependencies / blockers
+
+- **Depends on PR `worktree-policy-scheduler`** for the scheduler primitive. This PR cannot land until that one does. Implementation can begin with a stubbed scheduler interface.
+
+## Out-of-scope concerns to defer
+
+- Blocklist admin UI page (Trello ticket).
+- Operator-curated explicit blocklist (Trello ticket).
+- Multi-instance polling coordination (acceptable as-is).
+- A "soft" warning mode that surfaces but does not block (Trello ticket if requested).
+
+## Reference (do not lift code from these — re-derive from scratch)
+
+- **PR #540** (closed) at branch `worktree-supply-chain-gate`. The streaming buffer pattern, substitution builder, `_handle_block_delta` flush logic, and 5 `TestStreamingShape` tests are all correct in that PR and are the parts to re-derive from scratch (re-derivation is required, not lifting — Jai called for a fresh start).
+- **PR #536** (closed) at branch `worktree-supply-chain-advisory`. Reference for what content injection looks like and why it's wrong.
+- **PR #522** (closed) at branch `worktree-supply-chain-guard`. Reference for what an adversarial parser layer looks like and why it's wrong.
+- **Memory entry**: `feedback_db_agnostic_persistence.md` — DB-agnostic via `PoolProtocol` is mandatory.
+- **Memory entry**: `project_supply_chain_intervention_shape.md` — partially obsolete (the architectural answer changed from "command substitution as the whole policy" to "scheduled background task pulls a blocklist; request-time path is a tiny lookup with command substitution as the intervention"). Update this memory once the PR lands.
+- **Migration discipline**: `migrations/CLAUDE.md` for the dual-migration workflow and type translation rules.

--- a/migrations/postgres/014_add_supply_chain_blocklist.sql
+++ b/migrations/postgres/014_add_supply_chain_blocklist.sql
@@ -1,0 +1,24 @@
+-- Supply-chain blocklist populated by an in-process background task that polls
+-- OSV for newly-published CRITICAL CVEs. Loaded into an in-memory dict at
+-- policy startup. Request-time lookups never touch this table.
+CREATE TABLE IF NOT EXISTS supply_chain_blocklist (
+    ecosystem      TEXT NOT NULL,
+    canonical_name TEXT NOT NULL,
+    cve_id         TEXT NOT NULL,
+    affected_range TEXT NOT NULL,
+    severity       TEXT NOT NULL,
+    published_at   TIMESTAMPTZ NOT NULL,
+    fetched_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (ecosystem, canonical_name, cve_id, affected_range)
+);
+
+CREATE INDEX IF NOT EXISTS idx_supply_chain_blocklist_lookup
+    ON supply_chain_blocklist(ecosystem, canonical_name);
+
+-- Tracks the last `published_at` timestamp seen per ecosystem so the poller can
+-- fetch only newly-published advisories on subsequent ticks.
+CREATE TABLE IF NOT EXISTS supply_chain_blocklist_cursor (
+    ecosystem     TEXT PRIMARY KEY,
+    last_seen_at  TIMESTAMPTZ NOT NULL,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/migrations/sqlite/014_add_supply_chain_blocklist.sql
+++ b/migrations/sqlite/014_add_supply_chain_blocklist.sql
@@ -1,0 +1,24 @@
+-- Supply-chain blocklist populated by an in-process background task that polls
+-- OSV for newly-published CRITICAL CVEs. Loaded into an in-memory dict at
+-- policy startup. Request-time lookups never touch this table.
+CREATE TABLE IF NOT EXISTS supply_chain_blocklist (
+    ecosystem      TEXT NOT NULL,
+    canonical_name TEXT NOT NULL,
+    cve_id         TEXT NOT NULL,
+    affected_range TEXT NOT NULL,
+    severity       TEXT NOT NULL,
+    published_at   TEXT NOT NULL,
+    fetched_at     TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (ecosystem, canonical_name, cve_id, affected_range)
+);
+
+CREATE INDEX IF NOT EXISTS idx_supply_chain_blocklist_lookup
+    ON supply_chain_blocklist(ecosystem, canonical_name);
+
+-- Tracks the last published_at timestamp seen per ecosystem so the poller can
+-- fetch only newly-published advisories on subsequent ticks.
+CREATE TABLE IF NOT EXISTS supply_chain_blocklist_cursor (
+    ecosystem     TEXT PRIMARY KEY,
+    last_seen_at  TEXT NOT NULL,
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/src/luthien_proxy/policies/supply_chain_blocklist_db.py
+++ b/src/luthien_proxy/policies/supply_chain_blocklist_db.py
@@ -1,0 +1,116 @@
+"""Database access layer for the supply-chain blocklist policy.
+
+Thin wrapper around ``PoolProtocol`` so the policy and background task stay
+DB-agnostic: queries use asyncpg-style ``$N`` placeholders that the SQLite
+translator understands. Nothing in this module imports asyncpg or aiosqlite
+directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Iterable, Sequence
+
+from luthien_proxy.utils.db import PoolProtocol, parse_db_ts
+
+
+@dataclass(frozen=True)
+class BlocklistRow:
+    """One row of the ``supply_chain_blocklist`` table."""
+
+    ecosystem: str
+    canonical_name: str
+    cve_id: str
+    affected_range: str
+    severity: str
+    published_at: datetime
+
+
+async def load_all_entries(pool: PoolProtocol) -> list[BlocklistRow]:
+    """Return every row in ``supply_chain_blocklist``, used at policy startup."""
+    rows: Sequence[object] = await pool.fetch(
+        """
+        SELECT ecosystem, canonical_name, cve_id, affected_range, severity, published_at
+        FROM supply_chain_blocklist
+        """
+    )
+    return [_row_to_entry(r) for r in rows]
+
+
+async def upsert_entries(pool: PoolProtocol, entries: Iterable[BlocklistRow]) -> int:
+    """Insert or refresh rows from one background-task tick.
+
+    Uses ``ON CONFLICT DO NOTHING`` semantics: the primary key is
+    ``(ecosystem, canonical_name, cve_id, affected_range)``, so re-fetching
+    the same advisory window is idempotent. Returns the number of attempted
+    inserts (not a delta — the DB drivers don't report rows-affected uniformly).
+    """
+    count = 0
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            for entry in entries:
+                await conn.execute(
+                    """
+                    INSERT INTO supply_chain_blocklist
+                        (ecosystem, canonical_name, cve_id, affected_range, severity, published_at)
+                    VALUES ($1, $2, $3, $4, $5, $6)
+                    ON CONFLICT DO NOTHING
+                    """,
+                    entry.ecosystem,
+                    entry.canonical_name,
+                    entry.cve_id,
+                    entry.affected_range,
+                    entry.severity,
+                    entry.published_at.isoformat(),
+                )
+                count += 1
+    return count
+
+
+async def get_cursor(pool: PoolProtocol, ecosystem: str) -> datetime | None:
+    """Return the most recent ``published_at`` watermark seen for ``ecosystem``."""
+    row = await pool.fetchrow(
+        "SELECT last_seen_at FROM supply_chain_blocklist_cursor WHERE ecosystem = $1",
+        ecosystem,
+    )
+    if row is None:
+        return None
+    return parse_db_ts(row["last_seen_at"])
+
+
+async def set_cursor(pool: PoolProtocol, ecosystem: str, last_seen_at: datetime) -> None:
+    """Update the watermark, creating the row if missing."""
+    now_iso = datetime.now(UTC).isoformat()
+    await pool.execute(
+        """
+        INSERT INTO supply_chain_blocklist_cursor (ecosystem, last_seen_at, updated_at)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (ecosystem) DO UPDATE SET last_seen_at = excluded.last_seen_at,
+                                              updated_at = excluded.updated_at
+        """,
+        ecosystem,
+        last_seen_at.isoformat(),
+        now_iso,
+    )
+
+
+def _row_to_entry(row: object) -> BlocklistRow:
+    record = row  # type: ignore[assignment]
+    return BlocklistRow(
+        ecosystem=str(record["ecosystem"]),  # type: ignore[index]
+        canonical_name=str(record["canonical_name"]),  # type: ignore[index]
+        cve_id=str(record["cve_id"]),  # type: ignore[index]
+        affected_range=str(record["affected_range"]),  # type: ignore[index]
+        severity=str(record["severity"]),  # type: ignore[index]
+        published_at=parse_db_ts(record["published_at"]),  # type: ignore[index]
+    )
+
+
+__all__ = [
+    "BlocklistRow",
+    "get_cursor",
+    "load_all_entries",
+    "set_cursor",
+    "upsert_entries",
+]

--- a/src/luthien_proxy/policies/supply_chain_blocklist_policy.py
+++ b/src/luthien_proxy/policies/supply_chain_blocklist_policy.py
@@ -1,0 +1,540 @@
+"""SupplyChainBlocklistPolicy — best-effort blocklist for compromised package installs.
+
+This policy blocks bash ``tool_use`` install commands for known-compromised
+package versions. The blocklist is built and refreshed by an in-process
+background task that polls OSV every few minutes for newly-published CRITICAL
+CVEs. Request-time checks are a tiny in-memory lookup with PEP 440 / semver
+range matching plus a literal-substring backstop. On a hit, the policy
+rewrites the bash ``tool_use.input.command`` field in place to a
+``sh -c '... LUTHIEN BLOCKED ... exit 42'`` substitute — the cooperative LLM
+then sees a failed command in the next turn's ``tool_result`` and relays the
+CVE information to the user via its normal error-reporting path.
+
+Explicit non-properties of this policy:
+
+- **Not a security boundary against adversarial obfuscation.** A motivated
+  adversarial LLM can trivially bypass it (``sh -c "$(base64 -d ...)"``,
+  ``eval``, writing scripts and sourcing them). Cooperative LLMs only.
+- **Does not cover lockfile installs** (``npm ci``, ``pip install -r``, ``yarn
+  install --frozen-lockfile``). Run OSV-Scanner in CI for lockfile coverage.
+- **Minutes-resolution freshness only.** The gap between CVE publication and
+  the next poll tick is the window where compromised installs can slip
+  through. The policy's value is catching the gap between publication and
+  registry yank, not providing zero-latency detection.
+
+Three prior attempts at this feature (PRs #522, #536, #540) are all closed.
+The meta-pattern that killed them was regex-parsing free-form bash strings to
+decide whether to make an OSV call, then bolting on layer after layer to
+handle edge cases in that parser. This fourth design shifts OSV traffic to a
+background task, making the request-time path a literal lookup that does not
+need to interpret arbitrary commands — most of the prior edge-case load
+dissolves as a result.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol, cast
+
+from anthropic.lib.streaming import MessageStreamEvent
+from anthropic.types import (
+    InputJSONDelta,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    ToolUseBlock,
+)
+
+from luthien_proxy.policies.supply_chain_blocklist_db import (
+    BlocklistRow,
+    get_cursor,
+    load_all_entries,
+    set_cursor,
+    upsert_entries,
+)
+from luthien_proxy.policies.supply_chain_blocklist_utils import (
+    SUPPORTED_ECOSYSTEMS,
+    BlocklistEntry,
+    BlocklistIndex,
+    OSVClient,
+    SupplyChainBlocklistConfig,
+    build_substitute_command,
+    extract_literals,
+)
+from luthien_proxy.policy_core import AnthropicHookPolicy, BasePolicy
+
+if TYPE_CHECKING:
+    from luthien_proxy.llm.types.anthropic import (
+        AnthropicContentBlock,
+        AnthropicResponse,
+        AnthropicToolUseBlock,
+    )
+    from luthien_proxy.policy_core.policy_context import PolicyContext
+    from luthien_proxy.utils.db import PoolProtocol
+
+logger = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# Scheduler protocol (stub — PR worktree-policy-scheduler will wire the real
+# implementation). The policy accepts any object satisfying this shape so
+# tests can pass a trivial in-memory scheduler and PR A can swap in the real
+# one without touching policy code.
+# -----------------------------------------------------------------------------
+
+
+class SchedulerProtocol(Protocol):
+    """The minimal surface area the policy needs from a scheduler."""
+
+    def schedule(
+        self,
+        name: str,
+        interval_seconds: float,
+        callback: Callable[[], Awaitable[None]],
+        jitter_seconds: float = 0.0,
+        run_immediately: bool = False,
+    ) -> None:
+        """Register a periodic callback."""
+        ...
+
+
+# -----------------------------------------------------------------------------
+# Per-request state
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class _BufferedBashToolUse:
+    """A tool_use block being buffered across the stream until its stop event."""
+
+    id: str
+    name: str
+    input_json: str = ""
+
+
+@dataclass
+class _PolicyState:
+    """Per-request mutable state stored on ``PolicyContext``."""
+
+    buffered_tool_uses: dict[int, _BufferedBashToolUse] = field(default_factory=dict)
+
+
+# -----------------------------------------------------------------------------
+# Policy
+# -----------------------------------------------------------------------------
+
+
+class SupplyChainBlocklistPolicy(BasePolicy, AnthropicHookPolicy):
+    """Substitute bash install commands that match a known-compromised entry."""
+
+    @property
+    def short_policy_name(self) -> str:
+        """Short human-readable name used in emitted events."""
+        return "SupplyChainBlocklist"
+
+    def __init__(
+        self,
+        config: SupplyChainBlocklistConfig | dict | None = None,
+        *,
+        db_pool: "PoolProtocol | None" = None,
+        osv_client: OSVClient | None = None,
+        scheduler: SchedulerProtocol | None = None,
+    ) -> None:
+        """Create a stateless policy instance.
+
+        Args:
+            config: Policy configuration (or raw dict from YAML).
+            db_pool: Shared DB pool (DB-agnostic via ``PoolProtocol``). When
+                unset, the policy runs with an empty blocklist — PR
+                ``worktree-policy-scheduler`` will wire the real pool through
+                ``register_scheduled_tasks``.
+            osv_client: Injectable OSV client for tests. Defaults to the
+                real HTTP-backed client.
+            scheduler: Optional scheduler to register the background task
+                against immediately (test convenience; production uses
+                ``register_scheduled_tasks``).
+        """
+        self.config = self._init_config(config, SupplyChainBlocklistConfig)
+        self._bash_tool_names: frozenset[str] = frozenset(self.config.bash_tool_names)
+        self._db_pool: "PoolProtocol | None" = db_pool
+        self._osv = osv_client or OSVClient(
+            api_url=self.config.osv_api_url,
+            timeout_seconds=self.config.osv_timeout_seconds,
+        )
+        # Immutable snapshot-swap: we never mutate the index in place. The
+        # background task assembles a new BlocklistIndex from all entries and
+        # atomically rebinds ``self._index``. Reads (per-request) see a
+        # consistent snapshot at any given instant.
+        self._index: BlocklistIndex = BlocklistIndex([])
+        self._scheduler_registered = False
+        if scheduler is not None:
+            self.register_scheduled_tasks(scheduler)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def register_scheduled_tasks(self, scheduler: SchedulerProtocol) -> None:
+        """Register the blocklist poller with ``scheduler``.
+
+        Called by the policy loader once PR ``worktree-policy-scheduler`` is
+        merged. The scheduler is responsible for calling ``poll_once`` at
+        ``poll_interval_seconds`` with ``poll_jitter_seconds`` of jitter and
+        running it once immediately on startup.
+        """
+        if self._scheduler_registered:
+            return
+        scheduler.schedule(
+            name=f"{self.short_policy_name}.poll",
+            interval_seconds=self.config.poll_interval_seconds,
+            callback=self.poll_once,
+            jitter_seconds=self.config.poll_jitter_seconds,
+            run_immediately=True,
+        )
+        self._scheduler_registered = True
+
+    async def load_initial_state(self, db_pool: "PoolProtocol | None" = None) -> None:
+        """Populate the in-memory index from the DB at startup.
+
+        Tests and the (future) scheduler-backed lifecycle can call this
+        explicitly. No-op when no pool is available.
+        """
+        pool = db_pool or self._db_pool
+        if pool is None:
+            return
+        try:
+            rows = await load_all_entries(pool)
+        except Exception as exc:
+            logger.warning("Failed to load supply-chain blocklist from DB: %s", exc)
+            return
+        self._index = BlocklistIndex(BlocklistEntry.from_row(r) for r in rows)
+        logger.info("Supply-chain blocklist loaded: %d entries", len(self._index))
+
+    async def poll_once(self) -> None:
+        """Run one tick of the background poller.
+
+        Fetches new advisories for each supported ecosystem, upserts them
+        into the DB, advances the per-ecosystem cursor, and rebuilds the
+        in-memory index. Failures for one ecosystem do not block the others
+        and are logged, not raised — the scheduler will retry on the next
+        tick.
+        """
+        pool = self._db_pool
+        if pool is None:
+            logger.debug("SupplyChainBlocklistPolicy.poll_once: no DB pool, skipping")
+            return
+        for ecosystem in SUPPORTED_ECOSYSTEMS:
+            try:
+                await self._poll_ecosystem(pool, ecosystem)
+            except Exception as exc:
+                logger.warning("OSV poll failed for ecosystem=%s: %s", ecosystem, exc)
+        await self._refresh_index(pool)
+
+    async def _poll_ecosystem(self, pool: "PoolProtocol", ecosystem: str) -> None:
+        since = await get_cursor(pool, ecosystem)
+        result = await self._osv.fetch_recent(
+            ecosystem=ecosystem,
+            since=since,
+            min_severity=self.config.min_severity,
+            limit=self.config.max_entries_per_tick,
+        )
+        if result.entries:
+            await upsert_entries(pool, result.entries)
+        watermark = _pick_watermark(since, result.entries, result.latest_published_at)
+        if watermark is not None:
+            await set_cursor(pool, ecosystem, watermark)
+
+    async def _refresh_index(self, pool: "PoolProtocol") -> None:
+        try:
+            rows = await load_all_entries(pool)
+        except Exception as exc:
+            logger.warning("Failed to refresh supply-chain blocklist index: %s", exc)
+            return
+        self._index = BlocklistIndex(BlocklistEntry.from_row(r) for r in rows)
+
+    # ------------------------------------------------------------------
+    # Per-request hooks
+    # ------------------------------------------------------------------
+
+    def _state(self, context: "PolicyContext") -> _PolicyState:
+        return context.get_request_state(self, _PolicyState, _PolicyState)
+
+    def _buffered(self, context: "PolicyContext") -> dict[int, _BufferedBashToolUse]:
+        return self._state(context).buffered_tool_uses
+
+    async def on_anthropic_streaming_policy_complete(self, context: "PolicyContext") -> None:
+        """Drop per-request state when the streaming pipeline finishes."""
+        context.pop_request_state(self, _PolicyState)
+
+    async def on_anthropic_stream_complete(self, context: "PolicyContext") -> list[MessageStreamEvent]:
+        """Flush any tool_use blocks still buffered when the upstream stream ends."""
+        buffered_map = self._buffered(context)
+        if not buffered_map:
+            return []
+        emissions: list[MessageStreamEvent] = []
+        for index, buffered in sorted(buffered_map.items()):
+            logger.warning(
+                "Stream ended with tool_use still buffered (index=%d, id=%s); emitting as-is",
+                index,
+                buffered.id,
+            )
+            emissions.extend(_reemit_tool_use_events(buffered, index, buffered.input_json or "{}"))
+            emissions.append(
+                cast(
+                    MessageStreamEvent,
+                    RawContentBlockStopEvent(type="content_block_stop", index=index),
+                )
+            )
+        buffered_map.clear()
+        return emissions
+
+    async def on_anthropic_stream_event(
+        self, event: MessageStreamEvent, context: "PolicyContext"
+    ) -> list[MessageStreamEvent]:
+        """Buffer bash tool_use blocks; rewrite the command at stop time."""
+        if isinstance(event, RawContentBlockStartEvent):
+            return self._handle_block_start(event, context)
+        if isinstance(event, RawContentBlockDeltaEvent):
+            return self._handle_block_delta(event, context)
+        if isinstance(event, RawContentBlockStopEvent):
+            return await self._handle_block_stop(event, context)
+        return [event]
+
+    def _handle_block_start(
+        self, event: RawContentBlockStartEvent, context: "PolicyContext"
+    ) -> list[MessageStreamEvent]:
+        block = event.content_block
+        if isinstance(block, ToolUseBlock) and block.name in self._bash_tool_names:
+            self._buffered(context)[event.index] = _BufferedBashToolUse(id=block.id, name=block.name)
+            return []
+        return [event]
+
+    def _handle_block_delta(
+        self, event: RawContentBlockDeltaEvent, context: "PolicyContext"
+    ) -> list[MessageStreamEvent]:
+        buffered = self._buffered(context)
+        if event.index not in buffered:
+            return [event]
+        if isinstance(event.delta, InputJSONDelta):
+            buffered[event.index].input_json += event.delta.partial_json
+            return []
+        # Defensive flush: an unexpected delta type arrived at an index where
+        # we already swallowed the content_block_start. Emitting the delta
+        # alone would leave the downstream consumer with an orphaned delta.
+        # Release the buffered block first (unmodified start + any accumulated
+        # input JSON) so downstream sees a well-formed sequence, then pass
+        # through the unexpected delta.
+        logger.warning(
+            "Unexpected delta type %s at buffered index %d; flushing buffered block and releasing",
+            type(event.delta).__name__,
+            event.index,
+        )
+        flushed = buffered.pop(event.index)
+        emissions = _reemit_tool_use_events(flushed, event.index, flushed.input_json or "{}")
+        emissions.append(event)
+        return emissions
+
+    async def _handle_block_stop(
+        self, event: RawContentBlockStopEvent, context: "PolicyContext"
+    ) -> list[MessageStreamEvent]:
+        buffered_map = self._buffered(context)
+        if event.index not in buffered_map:
+            return [cast(MessageStreamEvent, event)]
+        buffered = buffered_map.pop(event.index)
+        command = _extract_command_from_json(buffered.input_json)
+        substitute = self._maybe_substitute(command or "", context)
+        input_json = (
+            _rewrite_command_in_input_json(buffered.input_json, substitute)
+            if substitute is not None
+            else (buffered.input_json or "{}")
+        )
+        reemit = _reemit_tool_use_events(buffered, event.index, input_json)
+        reemit.append(cast(MessageStreamEvent, event))
+        return reemit
+
+    async def on_anthropic_response(
+        self, response: "AnthropicResponse", context: "PolicyContext"
+    ) -> "AnthropicResponse":
+        """Mutate ``content[]`` in place for any flagged bash tool_use blocks."""
+        content = response.get("content", [])
+        if not content:
+            return response
+        new_content: list[AnthropicContentBlock] = []
+        modified = False
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                tool_use = cast("AnthropicToolUseBlock", block)
+                if tool_use.get("name") in self._bash_tool_names:
+                    command = _extract_bash_command(tool_use.get("input", {}))
+                    substitute = self._maybe_substitute(command or "", context)
+                    if substitute is not None:
+                        new_block = dict(tool_use)
+                        new_input = dict(tool_use.get("input") or {})
+                        new_input["command"] = substitute
+                        new_block["input"] = cast(Any, new_input)
+                        new_content.append(cast("AnthropicContentBlock", new_block))
+                        modified = True
+                        continue
+            new_content.append(block)
+        if not modified:
+            return response
+        modified_response = dict(response)
+        modified_response["content"] = new_content
+        return cast("AnthropicResponse", modified_response)
+
+    # ------------------------------------------------------------------
+    # Check path
+    # ------------------------------------------------------------------
+
+    def _maybe_substitute(self, command: str, context: "PolicyContext") -> str | None:
+        """Return a substitute command if ``command`` matches a blocklist entry."""
+        if not command:
+            return None
+        index = self._index
+        if len(index) == 0:
+            return None
+        # Primary path: extract literals via the loose regex, run each against
+        # the range matcher.
+        for extracted in extract_literals(command):
+            entry = index.lookup(extracted)
+            if entry is not None:
+                context.record_event(
+                    "policy.supply_chain_blocklist.substituted",
+                    {
+                        "summary": (
+                            f"Supply chain blocklist substituted install of {extracted.name}@{extracted.version}"
+                        ),
+                        "ecosystem": extracted.ecosystem,
+                        "package": extracted.name,
+                        "version": extracted.version,
+                        "cve_id": entry.cve_id,
+                        "severity": entry.severity,
+                        "matched_via": "range",
+                    },
+                )
+                return build_substitute_command(command, entry)
+        # Backstop: exact literal substring scan for advisories that pin a
+        # single version (catches line continuations, exotic spacing, and
+        # wrappers without needing adversarial parsing).
+        backstop = index.substring_backstop(command)
+        if backstop is not None:
+            context.record_event(
+                "policy.supply_chain_blocklist.substituted",
+                {
+                    "summary": (
+                        f"Supply chain blocklist substituted install matching "
+                        f"substring literal for {backstop.canonical_name}"
+                    ),
+                    "ecosystem": backstop.ecosystem,
+                    "package": backstop.canonical_name,
+                    "cve_id": backstop.cve_id,
+                    "severity": backstop.severity,
+                    "matched_via": "substring",
+                },
+            )
+            return build_substitute_command(command, backstop)
+        return None
+
+    # ------------------------------------------------------------------
+    # Test-facing hooks
+    # ------------------------------------------------------------------
+
+    def set_index_for_testing(self, entries: list[BlocklistEntry]) -> None:
+        """Inject a fixed in-memory index for tests.
+
+        Tests that want to exercise the request-time path without spinning
+        up a DB pool use this hook. It is intentionally public (mutable
+        rebind of the private snapshot field is the only state change).
+        """
+        self._index = BlocklistIndex(entries)
+
+    @property
+    def index_size(self) -> int:
+        """Return the number of entries in the current in-memory index."""
+        return len(self._index)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _extract_bash_command(tool_input: object) -> str | None:
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command")
+        if isinstance(command, str):
+            return command
+    return None
+
+
+def _extract_command_from_json(raw_json: str) -> str | None:
+    if not raw_json:
+        return None
+    try:
+        parsed = json.loads(raw_json)
+    except json.JSONDecodeError:
+        return None
+    return _extract_bash_command(parsed)
+
+
+def _rewrite_command_in_input_json(raw_json: str, new_command: str) -> str:
+    try:
+        parsed = json.loads(raw_json) if raw_json else {}
+    except json.JSONDecodeError:
+        parsed = {}
+    if not isinstance(parsed, dict):
+        parsed = {}
+    parsed["command"] = new_command
+    return json.dumps(parsed, ensure_ascii=False)
+
+
+def _reemit_tool_use_events(buffered: _BufferedBashToolUse, index: int, input_json: str) -> list[MessageStreamEvent]:
+    """Rebuild the (start, delta) events for a buffered tool_use block.
+
+    Partial-json chunk boundaries are lost; we coalesce into one delta.
+    """
+    tool_use_block = ToolUseBlock(type="tool_use", id=buffered.id, name=buffered.name, input={})
+    start_event = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=tool_use_block)
+    delta_event = RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=InputJSONDelta(type="input_json_delta", partial_json=input_json or "{}"),
+    )
+    return [cast(MessageStreamEvent, start_event), cast(MessageStreamEvent, delta_event)]
+
+
+def _pick_watermark(
+    previous: datetime | None,
+    entries: list[BlocklistRow],
+    latest_published_at: datetime | None,
+) -> datetime | None:
+    """Pick the next cursor watermark.
+
+    Prefer the parser's explicit ``latest_published_at`` (already filtered by
+    ``since``); if not present, use the max ``published_at`` across the
+    ingested entries; otherwise keep the previous cursor.
+    """
+    if latest_published_at is not None:
+        if previous is None or latest_published_at > previous:
+            return latest_published_at
+        return previous
+    if entries:
+        entries_max = max(e.published_at for e in entries)
+        if previous is None or entries_max > previous:
+            return entries_max
+    return previous
+
+
+# TODO(PR-policy-scheduler): production wiring for the background poll task.
+# Today the policy is only driven by tests (which call ``poll_once`` directly
+# or pass a ``scheduler=`` arg) and therefore runs with an empty blocklist in
+# any production deployment that has not been wired to the scheduler loader.
+# When PR ``worktree-policy-scheduler`` merges, the policy manager will
+# invoke ``register_scheduled_tasks`` after instantiating the policy and the
+# real DB pool; at that point the blocklist will begin populating on schedule.
+
+
+__all__ = ["SchedulerProtocol", "SupplyChainBlocklistPolicy"]

--- a/src/luthien_proxy/policies/supply_chain_blocklist_utils.py
+++ b/src/luthien_proxy/policies/supply_chain_blocklist_utils.py
@@ -1,0 +1,642 @@
+"""Utilities for :mod:`supply_chain_blocklist_policy`.
+
+Pure helpers (no I/O other than the OSV HTTP client): blocklist data
+structures, PEP 440 / semver range matching, loose-regex extraction of package
+literals from shell commands, and the ``sh -c`` substitute builder. Kept
+separate from the policy so each concern is unit-testable in isolation.
+
+The policy is cooperative-LLM only. We never attempt to parse arbitrary bash;
+the regex extraction is a best-effort surface, backed by a literal-substring
+backstop that catches exact ``name@version`` strings anywhere in the command.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Final, Iterable
+
+import httpx
+from packaging.version import InvalidVersion, Version
+from pydantic import BaseModel, ConfigDict, Field
+
+from luthien_proxy.policies.supply_chain_blocklist_db import BlocklistRow
+
+logger = logging.getLogger(__name__)
+
+
+ECOSYSTEM_PYPI: Final[str] = "PyPI"
+ECOSYSTEM_NPM: Final[str] = "npm"
+SUPPORTED_ECOSYSTEMS: Final[tuple[str, ...]] = (ECOSYSTEM_PYPI, ECOSYSTEM_NPM)
+
+
+class SupplyChainBlocklistConfig(BaseModel):
+    """Policy configuration (all fields defaulted for drop-in YAML use)."""
+
+    bash_tool_names: tuple[str, ...] = Field(default=("Bash",))
+    osv_api_url: str = Field(default="https://api.osv.dev/v1/query")
+    osv_fetch_url: str = Field(default="https://api.osv.dev/v1/vulns/")
+    osv_timeout_seconds: float = Field(default=15.0)
+    poll_interval_seconds: float = Field(default=300.0)
+    poll_jitter_seconds: float = Field(default=60.0)
+    min_severity: str = Field(default="CRITICAL")
+    # On first run, ingest advisories published in the last N days.
+    initial_lookback_days: int = Field(default=30)
+    # Soft cap on entries returned per ecosystem per tick.
+    max_entries_per_tick: int = Field(default=500)
+
+    model_config = ConfigDict(frozen=True)
+
+
+@dataclass(frozen=True)
+class AffectedRange:
+    """A structured version range from an OSV advisory.
+
+    OSV emits ``ranges`` as ordered events (``introduced``, ``fixed``,
+    ``last_affected``). We normalize to closed/half-open bounds:
+
+    - ``introduced``: lower inclusive bound (``None`` for "all versions below fixed").
+    - ``fixed``: upper exclusive bound (``None`` for "no fix yet").
+    - ``last_affected``: upper inclusive bound (mutually exclusive with ``fixed``).
+    """
+
+    introduced: str | None
+    fixed: str | None
+    last_affected: str | None
+
+    def to_json(self) -> str:
+        """Serialize to the shape stored in the ``affected_range`` column."""
+        return json.dumps(
+            {"introduced": self.introduced, "fixed": self.fixed, "last_affected": self.last_affected},
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> "AffectedRange":
+        """Parse a range serialized by :meth:`to_json`."""
+        data = json.loads(raw)
+        return cls(
+            introduced=data.get("introduced"),
+            fixed=data.get("fixed"),
+            last_affected=data.get("last_affected"),
+        )
+
+
+@dataclass(frozen=True)
+class BlocklistEntry:
+    """An in-memory blocklist entry for a single (ecosystem, package, range, cve)."""
+
+    ecosystem: str
+    canonical_name: str
+    cve_id: str
+    severity: str
+    range: AffectedRange
+
+    @classmethod
+    def from_row(cls, row: BlocklistRow) -> "BlocklistEntry":
+        """Build an in-memory entry from a DB row."""
+        return cls(
+            ecosystem=row.ecosystem,
+            canonical_name=row.canonical_name,
+            cve_id=row.cve_id,
+            severity=row.severity,
+            range=AffectedRange.from_json(row.affected_range),
+        )
+
+
+def canonicalize_name(ecosystem: str, name: str) -> str:
+    """Lowercase name and apply PEP 503 collapse for PyPI.
+
+    PyPI: case-insensitive, ``[-_.]+`` collapses to ``-`` (PEP 503).
+    npm: case-insensitive with scope preserved (``@scope/name``).
+    """
+    stripped = name.strip()
+    if ecosystem == ECOSYSTEM_PYPI:
+        return re.sub(r"[-_.]+", "-", stripped).lower()
+    return stripped.lower()
+
+
+# =============================================================================
+# RANGE MATCHING
+# =============================================================================
+
+
+def _parse_pypi_version(v: str) -> Version | None:
+    try:
+        return Version(v)
+    except InvalidVersion:
+        return None
+
+
+# Strict numeric semver (X.Y.Z, optional -pre.N). Enough for our OSV range
+# endpoints; the lookup literals we match also have to be numeric semver or
+# we fail closed (no match). Hand-rolled because ``python-semver`` isn't a
+# dependency and this is easier to audit than importing a package.
+_SEMVER_RE: Final[re.Pattern[str]] = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$")
+
+
+@dataclass(frozen=True)
+class _SemverTuple:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[object, ...] | None  # None ranks higher than any prerelease
+
+    def __lt__(self, other: "_SemverTuple") -> bool:
+        if (self.major, self.minor, self.patch) != (other.major, other.minor, other.patch):
+            return (self.major, self.minor, self.patch) < (other.major, other.minor, other.patch)
+        # Same core: the one WITH a prerelease ranks lower than the one without.
+        if self.prerelease is None and other.prerelease is None:
+            return False
+        if self.prerelease is None:
+            return False
+        if other.prerelease is None:
+            return True
+        return self.prerelease < other.prerelease
+
+    def __le__(self, other: "_SemverTuple") -> bool:
+        return self == other or self < other
+
+
+def _parse_semver(v: str) -> _SemverTuple | None:
+    m = _SEMVER_RE.match(v.strip())
+    if not m:
+        return None
+    major, minor, patch, pre = m.group(1), m.group(2), m.group(3), m.group(4)
+    if pre is None:
+        return _SemverTuple(int(major), int(minor), int(patch), None)
+    pre_parts: tuple[object, ...] = tuple(int(p) if p.isdigit() else p for p in pre.split("."))
+    return _SemverTuple(int(major), int(minor), int(patch), pre_parts)
+
+
+def version_matches(ecosystem: str, candidate: str, affected: AffectedRange) -> bool:
+    """Check whether ``candidate`` falls inside ``affected`` for ``ecosystem``.
+
+    Returns ``False`` (fail-closed) if the candidate version cannot be parsed
+    — the substring backstop is still in play, and the policy caller never
+    emits a substitution based on False here alone.
+    """
+    if ecosystem == ECOSYSTEM_PYPI:
+        return _pypi_in_range(candidate, affected)
+    if ecosystem == ECOSYSTEM_NPM:
+        return _npm_in_range(candidate, affected)
+    return False
+
+
+def _pypi_in_range(candidate: str, affected: AffectedRange) -> bool:
+    cand = _parse_pypi_version(candidate)
+    if cand is None:
+        return False
+    if affected.introduced is not None:
+        lower = _parse_pypi_version(affected.introduced)
+        if lower is None or cand < lower:
+            return False
+    if affected.fixed is not None:
+        upper = _parse_pypi_version(affected.fixed)
+        if upper is None:
+            return False
+        if cand >= upper:
+            return False
+    if affected.last_affected is not None:
+        upper = _parse_pypi_version(affected.last_affected)
+        if upper is None:
+            return False
+        if cand > upper:
+            return False
+    # All-None range means "every version affected".
+    return True
+
+
+def _npm_in_range(candidate: str, affected: AffectedRange) -> bool:
+    cand = _parse_semver(candidate)
+    if cand is None:
+        return False
+    if affected.introduced is not None:
+        lower = _parse_semver(affected.introduced)
+        if lower is None or cand < lower:
+            return False
+    if affected.fixed is not None:
+        upper = _parse_semver(affected.fixed)
+        if upper is None:
+            return False
+        if not (cand < upper):
+            return False
+    if affected.last_affected is not None:
+        upper = _parse_semver(affected.last_affected)
+        if upper is None:
+            return False
+        if upper < cand:
+            return False
+    return True
+
+
+# =============================================================================
+# COMMAND EXTRACTION
+# =============================================================================
+
+# Loose regex: captures ``name@version`` or ``name==version`` literals anywhere
+# in a command string. Scoped packages (``@scope/name@version``) are handled
+# by the second alternation. Version = any non-whitespace run containing at
+# least one digit (so ``foo@latest`` doesn't match).
+_PYPI_LITERAL_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)\s*==\s*(?P<version>[0-9][A-Za-z0-9._+!-]*)"
+)
+_NPM_LITERAL_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?P<name>(?:@[A-Za-z0-9][A-Za-z0-9._-]*/)?[A-Za-z0-9][A-Za-z0-9._-]*)@(?P<version>[0-9][A-Za-z0-9._+-]*)"
+)
+
+
+@dataclass(frozen=True)
+class ExtractedLiteral:
+    """A (potential) ``name version`` literal extracted from a command."""
+
+    ecosystem: str
+    name: str
+    version: str
+    # The exact slice of the source command this literal was drawn from, for
+    # substring backstop and error-reporting.
+    raw: str
+
+
+def extract_literals(command: str) -> list[ExtractedLiteral]:
+    """Extract PyPI ``name==version`` and npm ``name@version`` literals.
+
+    The regexes are loose on purpose: this is the happy path for cooperative
+    LLMs. Adversarial obfuscation is explicitly out of scope (see policy
+    docstring). The backstop substring scan catches literals the regex misses.
+    """
+    if not command:
+        return []
+    seen: set[tuple[str, str, str]] = set()
+    out: list[ExtractedLiteral] = []
+    for m in _PYPI_LITERAL_RE.finditer(command):
+        key = (ECOSYSTEM_PYPI, m.group("name").lower(), m.group("version"))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(
+            ExtractedLiteral(
+                ecosystem=ECOSYSTEM_PYPI,
+                name=m.group("name"),
+                version=m.group("version"),
+                raw=m.group(0),
+            )
+        )
+    for m in _NPM_LITERAL_RE.finditer(command):
+        # Exclude emails and similar ``user@host`` hits: the npm regex's
+        # version group requires a leading digit, so ``foo@latest`` and
+        # ``foo@example.com`` both fall out automatically.
+        key = (ECOSYSTEM_NPM, m.group("name").lower(), m.group("version"))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(
+            ExtractedLiteral(
+                ecosystem=ECOSYSTEM_NPM,
+                name=m.group("name"),
+                version=m.group("version"),
+                raw=m.group(0),
+            )
+        )
+    return out
+
+
+# =============================================================================
+# BLOCKLIST INDEX
+# =============================================================================
+
+
+class BlocklistIndex:
+    """In-memory lookup structure.
+
+    Bundles the ``(ecosystem, canonical_name) -> entries`` map with the set
+    of literal ``name@version`` strings used by the substring backstop. The
+    index is rebuilt (not mutated in place) every time the background task
+    pushes updates; per-request lookups read a snapshot.
+    """
+
+    def __init__(self, entries: Iterable[BlocklistEntry]) -> None:
+        """Index the given entries."""
+        by_key: dict[tuple[str, str], list[BlocklistEntry]] = {}
+        literals: dict[str, BlocklistEntry] = {}
+        for entry in entries:
+            key = (entry.ecosystem, entry.canonical_name)
+            by_key.setdefault(key, []).append(entry)
+            # Best-effort literal backstop: only meaningful when the entry's
+            # range pins a single version (introduced == last_affected == fixed?).
+            for lit in _literal_strings_for(entry):
+                literals[lit] = entry
+        self._by_key = by_key
+        self._literals = literals
+
+    def __len__(self) -> int:  # noqa: D105
+        return sum(len(v) for v in self._by_key.values())
+
+    def lookup(self, extracted: ExtractedLiteral) -> BlocklistEntry | None:
+        """Return the first entry whose range contains ``extracted``."""
+        canon = canonicalize_name(extracted.ecosystem, extracted.name)
+        candidates = self._by_key.get((extracted.ecosystem, canon), [])
+        for entry in candidates:
+            if version_matches(extracted.ecosystem, extracted.version, entry.range):
+                return entry
+        return None
+
+    def substring_backstop(self, command: str) -> BlocklistEntry | None:
+        """Return an entry whose literal ``name@version`` form appears in ``command``."""
+        if not command or not self._literals:
+            return None
+        for literal, entry in self._literals.items():
+            if literal in command:
+                return entry
+        return None
+
+
+def _literal_strings_for(entry: BlocklistEntry) -> list[str]:
+    """Return a small set of literal strings to probe with the substring backstop.
+
+    We emit backstops only when the range pins exact versions (introduced ==
+    last_affected, or fixed is the next patch of introduced). Emitting a
+    backstop for an open-ended range ("<1.6.9") would cause noisy false hits
+    on unrelated version literals; the primary path already handles open
+    ranges via version_matches().
+    """
+    r = entry.range
+    exact: str | None = None
+    if r.introduced is not None and r.last_affected is not None and r.introduced == r.last_affected:
+        exact = r.introduced
+    elif r.introduced is not None and r.fixed is None and r.last_affected is None:
+        # Single-version advisory encoded as introduced-only.
+        exact = r.introduced
+    if exact is None:
+        return []
+    forms: list[str] = []
+    if entry.ecosystem == ECOSYSTEM_PYPI:
+        forms.append(f"{entry.canonical_name}=={exact}")
+    elif entry.ecosystem == ECOSYSTEM_NPM:
+        forms.append(f"{entry.canonical_name}@{exact}")
+    return forms
+
+
+# =============================================================================
+# OSV CLIENT
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class OSVFetchResult:
+    """One tick of OSV data for one ecosystem."""
+
+    ecosystem: str
+    entries: list[BlocklistRow]
+    latest_published_at: datetime | None
+
+
+class OSVClient:
+    """Minimal OSV client.
+
+    Uses ``POST /v1/query`` with ``{"package": {"ecosystem": ...}}`` to fetch
+    advisories for an ecosystem. OSV does not support a true "since"
+    parameter on the query endpoint, so the caller post-filters by
+    ``published_at > last_seen_at``.
+
+    Injectable via :class:`SupplyChainBlocklistPolicy` for tests; the real
+    client is ``httpx.AsyncClient``-backed.
+    """
+
+    def __init__(self, api_url: str, timeout_seconds: float) -> None:
+        """Init with an OSV base URL and a timeout."""
+        self._api_url = api_url
+        self._timeout = timeout_seconds
+
+    async def fetch_recent(
+        self,
+        ecosystem: str,
+        since: datetime | None,
+        min_severity: str,
+        limit: int,
+    ) -> OSVFetchResult:
+        """Query OSV and return parsed ranges for ``ecosystem`` published after ``since``."""
+        payload = {"package": {"ecosystem": ecosystem}}
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.post(self._api_url, json=payload)
+            response.raise_for_status()
+            data = response.json()
+        vulns = data.get("vulns") or []
+        return self._parse_response(ecosystem, vulns, since, min_severity, limit)
+
+    @staticmethod
+    def _parse_response(
+        ecosystem: str,
+        raw_vulns: list[dict],
+        since: datetime | None,
+        min_severity: str,
+        limit: int,
+    ) -> OSVFetchResult:
+        min_rank = _severity_rank(min_severity)
+        entries: list[BlocklistRow] = []
+        latest_seen: datetime | None = None
+        for vuln in raw_vulns:
+            if len(entries) >= limit:
+                break
+            published = _parse_iso(vuln.get("published"))
+            if published is None:
+                continue
+            if since is not None and published <= since:
+                continue
+            if latest_seen is None or published > latest_seen:
+                latest_seen = published
+            severity = _extract_severity_label(vuln)
+            if _severity_rank(severity) < min_rank:
+                continue
+            cve_id = str(vuln.get("id") or "")
+            if not cve_id:
+                continue
+            for affected in vuln.get("affected") or []:
+                pkg = affected.get("package") or {}
+                if pkg.get("ecosystem") != ecosystem:
+                    continue
+                name = pkg.get("name")
+                if not isinstance(name, str):
+                    continue
+                canonical = canonicalize_name(ecosystem, name)
+                for range_payload in affected.get("ranges") or []:
+                    for parsed in _parse_osv_range(range_payload):
+                        entries.append(
+                            BlocklistRow(
+                                ecosystem=ecosystem,
+                                canonical_name=canonical,
+                                cve_id=cve_id,
+                                affected_range=parsed.to_json(),
+                                severity=severity,
+                                published_at=published,
+                            )
+                        )
+                        if len(entries) >= limit:
+                            break
+                    if len(entries) >= limit:
+                        break
+                if len(entries) >= limit:
+                    break
+        return OSVFetchResult(ecosystem=ecosystem, entries=entries, latest_published_at=latest_seen)
+
+
+_SEVERITY_ORDER: Final[dict[str, int]] = {
+    "UNKNOWN": 0,
+    "LOW": 1,
+    "MODERATE": 2,
+    "MEDIUM": 2,
+    "HIGH": 3,
+    "CRITICAL": 4,
+}
+
+
+def _severity_rank(label: str) -> int:
+    return _SEVERITY_ORDER.get(label.upper(), 0)
+
+
+def _extract_severity_label(vuln: dict) -> str:
+    """Pull a coarse severity label from an OSV vuln payload.
+
+    OSV places qualitative labels in ``database_specific.severity`` when
+    available. Numeric CVSS vectors live in ``severity[]``; we do not parse
+    them at fetch time (non-goal).
+    """
+    db_spec = vuln.get("database_specific") or {}
+    label = db_spec.get("severity")
+    if isinstance(label, str) and label:
+        return label.upper()
+    return "UNKNOWN"
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _parse_osv_range(range_payload: dict) -> list[AffectedRange]:
+    """Translate one OSV ``ranges[i]`` entry into ``AffectedRange`` objects.
+
+    OSV emits ordered events; each (introduced, fixed|last_affected) pair
+    becomes one range. We ignore "limit" events and type-specific details;
+    the canonical OSV order is (introduced -> fixed?) repeating.
+    """
+    events = range_payload.get("events") or []
+    ranges: list[AffectedRange] = []
+    current_intro: str | None = None
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        if "introduced" in ev:
+            current_intro = str(ev["introduced"]) if ev["introduced"] is not None else None
+            if current_intro == "0":
+                current_intro = None  # OSV's "from the beginning" sentinel
+        elif "fixed" in ev:
+            ranges.append(
+                AffectedRange(
+                    introduced=current_intro,
+                    fixed=str(ev["fixed"]),
+                    last_affected=None,
+                )
+            )
+            current_intro = None
+        elif "last_affected" in ev:
+            ranges.append(
+                AffectedRange(
+                    introduced=current_intro,
+                    fixed=None,
+                    last_affected=str(ev["last_affected"]),
+                )
+            )
+            current_intro = None
+    # Dangling "introduced" with no terminator == "affected from there on".
+    if current_intro is not None:
+        ranges.append(AffectedRange(introduced=current_intro, fixed=None, last_affected=None))
+    return ranges
+
+
+# =============================================================================
+# SUBSTITUTION BUILDER
+# =============================================================================
+
+
+_ORIGINAL_CMD_CLIP: Final[int] = 200
+
+
+def _clip(text: str, limit: int = _ORIGINAL_CMD_CLIP) -> str:
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _sh_single_quote(text: str) -> str:
+    r"""Escape ``text`` for embedding inside a single-quoted shell string.
+
+    Inside single quotes every character is literal except the single quote
+    itself. Replace each ``'`` with ``'\''`` so the outer quoted string
+    terminates, inserts an escaped quote, and resumes.
+    """
+    return "'" + text.replace("'", "'\\''") + "'"
+
+
+def build_substitute_command(original_command: str, entry: BlocklistEntry) -> str:
+    """Build the ``sh -c '... exit 42'`` replacement for a flagged command.
+
+    Every string in the output is under our control: the CVE ID, severity,
+    canonical name, ecosystem, and the clipped/redacted original command.
+    No free-form OSV text (no ``summary`` field) is ever included — we
+    treat OSV responses as untrusted even though the background task has
+    already filtered them.
+    """
+    redacted = _clip(original_command)
+    lines = [
+        f"LUTHIEN BLOCKED: {entry.canonical_name} version matches known-compromised advisory.",
+        f"Ecosystem: {entry.ecosystem}",
+        f"Advisory:  {entry.cve_id} ({entry.severity})",
+        f"Range:     {_describe_range(entry.range)}",
+        "",
+        f"Original command (clipped): {redacted}",
+        "",
+        "This is a best-effort supply-chain gate for cooperative LLMs. To",
+        "proceed intentionally, pin a patched version that does not match",
+        "the advisory range.",
+    ]
+    body = "\n".join(lines)
+    inner = f"printf '%s\\n' {_sh_single_quote(body)} >&2; exit 42"
+    return f"sh -c {_sh_single_quote(inner)}"
+
+
+def _describe_range(r: AffectedRange) -> str:
+    parts: list[str] = []
+    if r.introduced is not None:
+        parts.append(f">={r.introduced}")
+    if r.fixed is not None:
+        parts.append(f"<{r.fixed}")
+    if r.last_affected is not None:
+        parts.append(f"<={r.last_affected}")
+    return ",".join(parts) if parts else "(all versions)"
+
+
+__all__ = [
+    "AffectedRange",
+    "BlocklistEntry",
+    "BlocklistIndex",
+    "ECOSYSTEM_NPM",
+    "ECOSYSTEM_PYPI",
+    "ExtractedLiteral",
+    "OSVClient",
+    "OSVFetchResult",
+    "SUPPORTED_ECOSYSTEMS",
+    "SupplyChainBlocklistConfig",
+    "build_substitute_command",
+    "canonicalize_name",
+    "extract_literals",
+    "version_matches",
+]

--- a/src/luthien_proxy/utils/sqlite_migrations/014_add_supply_chain_blocklist.sql
+++ b/src/luthien_proxy/utils/sqlite_migrations/014_add_supply_chain_blocklist.sql
@@ -1,0 +1,24 @@
+-- Supply-chain blocklist populated by an in-process background task that polls
+-- OSV for newly-published CRITICAL CVEs. Loaded into an in-memory dict at
+-- policy startup. Request-time lookups never touch this table.
+CREATE TABLE IF NOT EXISTS supply_chain_blocklist (
+    ecosystem      TEXT NOT NULL,
+    canonical_name TEXT NOT NULL,
+    cve_id         TEXT NOT NULL,
+    affected_range TEXT NOT NULL,
+    severity       TEXT NOT NULL,
+    published_at   TEXT NOT NULL,
+    fetched_at     TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (ecosystem, canonical_name, cve_id, affected_range)
+);
+
+CREATE INDEX IF NOT EXISTS idx_supply_chain_blocklist_lookup
+    ON supply_chain_blocklist(ecosystem, canonical_name);
+
+-- Tracks the last published_at timestamp seen per ecosystem so the poller can
+-- fetch only newly-published advisories on subsequent ticks.
+CREATE TABLE IF NOT EXISTS supply_chain_blocklist_cursor (
+    ecosystem     TEXT PRIMARY KEY,
+    last_seen_at  TEXT NOT NULL,
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/tests/luthien_proxy/unit_tests/policies/test_supply_chain_blocklist_db.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_supply_chain_blocklist_db.py
@@ -1,0 +1,144 @@
+"""Unit tests for the supply-chain blocklist DB layer.
+
+Runs against an in-memory SQLite :class:`DatabasePool` using the canonical
+fixture pattern from ``tests/luthien_proxy/unit_tests/utils/test_db.py``.
+Every query written by the DB layer is exercised against the real SQLite
+translator so any asyncpg-only syntax shows up immediately.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from luthien_proxy.policies.supply_chain_blocklist_db import (
+    BlocklistRow,
+    get_cursor,
+    load_all_entries,
+    set_cursor,
+    upsert_entries,
+)
+from luthien_proxy.utils import db
+
+
+async def _setup_pool() -> db.DatabasePool:
+    pool = db.DatabasePool("sqlite://:memory:")
+    backing = await pool.get_pool()
+    await backing.execute(
+        """
+        CREATE TABLE supply_chain_blocklist (
+            ecosystem      TEXT NOT NULL,
+            canonical_name TEXT NOT NULL,
+            cve_id         TEXT NOT NULL,
+            affected_range TEXT NOT NULL,
+            severity       TEXT NOT NULL,
+            published_at   TEXT NOT NULL,
+            fetched_at     TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (ecosystem, canonical_name, cve_id, affected_range)
+        )
+        """
+    )
+    await backing.execute(
+        """
+        CREATE TABLE supply_chain_blocklist_cursor (
+            ecosystem     TEXT PRIMARY KEY,
+            last_seen_at  TEXT NOT NULL,
+            updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        """
+    )
+    return pool
+
+
+def _row(cve: str = "CVE-1", name: str = "litellm") -> BlocklistRow:
+    return BlocklistRow(
+        ecosystem="PyPI",
+        canonical_name=name,
+        cve_id=cve,
+        affected_range='{"fixed":"1.6.9","introduced":null,"last_affected":null}',
+        severity="CRITICAL",
+        published_at=datetime(2026, 4, 1, tzinfo=UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_all_entries_empty() -> None:
+    pool = await _setup_pool()
+    try:
+        assert await load_all_entries(await pool.get_pool()) == []
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_upsert_then_load() -> None:
+    pool = await _setup_pool()
+    try:
+        backing = await pool.get_pool()
+        await upsert_entries(backing, [_row(cve="CVE-1"), _row(cve="CVE-2", name="axios")])
+        rows = await load_all_entries(backing)
+        assert len(rows) == 2
+        cve_ids = sorted(r.cve_id for r in rows)
+        assert cve_ids == ["CVE-1", "CVE-2"]
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_upsert_is_idempotent() -> None:
+    pool = await _setup_pool()
+    try:
+        backing = await pool.get_pool()
+        await upsert_entries(backing, [_row()])
+        await upsert_entries(backing, [_row()])
+        rows = await load_all_entries(backing)
+        assert len(rows) == 1
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_cursor_set_and_get() -> None:
+    pool = await _setup_pool()
+    try:
+        backing = await pool.get_pool()
+        assert await get_cursor(backing, "PyPI") is None
+        ts = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
+        await set_cursor(backing, "PyPI", ts)
+        got = await get_cursor(backing, "PyPI")
+        assert got is not None
+        assert got.replace(microsecond=0) == ts.replace(microsecond=0)
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_cursor_upsert_updates_existing() -> None:
+    pool = await _setup_pool()
+    try:
+        backing = await pool.get_pool()
+        t1 = datetime(2026, 4, 1, tzinfo=UTC)
+        t2 = datetime(2026, 4, 5, tzinfo=UTC)
+        await set_cursor(backing, "PyPI", t1)
+        await set_cursor(backing, "PyPI", t2)
+        got = await get_cursor(backing, "PyPI")
+        assert got is not None
+        assert got.replace(microsecond=0) == t2.replace(microsecond=0)
+    finally:
+        await pool.close()
+
+
+@pytest.mark.asyncio
+async def test_cursor_per_ecosystem_independent() -> None:
+    pool = await _setup_pool()
+    try:
+        backing = await pool.get_pool()
+        t_pypi = datetime(2026, 4, 1, tzinfo=UTC)
+        t_npm = datetime(2026, 4, 5, tzinfo=UTC)
+        await set_cursor(backing, "PyPI", t_pypi)
+        await set_cursor(backing, "npm", t_npm)
+        assert (await get_cursor(backing, "PyPI")).replace(microsecond=0) == t_pypi  # type: ignore[union-attr]
+        assert (await get_cursor(backing, "npm")).replace(microsecond=0) == t_npm  # type: ignore[union-attr]
+    finally:
+        await pool.close()

--- a/tests/luthien_proxy/unit_tests/policies/test_supply_chain_blocklist_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_supply_chain_blocklist_policy.py
@@ -1,0 +1,734 @@
+"""Unit tests for :class:`SupplyChainBlocklistPolicy`.
+
+The critical streaming-correctness regression suite lives in
+``TestStreamingShape`` below. These exist because prior attempts (#536, #540)
+shipped streaming-protocol violations that only manifested as downstream
+parsing failures. Each test asserts specific ``content_block_start`` indices
+and counts the starts emitted relative to the upstream shape — never "events
+were emitted" alone.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any, Awaitable, Callable
+
+import pytest
+from anthropic.lib.streaming import MessageStreamEvent
+from anthropic.types import (
+    InputJSONDelta,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    TextBlock,
+    TextDelta,
+    ToolUseBlock,
+)
+
+from luthien_proxy.policies.supply_chain_blocklist_policy import (
+    SupplyChainBlocklistPolicy,
+)
+from luthien_proxy.policies.supply_chain_blocklist_utils import (
+    ECOSYSTEM_NPM,
+    ECOSYSTEM_PYPI,
+    AffectedRange,
+    BlocklistEntry,
+    OSVFetchResult,
+    SupplyChainBlocklistConfig,
+)
+from luthien_proxy.policy_core.policy_context import PolicyContext
+from luthien_proxy.utils import db
+
+# =============================================================================
+# Test helpers
+# =============================================================================
+
+
+def _entry(
+    name: str = "litellm",
+    ecosystem: str = ECOSYSTEM_PYPI,
+    cve: str = "CVE-2024-0001",
+    introduced: str | None = None,
+    fixed: str | None = "1.6.9",
+    last_affected: str | None = None,
+) -> BlocklistEntry:
+    return BlocklistEntry(
+        ecosystem=ecosystem,
+        canonical_name=name,
+        cve_id=cve,
+        severity="CRITICAL",
+        range=AffectedRange(introduced=introduced, fixed=fixed, last_affected=last_affected),
+    )
+
+
+def _make_policy(entries: list[BlocklistEntry] | None = None) -> SupplyChainBlocklistPolicy:
+    policy = SupplyChainBlocklistPolicy()
+    if entries:
+        policy.set_index_for_testing(entries)
+    return policy
+
+
+def _make_context() -> PolicyContext:
+    return PolicyContext.for_testing()
+
+
+def _tool_start(index: int, name: str = "Bash", tool_id: str = "toolu_x") -> RawContentBlockStartEvent:
+    return RawContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=ToolUseBlock(type="tool_use", id=tool_id, name=name, input={}),
+    )
+
+
+def _text_start(index: int) -> RawContentBlockStartEvent:
+    return RawContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=TextBlock(type="text", text=""),
+    )
+
+
+def _text_delta(index: int, text: str) -> RawContentBlockDeltaEvent:
+    return RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=TextDelta(type="text_delta", text=text),
+    )
+
+
+def _input_delta(index: int, partial_json: str) -> RawContentBlockDeltaEvent:
+    return RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=InputJSONDelta(type="input_json_delta", partial_json=partial_json),
+    )
+
+
+def _block_stop(index: int) -> RawContentBlockStopEvent:
+    return RawContentBlockStopEvent(type="content_block_stop", index=index)
+
+
+async def _run_stream(
+    policy: SupplyChainBlocklistPolicy,
+    events: list[MessageStreamEvent],
+    ctx: PolicyContext,
+) -> list[MessageStreamEvent]:
+    out: list[MessageStreamEvent] = []
+    for e in events:
+        out.extend(await policy.on_anthropic_stream_event(e, ctx))
+    return out
+
+
+# =============================================================================
+# Config + instantiation
+# =============================================================================
+
+
+class TestConstruction:
+    def test_default_config(self) -> None:
+        p = SupplyChainBlocklistPolicy()
+        assert p.short_policy_name == "SupplyChainBlocklist"
+        assert p.index_size == 0
+
+    def test_freeze_configured_state(self) -> None:
+        p = SupplyChainBlocklistPolicy()
+        p.freeze_configured_state()  # Must not raise.
+
+    def test_custom_config_as_dict(self) -> None:
+        p = SupplyChainBlocklistPolicy(config={"poll_interval_seconds": 60.0})
+        assert p.config.poll_interval_seconds == 60.0
+
+    def test_custom_config_as_model(self) -> None:
+        p = SupplyChainBlocklistPolicy(config=SupplyChainBlocklistConfig(poll_interval_seconds=30.0))
+        assert p.config.poll_interval_seconds == 30.0
+
+
+# =============================================================================
+# Scheduler integration (stub)
+# =============================================================================
+
+
+class _FakeScheduler:
+    """In-memory scheduler used by tests.
+
+    Captures callbacks and exposes a ``trigger`` method for deterministic
+    invocation so tests never rely on wall-clock timing.
+    """
+
+    def __init__(self) -> None:
+        self.callbacks: dict[str, Callable[[], Awaitable[None]]] = {}
+        self.registrations: list[dict[str, Any]] = []
+
+    def schedule(
+        self,
+        name: str,
+        interval_seconds: float,
+        callback: Callable[[], Awaitable[None]],
+        jitter_seconds: float = 0.0,
+        run_immediately: bool = False,
+    ) -> None:
+        self.callbacks[name] = callback
+        self.registrations.append(
+            {
+                "name": name,
+                "interval": interval_seconds,
+                "jitter": jitter_seconds,
+                "run_immediately": run_immediately,
+            }
+        )
+
+    async def trigger(self, name: str) -> None:
+        await self.callbacks[name]()
+
+
+class TestSchedulerRegistration:
+    def test_register_via_init(self) -> None:
+        scheduler = _FakeScheduler()
+        policy = SupplyChainBlocklistPolicy(scheduler=scheduler)
+        assert len(scheduler.registrations) == 1
+        reg = scheduler.registrations[0]
+        assert reg["name"].startswith("SupplyChainBlocklist")
+        assert reg["run_immediately"] is True
+        assert reg["interval"] == policy.config.poll_interval_seconds
+        assert reg["jitter"] == policy.config.poll_jitter_seconds
+
+    def test_register_via_method(self) -> None:
+        scheduler = _FakeScheduler()
+        policy = SupplyChainBlocklistPolicy()
+        policy.register_scheduled_tasks(scheduler)
+        assert len(scheduler.callbacks) == 1
+
+    def test_register_is_idempotent(self) -> None:
+        scheduler = _FakeScheduler()
+        policy = SupplyChainBlocklistPolicy()
+        policy.register_scheduled_tasks(scheduler)
+        policy.register_scheduled_tasks(scheduler)
+        assert len(scheduler.registrations) == 1
+
+
+# =============================================================================
+# Streaming shape — MANDATORY regression tests (the class of bug that
+# killed #536 and nearly killed #540 v1)
+# =============================================================================
+
+
+class TestStreamingShape:
+    """Verify the policy respects the Anthropic streaming protocol.
+
+    - ``content_block_start`` indices must be strictly monotonic across the
+      full emitted stream.
+    - The count of emitted ``content_block_start`` events must equal the
+      count of upstream ``content_block_start`` events.
+    - Flagged tool_use blocks keep their ORIGINAL index after substitution.
+    - Assertions name specific index values — never just "an event exists".
+    """
+
+    @pytest.mark.asyncio
+    async def test_flagged_tool_use_preserves_block_index(self) -> None:
+        policy = _make_policy([_entry()])
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _tool_start(0),
+            _input_delta(0, '{"command": "pip install litellm==1.6.8"}'),
+            _block_stop(0),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        starts = [e for e in out if isinstance(e, RawContentBlockStartEvent)]
+        assert len(starts) == 1
+        assert starts[0].index == 0
+
+    @pytest.mark.asyncio
+    async def test_flagged_tool_use_preserves_block_count(self) -> None:
+        policy = _make_policy([_entry()])
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _tool_start(0),
+            _input_delta(0, '{"command": "pip install litellm==1.6.8"}'),
+            _block_stop(0),
+        ]
+        upstream_start_count = sum(1 for e in events if isinstance(e, RawContentBlockStartEvent))
+        out = await _run_stream(policy, events, ctx)
+        emitted_start_count = sum(1 for e in out if isinstance(e, RawContentBlockStartEvent))
+        assert emitted_start_count == upstream_start_count == 1
+
+    @pytest.mark.asyncio
+    async def test_two_flagged_tool_uses_in_one_response(self) -> None:
+        policy = _make_policy(
+            [
+                _entry(name="litellm", ecosystem=ECOSYSTEM_PYPI, cve="CVE-A", fixed="1.6.9"),
+                _entry(
+                    name="axios",
+                    ecosystem=ECOSYSTEM_NPM,
+                    cve="CVE-B",
+                    introduced="1.6.8",
+                    fixed=None,
+                    last_affected="1.6.8",
+                ),
+            ]
+        )
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _tool_start(0, tool_id="t0"),
+            _input_delta(0, '{"command": "pip install litellm==1.6.8"}'),
+            _block_stop(0),
+            _text_start(1),
+            _text_delta(1, "ok"),
+            _block_stop(1),
+            _tool_start(2, tool_id="t2"),
+            _input_delta(2, '{"command": "npm install axios@1.6.8"}'),
+            _block_stop(2),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        starts = [e for e in out if isinstance(e, RawContentBlockStartEvent)]
+        # One start per upstream block, preserving indices [0, 1, 2].
+        assert [s.index for s in starts] == [0, 1, 2]
+        # Both tool_use blocks have their command rewritten.
+        deltas = [e for e in out if isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, InputJSONDelta)]
+        assert len(deltas) == 2
+        for d in deltas:
+            partial = d.delta.partial_json  # type: ignore[union-attr]
+            parsed = json.loads(partial)
+            assert parsed["command"].startswith("sh -c")
+
+    @pytest.mark.asyncio
+    async def test_monotonic_block_start_across_stream(self) -> None:
+        policy = _make_policy([_entry()])
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _text_start(0),
+            _text_delta(0, "thinking..."),
+            _block_stop(0),
+            _tool_start(1, tool_id="flagged"),
+            _input_delta(1, '{"command": "pip install litellm==1.6.8"}'),
+            _block_stop(1),
+            _text_start(2),
+            _text_delta(2, "okay"),
+            _block_stop(2),
+            _tool_start(3, tool_id="unflagged"),
+            _input_delta(3, '{"command": "echo hi"}'),
+            _block_stop(3),
+            _text_start(4),
+            _text_delta(4, "done"),
+            _block_stop(4),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        starts = [e.index for e in out if isinstance(e, RawContentBlockStartEvent)]
+        assert starts == [0, 1, 2, 3, 4]
+        assert starts == sorted(starts)
+
+    @pytest.mark.asyncio
+    async def test_flagged_tool_use_rewrites_command_field(self) -> None:
+        policy = _make_policy([_entry()])
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _tool_start(0),
+            _input_delta(0, '{"command": "pip install litellm==1.6.8"}'),
+            _block_stop(0),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        deltas = [e for e in out if isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, InputJSONDelta)]
+        assert len(deltas) == 1
+        partial = deltas[0].delta.partial_json  # type: ignore[union-attr]
+        assert "sh -c" in partial
+        assert "LUTHIEN BLOCKED" in partial
+        parsed = json.loads(partial)
+        assert parsed["command"].startswith("sh -c")
+
+
+# =============================================================================
+# Streaming basics — passthrough, buffering, orphan flush
+# =============================================================================
+
+
+class TestStreamingBasics:
+    @pytest.mark.asyncio
+    async def test_passthrough_text_block(self) -> None:
+        policy = _make_policy()
+        ctx = _make_context()
+        event = _text_start(0)
+        out = await policy.on_anthropic_stream_event(event, ctx)
+        assert out == [event]
+
+    @pytest.mark.asyncio
+    async def test_non_bash_tool_passthrough(self) -> None:
+        policy = _make_policy()
+        ctx = _make_context()
+        event = _tool_start(0, name="Read")
+        out = await policy.on_anthropic_stream_event(event, ctx)
+        assert out == [event]
+
+    @pytest.mark.asyncio
+    async def test_buffers_until_stop(self) -> None:
+        policy = _make_policy()
+        ctx = _make_context()
+        out_start = await policy.on_anthropic_stream_event(_tool_start(0), ctx)
+        assert out_start == []
+        out_delta = await policy.on_anthropic_stream_event(
+            _input_delta(0, '{"command": "pip install safe==1.0"}'),
+            ctx,
+        )
+        assert out_delta == []
+        out_stop = await policy.on_anthropic_stream_event(_block_stop(0), ctx)
+        types = [type(e).__name__ for e in out_stop]
+        assert types == [
+            "RawContentBlockStartEvent",
+            "RawContentBlockDeltaEvent",
+            "RawContentBlockStopEvent",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_unflagged_command_preserved(self) -> None:
+        policy = _make_policy([_entry()])
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _tool_start(0),
+            _input_delta(0, '{"command": "pip install requests==2.31.0"}'),
+            _block_stop(0),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        delta = next(e for e in out if isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, InputJSONDelta))
+        parsed = json.loads(delta.delta.partial_json)  # type: ignore[union-attr]
+        assert parsed["command"] == "pip install requests==2.31.0"
+
+    @pytest.mark.asyncio
+    async def test_stream_complete_flushes_orphan(self) -> None:
+        policy = _make_policy()
+        ctx = _make_context()
+        await policy.on_anthropic_stream_event(_tool_start(0), ctx)
+        await policy.on_anthropic_stream_event(_input_delta(0, '{"command": "echo hi"}'), ctx)
+        flushed = await policy.on_anthropic_stream_complete(ctx)
+        types = [type(e).__name__ for e in flushed]
+        assert types == [
+            "RawContentBlockStartEvent",
+            "RawContentBlockDeltaEvent",
+            "RawContentBlockStopEvent",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_stream_complete_empty(self) -> None:
+        policy = _make_policy()
+        ctx = _make_context()
+        out = await policy.on_anthropic_stream_complete(ctx)
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_partial_json_chunks_accumulate(self) -> None:
+        policy = _make_policy([_entry()])
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _tool_start(0),
+            _input_delta(0, '{"comma'),
+            _input_delta(0, 'nd": "pip install '),
+            _input_delta(0, 'litellm==1.6.8"}'),
+            _block_stop(0),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        delta = next(e for e in out if isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, InputJSONDelta))
+        parsed = json.loads(delta.delta.partial_json)  # type: ignore[union-attr]
+        assert parsed["command"].startswith("sh -c")
+
+    @pytest.mark.asyncio
+    async def test_streaming_policy_complete_pops_state(self) -> None:
+        policy = _make_policy()
+        ctx = _make_context()
+        await policy.on_anthropic_stream_event(_tool_start(0), ctx)
+        await policy.on_anthropic_streaming_policy_complete(ctx)
+        # Subsequent calls see a fresh state.
+        out = await policy.on_anthropic_stream_event(_block_stop(0), ctx)
+        # Index 0 is no longer buffered → passthrough.
+        assert len(out) == 1
+
+
+class TestDefensiveFlush:
+    """``_handle_block_delta`` must flush buffered state on unexpected deltas."""
+
+    @pytest.mark.asyncio
+    async def test_text_delta_at_buffered_tool_use_index_flushes(self) -> None:
+        policy = _make_policy()
+        ctx = _make_context()
+        await policy.on_anthropic_stream_event(_tool_start(0), ctx)
+        # Hand-construct an unexpected delta: a TextDelta arriving at the
+        # buffered tool_use index. The policy must emit the buffered start
+        # (so downstream has a matched start/stop pair) plus the unexpected
+        # delta itself, then let subsequent events at index 0 flow through.
+        unexpected = RawContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=0,
+            delta=TextDelta(type="text_delta", text="surprise"),
+        )
+        out = await policy.on_anthropic_stream_event(unexpected, ctx)
+        types = [type(e).__name__ for e in out]
+        # Start + input_json_delta (coalesced) + the unexpected text_delta.
+        assert types[0] == "RawContentBlockStartEvent"
+        assert any(isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, InputJSONDelta) for e in out)
+        assert any(isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, TextDelta) for e in out)
+        # After flush, a stop event at index 0 passes through unchanged.
+        stop_out = await policy.on_anthropic_stream_event(_block_stop(0), ctx)
+        assert len(stop_out) == 1
+
+
+# =============================================================================
+# Substitution path — primary lookup + substring backstop + no-op
+# =============================================================================
+
+
+class TestSubstitution:
+    @pytest.mark.asyncio
+    async def test_no_blocklist_no_substitution(self) -> None:
+        policy = _make_policy()  # empty index
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _tool_start(0),
+            _input_delta(0, '{"command": "pip install litellm==1.6.8"}'),
+            _block_stop(0),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        delta = next(e for e in out if isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, InputJSONDelta))
+        parsed = json.loads(delta.delta.partial_json)  # type: ignore[union-attr]
+        assert parsed["command"] == "pip install litellm==1.6.8"
+
+    @pytest.mark.asyncio
+    async def test_substring_backstop_fires_on_echo_command(self) -> None:
+        policy = _make_policy(
+            [_entry(name="axios", ecosystem=ECOSYSTEM_NPM, introduced="1.6.8", fixed=None, last_affected="1.6.8")]
+        )
+        ctx = _make_context()
+        events: list[MessageStreamEvent] = [
+            _tool_start(0),
+            _input_delta(0, '{"command": "echo axios@1.6.8 is bad"}'),
+            _block_stop(0),
+        ]
+        out = await _run_stream(policy, events, ctx)
+        delta = next(e for e in out if isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, InputJSONDelta))
+        parsed = json.loads(delta.delta.partial_json)  # type: ignore[union-attr]
+        assert parsed["command"].startswith("sh -c")
+        assert "LUTHIEN BLOCKED" in parsed["command"]
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_response_substitution(self) -> None:
+        policy = _make_policy([_entry()])
+        ctx = _make_context()
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install litellm==1.6.8"},
+                }
+            ]
+        }
+        out = await policy.on_anthropic_response(response, ctx)  # type: ignore[arg-type]
+        block = out["content"][0]
+        assert block["input"]["command"].startswith("sh -c")  # type: ignore[index]
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_passthrough_when_no_match(self) -> None:
+        policy = _make_policy()
+        ctx = _make_context()
+        response: dict[str, Any] = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "pip install safe==1.0.0"},
+                }
+            ]
+        }
+        out = await policy.on_anthropic_response(response, ctx)  # type: ignore[arg-type]
+        assert out["content"][0]["input"]["command"] == "pip install safe==1.0.0"  # type: ignore[index]
+
+
+# =============================================================================
+# Background poller — one tick with a fake OSV client + real in-memory DB
+# =============================================================================
+
+
+class _FakeOSVClient:
+    def __init__(self, results: dict[str, list[OSVFetchResult]] | None = None) -> None:
+        self._results = results or {}
+        self.calls: list[tuple[str, datetime | None]] = []
+        self.raise_for: set[str] = set()
+
+    async def fetch_recent(
+        self,
+        ecosystem: str,
+        since: datetime | None,
+        min_severity: str,
+        limit: int,
+    ) -> OSVFetchResult:
+        self.calls.append((ecosystem, since))
+        if ecosystem in self.raise_for:
+            raise RuntimeError(f"simulated OSV failure for {ecosystem}")
+        queue = self._results.get(ecosystem, [])
+        if not queue:
+            return OSVFetchResult(ecosystem=ecosystem, entries=[], latest_published_at=None)
+        return queue.pop(0)
+
+
+async def _build_pool_with_schema() -> db.DatabasePool:
+    pool = db.DatabasePool("sqlite://:memory:")
+    backing = await pool.get_pool()
+    await backing.execute(
+        """
+        CREATE TABLE supply_chain_blocklist (
+            ecosystem      TEXT NOT NULL,
+            canonical_name TEXT NOT NULL,
+            cve_id         TEXT NOT NULL,
+            affected_range TEXT NOT NULL,
+            severity       TEXT NOT NULL,
+            published_at   TEXT NOT NULL,
+            fetched_at     TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (ecosystem, canonical_name, cve_id, affected_range)
+        )
+        """
+    )
+    await backing.execute(
+        """
+        CREATE TABLE supply_chain_blocklist_cursor (
+            ecosystem     TEXT PRIMARY KEY,
+            last_seen_at  TEXT NOT NULL,
+            updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        """
+    )
+    return pool
+
+
+class TestBackgroundPoller:
+    @pytest.mark.asyncio
+    async def test_poll_once_ingests_and_indexes(self) -> None:
+        from luthien_proxy.policies.supply_chain_blocklist_db import BlocklistRow
+
+        fake_osv = _FakeOSVClient(
+            results={
+                ECOSYSTEM_PYPI: [
+                    OSVFetchResult(
+                        ecosystem=ECOSYSTEM_PYPI,
+                        entries=[
+                            BlocklistRow(
+                                ecosystem=ECOSYSTEM_PYPI,
+                                canonical_name="litellm",
+                                cve_id="CVE-X",
+                                affected_range='{"introduced":null,"fixed":"1.6.9","last_affected":null}',
+                                severity="CRITICAL",
+                                published_at=datetime(2026, 4, 1, tzinfo=UTC),
+                            )
+                        ],
+                        latest_published_at=datetime(2026, 4, 1, tzinfo=UTC),
+                    )
+                ]
+            }
+        )
+        pool = await _build_pool_with_schema()
+        try:
+            policy = SupplyChainBlocklistPolicy(
+                db_pool=await pool.get_pool(),
+                osv_client=fake_osv,  # type: ignore[arg-type]
+            )
+            await policy.poll_once()
+            assert policy.index_size == 1
+            # Request-time hit against the freshly-loaded entry.
+            ctx = _make_context()
+            out = await _run_stream(
+                policy,
+                [
+                    _tool_start(0),
+                    _input_delta(0, '{"command": "pip install litellm==1.6.8"}'),
+                    _block_stop(0),
+                ],
+                ctx,
+            )
+            delta = next(
+                e for e in out if isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, InputJSONDelta)
+            )
+            parsed = json.loads(delta.delta.partial_json)  # type: ignore[union-attr]
+            assert parsed["command"].startswith("sh -c")
+        finally:
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_poll_once_second_tick_does_not_duplicate(self) -> None:
+        from luthien_proxy.policies.supply_chain_blocklist_db import BlocklistRow
+
+        first = OSVFetchResult(
+            ecosystem=ECOSYSTEM_PYPI,
+            entries=[
+                BlocklistRow(
+                    ecosystem=ECOSYSTEM_PYPI,
+                    canonical_name="litellm",
+                    cve_id="CVE-X",
+                    affected_range='{"introduced":null,"fixed":"1.6.9","last_affected":null}',
+                    severity="CRITICAL",
+                    published_at=datetime(2026, 4, 1, tzinfo=UTC),
+                )
+            ],
+            latest_published_at=datetime(2026, 4, 1, tzinfo=UTC),
+        )
+        # Second tick: OSV returns the same row again (as it would if the
+        # cursor filter is naive). Our upsert must keep this idempotent.
+        second = OSVFetchResult(
+            ecosystem=ECOSYSTEM_PYPI,
+            entries=list(first.entries),
+            latest_published_at=first.latest_published_at,
+        )
+        fake_osv = _FakeOSVClient(results={ECOSYSTEM_PYPI: [first, second]})
+        pool = await _build_pool_with_schema()
+        try:
+            policy = SupplyChainBlocklistPolicy(
+                db_pool=await pool.get_pool(),
+                osv_client=fake_osv,  # type: ignore[arg-type]
+            )
+            await policy.poll_once()
+            await policy.poll_once()
+            assert policy.index_size == 1
+        finally:
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_poll_once_logs_and_continues_on_osv_failure(self) -> None:
+        fake_osv = _FakeOSVClient()
+        fake_osv.raise_for = {ECOSYSTEM_PYPI}
+        pool = await _build_pool_with_schema()
+        try:
+            policy = SupplyChainBlocklistPolicy(
+                db_pool=await pool.get_pool(),
+                osv_client=fake_osv,  # type: ignore[arg-type]
+            )
+            # Must not raise.
+            await policy.poll_once()
+            assert policy.index_size == 0
+            # Both ecosystems were still attempted.
+            called_ecosystems = [c[0] for c in fake_osv.calls]
+            assert ECOSYSTEM_PYPI in called_ecosystems
+            assert ECOSYSTEM_NPM in called_ecosystems
+        finally:
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_load_initial_state_from_db(self) -> None:
+        from luthien_proxy.policies.supply_chain_blocklist_db import BlocklistRow, upsert_entries
+
+        pool = await _build_pool_with_schema()
+        try:
+            await upsert_entries(
+                await pool.get_pool(),
+                [
+                    BlocklistRow(
+                        ecosystem=ECOSYSTEM_PYPI,
+                        canonical_name="litellm",
+                        cve_id="CVE-SEED",
+                        affected_range='{"introduced":null,"fixed":"1.6.9","last_affected":null}',
+                        severity="CRITICAL",
+                        published_at=datetime(2026, 4, 1, tzinfo=UTC),
+                    )
+                ],
+            )
+            policy = SupplyChainBlocklistPolicy(db_pool=await pool.get_pool())
+            assert policy.index_size == 0  # Not loaded until explicit call.
+            await policy.load_initial_state()
+            assert policy.index_size == 1
+        finally:
+            await pool.close()

--- a/tests/luthien_proxy/unit_tests/policies/test_supply_chain_blocklist_utils.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_supply_chain_blocklist_utils.py
@@ -1,0 +1,490 @@
+"""Unit tests for :mod:`supply_chain_blocklist_utils`.
+
+Covers pure helpers: version range matching across PEP 440 / semver edges,
+loose regex extraction of package literals, OSV response parsing, and the
+``sh -c`` substitute builder (including real ``bash -c`` execution tests for
+every code path that emits a substitute).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from datetime import UTC, datetime
+
+import pytest
+
+from luthien_proxy.policies.supply_chain_blocklist_utils import (
+    ECOSYSTEM_NPM,
+    ECOSYSTEM_PYPI,
+    AffectedRange,
+    BlocklistEntry,
+    BlocklistIndex,
+    OSVClient,
+    build_substitute_command,
+    canonicalize_name,
+    extract_literals,
+    version_matches,
+)
+
+# =============================================================================
+# Name canonicalisation
+# =============================================================================
+
+
+class TestCanonicalizeName:
+    def test_pypi_pep503(self) -> None:
+        assert canonicalize_name(ECOSYSTEM_PYPI, "Flask-SQL_Alchemy") == "flask-sql-alchemy"
+
+    def test_pypi_mixed_separators(self) -> None:
+        assert canonicalize_name(ECOSYSTEM_PYPI, "a.b_c-d") == "a-b-c-d"
+
+    def test_npm_lowercase(self) -> None:
+        assert canonicalize_name(ECOSYSTEM_NPM, "Axios") == "axios"
+
+    def test_npm_scoped(self) -> None:
+        assert canonicalize_name(ECOSYSTEM_NPM, "@MyOrg/My-Pkg") == "@myorg/my-pkg"
+
+
+# =============================================================================
+# Range matching
+# =============================================================================
+
+
+class TestPypiRangeMatching:
+    def test_within_introduced_fixed(self) -> None:
+        r = AffectedRange(introduced="1.0.0", fixed="2.0.0", last_affected=None)
+        assert version_matches(ECOSYSTEM_PYPI, "1.5.0", r) is True
+
+    def test_at_introduced(self) -> None:
+        r = AffectedRange(introduced="1.0.0", fixed="2.0.0", last_affected=None)
+        assert version_matches(ECOSYSTEM_PYPI, "1.0.0", r) is True
+
+    def test_at_fixed_excluded(self) -> None:
+        r = AffectedRange(introduced="1.0.0", fixed="2.0.0", last_affected=None)
+        assert version_matches(ECOSYSTEM_PYPI, "2.0.0", r) is False
+
+    def test_below_introduced(self) -> None:
+        r = AffectedRange(introduced="1.6.0", fixed="1.6.9", last_affected=None)
+        assert version_matches(ECOSYSTEM_PYPI, "1.5.9", r) is False
+
+    def test_last_affected_inclusive(self) -> None:
+        r = AffectedRange(introduced=None, fixed=None, last_affected="1.6.8")
+        assert version_matches(ECOSYSTEM_PYPI, "1.6.8", r) is True
+        assert version_matches(ECOSYSTEM_PYPI, "1.6.9", r) is False
+
+    def test_litellm_regression_critical_bound(self) -> None:
+        # The canonical motivating example: SpecifierSet("<1.6.9") matches 1.6.8.
+        r = AffectedRange(introduced=None, fixed="1.6.9", last_affected=None)
+        assert version_matches(ECOSYSTEM_PYPI, "1.6.8", r) is True
+        assert version_matches(ECOSYSTEM_PYPI, "1.6.9", r) is False
+
+    def test_pre_release_excluded_by_fixed(self) -> None:
+        r = AffectedRange(introduced="1.0.0", fixed="2.0.0", last_affected=None)
+        assert version_matches(ECOSYSTEM_PYPI, "1.9.9a1", r) is True
+
+    def test_exact_version_range(self) -> None:
+        r = AffectedRange(introduced="1.2.3", fixed=None, last_affected="1.2.3")
+        assert version_matches(ECOSYSTEM_PYPI, "1.2.3", r) is True
+        assert version_matches(ECOSYSTEM_PYPI, "1.2.4", r) is False
+        assert version_matches(ECOSYSTEM_PYPI, "1.2.2", r) is False
+
+    def test_unparseable_candidate_fails_closed(self) -> None:
+        r = AffectedRange(introduced="1.0.0", fixed="2.0.0", last_affected=None)
+        assert version_matches(ECOSYSTEM_PYPI, "not-a-version", r) is False
+
+    def test_all_none_range_matches_any_version(self) -> None:
+        r = AffectedRange(introduced=None, fixed=None, last_affected=None)
+        assert version_matches(ECOSYSTEM_PYPI, "0.0.1", r) is True
+        assert version_matches(ECOSYSTEM_PYPI, "99.99.99", r) is True
+
+
+class TestNpmRangeMatching:
+    def test_basic_range(self) -> None:
+        r = AffectedRange(introduced="1.6.0", fixed="1.6.9", last_affected=None)
+        assert version_matches(ECOSYSTEM_NPM, "1.6.8", r) is True
+        assert version_matches(ECOSYSTEM_NPM, "1.6.9", r) is False
+        assert version_matches(ECOSYSTEM_NPM, "1.5.9", r) is False
+
+    def test_pre_release_ranks_below_release(self) -> None:
+        r = AffectedRange(introduced="1.0.0", fixed="2.0.0", last_affected=None)
+        assert version_matches(ECOSYSTEM_NPM, "1.5.0-alpha.1", r) is True
+
+    def test_exact_version(self) -> None:
+        r = AffectedRange(introduced="1.2.3", fixed=None, last_affected="1.2.3")
+        assert version_matches(ECOSYSTEM_NPM, "1.2.3", r) is True
+        assert version_matches(ECOSYSTEM_NPM, "1.2.4", r) is False
+
+    def test_garbage_fails_closed(self) -> None:
+        r = AffectedRange(introduced="1.0.0", fixed="2.0.0", last_affected=None)
+        assert version_matches(ECOSYSTEM_NPM, "latest", r) is False
+
+    def test_pre_release_ordering_within_core(self) -> None:
+        # 1.0.0 > 1.0.0-rc.1 > 1.0.0-beta > 1.0.0-alpha
+        r = AffectedRange(introduced="1.0.0-alpha", fixed="1.0.0", last_affected=None)
+        assert version_matches(ECOSYSTEM_NPM, "1.0.0-beta", r) is True
+        assert version_matches(ECOSYSTEM_NPM, "1.0.0", r) is False
+
+
+# =============================================================================
+# Command extraction
+# =============================================================================
+
+
+class TestExtractLiterals:
+    def test_pypi_double_equals(self) -> None:
+        out = extract_literals("pip install litellm==1.59.0")
+        assert [(e.ecosystem, e.name, e.version) for e in out] == [("PyPI", "litellm", "1.59.0")]
+
+    def test_npm_at_sign(self) -> None:
+        out = extract_literals("npm install axios@1.6.8")
+        assert [(e.ecosystem, e.name, e.version) for e in out] == [("npm", "axios", "1.6.8")]
+
+    def test_npm_scoped(self) -> None:
+        out = extract_literals("npm install @babel/core@7.22.0")
+        assert any(e.name == "@babel/core" and e.version == "7.22.0" for e in out)
+
+    def test_mixed(self) -> None:
+        out = extract_literals("pip install litellm==1.59.0 && npm install axios@1.6.8")
+        eco = {e.ecosystem for e in out}
+        assert eco == {ECOSYSTEM_NPM, ECOSYSTEM_PYPI}
+
+    def test_latest_tag_not_matched(self) -> None:
+        # Version must start with a digit — "latest" is not a version.
+        out = extract_literals("npm install foo@latest")
+        assert out == []
+
+    def test_email_like_not_matched_as_npm(self) -> None:
+        out = extract_literals("mail user@example.com")
+        assert all(e.ecosystem != ECOSYSTEM_NPM or e.version[0].isdigit() for e in out)
+
+    def test_dedupe(self) -> None:
+        out = extract_literals("pip install litellm==1.59.0; pip install litellm==1.59.0")
+        assert len(out) == 1
+
+    def test_empty_command(self) -> None:
+        assert extract_literals("") == []
+
+
+# =============================================================================
+# BlocklistIndex
+# =============================================================================
+
+
+class TestBlocklistIndex:
+    def test_lookup_miss(self) -> None:
+        idx = BlocklistIndex([])
+        out = extract_literals("pip install safe==1.0.0")
+        assert idx.lookup(out[0]) is None
+
+    def test_lookup_hit_pypi(self) -> None:
+        entry = BlocklistEntry(
+            ecosystem=ECOSYSTEM_PYPI,
+            canonical_name="litellm",
+            cve_id="CVE-2024-0001",
+            severity="CRITICAL",
+            range=AffectedRange(introduced=None, fixed="1.6.9", last_affected=None),
+        )
+        idx = BlocklistIndex([entry])
+        lit = extract_literals("pip install litellm==1.6.8")[0]
+        hit = idx.lookup(lit)
+        assert hit is not None
+        assert hit.cve_id == "CVE-2024-0001"
+
+    def test_substring_backstop_exact_pin(self) -> None:
+        entry = BlocklistEntry(
+            ecosystem=ECOSYSTEM_NPM,
+            canonical_name="axios",
+            cve_id="CVE-2024-0002",
+            severity="CRITICAL",
+            range=AffectedRange(introduced="1.6.8", fixed=None, last_affected="1.6.8"),
+        )
+        idx = BlocklistIndex([entry])
+        hit = idx.substring_backstop('echo "axios@1.6.8 is bad"')
+        assert hit is not None
+        assert hit.cve_id == "CVE-2024-0002"
+
+    def test_substring_backstop_ignores_open_range(self) -> None:
+        # Open ranges must NOT emit a substring backstop, or we'd false-hit
+        # every unrelated version string.
+        entry = BlocklistEntry(
+            ecosystem=ECOSYSTEM_NPM,
+            canonical_name="axios",
+            cve_id="CVE-2024-0002",
+            severity="CRITICAL",
+            range=AffectedRange(introduced="1.6.0", fixed="1.7.0", last_affected=None),
+        )
+        idx = BlocklistIndex([entry])
+        assert idx.substring_backstop("axios@1.6.8") is None
+
+    def test_case_insensitive_pypi(self) -> None:
+        entry = BlocklistEntry(
+            ecosystem=ECOSYSTEM_PYPI,
+            canonical_name="flask-sql-alchemy",
+            cve_id="CVE-X",
+            severity="CRITICAL",
+            range=AffectedRange(introduced=None, fixed="9.9.9", last_affected=None),
+        )
+        idx = BlocklistIndex([entry])
+        lit = extract_literals("pip install Flask_SQL.Alchemy==1.0.0")[0]
+        assert idx.lookup(lit) is not None
+
+
+# =============================================================================
+# Substitute builder — including subprocess tests against real bash
+# =============================================================================
+
+
+def _run_bash(substitute: str, cwd: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", substitute],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+class TestBuildSubstituteSubprocess:
+    """Run every generated substitute through real ``bash -c``.
+
+    Every code path that emits a ``sh -c '...'`` substitute is exercised
+    here (currently one: :func:`build_substitute_command`). For each, we
+    assert exit code 42, stderr content, and absence of side effects in
+    the cwd.
+    """
+
+    def test_clean_command_substitute(self) -> None:
+        entry = BlocklistEntry(
+            ecosystem=ECOSYSTEM_PYPI,
+            canonical_name="litellm",
+            cve_id="CVE-2024-0001",
+            severity="CRITICAL",
+            range=AffectedRange(introduced=None, fixed="1.6.9", last_affected=None),
+        )
+        sub = build_substitute_command("pip install litellm==1.6.8", entry)
+        with tempfile.TemporaryDirectory() as tmp:
+            before = set(os.listdir(tmp))
+            result = _run_bash(sub, tmp)
+            after = set(os.listdir(tmp))
+        assert result.returncode == 42
+        assert "LUTHIEN BLOCKED" in result.stderr
+        assert "litellm" in result.stderr
+        assert result.stdout == ""
+        assert after == before, f"unexpected files: {after - before}"
+
+    def test_attacker_quote_original_does_not_escape(self) -> None:
+        # Classic attacker quote: single quote + shell metacharacters +
+        # unterminated quote. If our _sh_single_quote is wrong, the outer
+        # sh -c string will re-interpret this and run `touch /tmp/PWN_*`.
+        entry = BlocklistEntry(
+            ecosystem=ECOSYSTEM_PYPI,
+            canonical_name="litellm",
+            cve_id="CVE-2024-0001",
+            severity="CRITICAL",
+            range=AffectedRange(introduced=None, fixed="1.6.9", last_affected=None),
+        )
+        hostile = "pip install 'litellm==1.6.8'; touch PWN_ATTACK; echo 'hi"
+        sub = build_substitute_command(hostile, entry)
+        with tempfile.TemporaryDirectory() as tmp:
+            result = _run_bash(sub, tmp)
+            files = os.listdir(tmp)
+        assert result.returncode == 42
+        assert "LUTHIEN BLOCKED" in result.stderr
+        assert "PWN_ATTACK" not in files
+        assert files == []
+
+    def test_backtick_command_substitution_does_not_fire(self) -> None:
+        entry = BlocklistEntry(
+            ecosystem=ECOSYSTEM_PYPI,
+            canonical_name="litellm",
+            cve_id="CVE-X",
+            severity="CRITICAL",
+            range=AffectedRange(introduced=None, fixed="1.6.9", last_affected=None),
+        )
+        hostile = "`touch PWN_BACKTICK`"
+        sub = build_substitute_command(hostile, entry)
+        with tempfile.TemporaryDirectory() as tmp:
+            result = _run_bash(sub, tmp)
+            files = os.listdir(tmp)
+        assert result.returncode == 42
+        assert "PWN_BACKTICK" not in files
+        assert files == []
+
+    def test_dollar_paren_substitution_does_not_fire(self) -> None:
+        entry = BlocklistEntry(
+            ecosystem=ECOSYSTEM_PYPI,
+            canonical_name="litellm",
+            cve_id="CVE-X",
+            severity="CRITICAL",
+            range=AffectedRange(introduced=None, fixed="1.6.9", last_affected=None),
+        )
+        hostile = "$(touch PWN_PAREN)"
+        sub = build_substitute_command(hostile, entry)
+        with tempfile.TemporaryDirectory() as tmp:
+            result = _run_bash(sub, tmp)
+            files = os.listdir(tmp)
+        assert result.returncode == 42
+        assert "PWN_PAREN" not in files
+        assert files == []
+
+
+# =============================================================================
+# OSV response parsing
+# =============================================================================
+
+
+def _vuln(
+    vuln_id: str,
+    ecosystem: str,
+    name: str,
+    events: list[dict],
+    *,
+    severity: str = "CRITICAL",
+    published: str = "2026-04-01T00:00:00Z",
+) -> dict:
+    return {
+        "id": vuln_id,
+        "published": published,
+        "database_specific": {"severity": severity},
+        "affected": [
+            {"package": {"ecosystem": ecosystem, "name": name}, "ranges": [{"events": events}]},
+        ],
+    }
+
+
+class TestOSVResponseParsing:
+    def test_parse_introduced_fixed(self) -> None:
+        raw = [_vuln("CVE-1", ECOSYSTEM_PYPI, "litellm", [{"introduced": "1.0.0"}, {"fixed": "1.6.9"}])]
+        out = OSVClient._parse_response(ECOSYSTEM_PYPI, raw, None, "CRITICAL", 100)
+        assert len(out.entries) == 1
+        row = out.entries[0]
+        assert row.canonical_name == "litellm"
+        assert row.cve_id == "CVE-1"
+        parsed_range = AffectedRange.from_json(row.affected_range)
+        assert parsed_range.introduced == "1.0.0"
+        assert parsed_range.fixed == "1.6.9"
+
+    def test_severity_floor_excludes(self) -> None:
+        raw = [_vuln("CVE-LOW", ECOSYSTEM_PYPI, "foo", [{"introduced": "1.0"}], severity="MEDIUM")]
+        out = OSVClient._parse_response(ECOSYSTEM_PYPI, raw, None, "CRITICAL", 100)
+        assert out.entries == []
+
+    def test_since_filter_excludes_old(self) -> None:
+        # Two vulns, one before `since`, one after.
+        raw = [
+            _vuln("CVE-OLD", ECOSYSTEM_PYPI, "a", [{"introduced": "1.0"}], published="2020-01-01T00:00:00Z"),
+            _vuln("CVE-NEW", ECOSYSTEM_PYPI, "a", [{"introduced": "1.0"}], published="2026-04-05T00:00:00Z"),
+        ]
+        since = datetime(2026, 1, 1, tzinfo=UTC)
+        out = OSVClient._parse_response(ECOSYSTEM_PYPI, raw, since, "CRITICAL", 100)
+        assert len(out.entries) == 1
+        assert out.entries[0].cve_id == "CVE-NEW"
+
+    def test_introduced_zero_sentinel(self) -> None:
+        raw = [_vuln("CVE-Z", ECOSYSTEM_PYPI, "foo", [{"introduced": "0"}, {"fixed": "2.0.0"}])]
+        out = OSVClient._parse_response(ECOSYSTEM_PYPI, raw, None, "CRITICAL", 100)
+        parsed = AffectedRange.from_json(out.entries[0].affected_range)
+        assert parsed.introduced is None  # "0" is the OSV "from the beginning" sentinel
+        assert parsed.fixed == "2.0.0"
+
+    def test_limit_caps_entries(self) -> None:
+        # Each vuln emits one range; limit is enforced across the loop.
+        raw = [
+            _vuln(f"CVE-{i}", ECOSYSTEM_PYPI, f"pkg{i}", [{"introduced": "1.0"}, {"fixed": "2.0"}]) for i in range(10)
+        ]
+        out = OSVClient._parse_response(ECOSYSTEM_PYPI, raw, None, "CRITICAL", 3)
+        assert len(out.entries) == 3
+
+    def test_ecosystem_filter(self) -> None:
+        raw = [
+            {
+                "id": "CVE-MIX",
+                "published": "2026-04-01T00:00:00Z",
+                "database_specific": {"severity": "CRITICAL"},
+                "affected": [
+                    {"package": {"ecosystem": "Go", "name": "some"}, "ranges": [{"events": [{"introduced": "1.0"}]}]},
+                    {
+                        "package": {"ecosystem": ECOSYSTEM_PYPI, "name": "p"},
+                        "ranges": [{"events": [{"introduced": "1.0"}]}],
+                    },
+                ],
+            },
+        ]
+        out = OSVClient._parse_response(ECOSYSTEM_PYPI, raw, None, "CRITICAL", 10)
+        assert len(out.entries) == 1
+        assert out.entries[0].canonical_name == "p"
+
+    def test_latest_published_at_tracks_max(self) -> None:
+        raw = [
+            _vuln("A", ECOSYSTEM_PYPI, "x", [{"introduced": "1.0"}], published="2026-04-01T00:00:00Z"),
+            _vuln("B", ECOSYSTEM_PYPI, "y", [{"introduced": "1.0"}], published="2026-04-05T12:00:00Z"),
+        ]
+        out = OSVClient._parse_response(ECOSYSTEM_PYPI, raw, None, "CRITICAL", 100)
+        assert out.latest_published_at == datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
+
+
+# =============================================================================
+# Full substitute text shape
+# =============================================================================
+
+
+class TestSubstituteShape:
+    def test_contains_header_and_exit(self) -> None:
+        entry = BlocklistEntry(
+            ecosystem=ECOSYSTEM_PYPI,
+            canonical_name="litellm",
+            cve_id="CVE-2024-0001",
+            severity="CRITICAL",
+            range=AffectedRange(introduced=None, fixed="1.6.9", last_affected=None),
+        )
+        sub = build_substitute_command("pip install litellm==1.6.8", entry)
+        assert sub.startswith("sh -c ")
+        assert "exit 42" in sub
+        assert "LUTHIEN BLOCKED" in sub
+
+    def test_clips_long_original(self) -> None:
+        entry = BlocklistEntry(
+            ecosystem=ECOSYSTEM_PYPI,
+            canonical_name="litellm",
+            cve_id="CVE-X",
+            severity="CRITICAL",
+            range=AffectedRange(introduced=None, fixed="9.9.9", last_affected=None),
+        )
+        huge = "pip install " + ("x" * 1000)
+        sub = build_substitute_command(huge, entry)
+        # The clipped original should appear inside, but not 1000 x's.
+        assert "xxxxxxxxx" in sub
+        assert sub.count("x") < 500
+
+    def test_does_not_include_summary_field(self) -> None:
+        # We deliberately never include untrusted OSV "summary" text in the
+        # substitute. The build_substitute_command API doesn't even accept
+        # such a parameter — this test pins that property.
+        entry = BlocklistEntry(
+            ecosystem=ECOSYSTEM_PYPI,
+            canonical_name="litellm",
+            cve_id="CVE-X",
+            severity="CRITICAL",
+            range=AffectedRange(introduced=None, fixed="9.9.9", last_affected=None),
+        )
+        sub = build_substitute_command("pip install litellm==1.0.0", entry)
+        # No free-form untrusted fields — just our own constant strings and
+        # structured metadata.
+        assert "summary" not in sub.lower()
+
+
+@pytest.mark.parametrize(
+    "candidate,introduced,fixed,expected",
+    [
+        ("1.6.8", None, "1.6.9", True),
+        ("1.6.9", None, "1.6.9", False),
+        ("1.6.8", "1.6.0", "1.7.0", True),
+        ("1.5.9", "1.6.0", "1.7.0", False),
+        ("2.0.0", "1.6.0", "1.7.0", False),
+    ],
+)
+def test_pypi_bounds_parametrized(candidate: str, introduced: str | None, fixed: str | None, expected: bool) -> None:
+    r = AffectedRange(introduced=introduced, fixed=fixed, last_affected=None)
+    assert version_matches(ECOSYSTEM_PYPI, candidate, r) is expected


### PR DESCRIPTION
## Summary

Fourth design pass on the supply-chain problem. PRs #522, #536, and #540 are all closed — see ``dev/OBJECTIVE.md`` for the design and why this one is different.

The fundamental shift: **OSV lookups happen out-of-band on a background schedule, not at request time.** The request-time path is a tiny in-memory lookup, which collapses most of #540's edge-case layers.

## Design at a glance

- Background task polls OSV every 5min (via new ``SchedulerProtocol`` from PR ``worktree-policy-scheduler``).
- Persists known-compromised (ecosystem, package, version-range, CVE) entries to a ``supply_chain_blocklist`` table (dual migrations, accessed via ``PoolProtocol``).
- Loads the blocklist into an in-memory dict at startup (single SELECT).
- Request-time: buffers bash tool_use, runs PEP 440 / semver range matching on extracted package literals, plus a substring backstop, substitutes ``command`` in place on hit.
- Substitution is ``sh -c '... LUTHIEN BLOCKED ... exit 42'`` — same block, same index, no new content blocks. The invariant whose violation killed #536 is pinned with streaming-shape tests.

## Depends on

- PR ``worktree-policy-scheduler`` (PR A) for the scheduler primitive. This PR stubs the ``SchedulerProtocol`` interface and a ``register_scheduled_tasks`` lifecycle hook; PR A will wire it into the policy loader.

## Related (closed)

- #522 — adversarial shell parser
- #536 — content injection + streaming protocol violation
- #540 — command substitution + regex parser layers

## Test plan

- [ ] Streaming-shape tests (monotonic indices, block counts, rewrites)
- [ ] ``subprocess.run`` tests on the sh -c substitute (exit 42, stderr, no side effects, attacker-quote safety)
- [ ] PEP 440 and semver range matching edge cases
- [ ] Substring backstop
- [ ] Background task success + failure + dedupe
- [ ] DB layer against in-memory SQLite pool
- [ ] Migration sync test