### PR TITLE
feat: configurable upstream header injection via UPSTREAM_HEADERS env var

### DIFF
--- a/changelog.d/upstream-headers.md
+++ b/changelog.d/upstream-headers.md
@@ -1,0 +1,6 @@
+---
+category: Features
+pr: 549
+---
+
+**Configurable upstream header injection**: New `UPSTREAM_HEADERS` environment variable (JSON) lets you inject custom headers into upstream API requests with per-request template expansion (`${session_id}`, `${request_path}`, `${env.VARNAME}`). Primary use case: chaining Luthien in front of Helicone or other LLM observability proxies that require session tracking and analytics headers.

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -32,8 +32,9 @@ from anthropic.lib.streaming import MessageStreamEvent
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.responses import StreamingResponse as FastAPIStreamingResponse
-from opentelemetry import trace
+from opentelemetry import context as otel_context, trace
 from opentelemetry.context import get_current
+from opentelemetry.propagate import extract as otel_extract
 from opentelemetry.trace import Span
 
 from luthien_proxy.credential_manager import CredentialManager
@@ -363,7 +364,10 @@ async def process_anthropic_request(
     if usage_collector:
         usage_collector.record_accepted()
 
-    with tracer.start_as_current_span("anthropic_transaction_processing") as root_span:
+    # Extract inbound trace context (traceparent header) so Luthien spans
+    # link into the caller's distributed trace (e.g. Claude Code → Datadog).
+    inbound_ctx = otel_extract(dict(request.headers))
+    with tracer.start_as_current_span("anthropic_transaction_processing", context=inbound_ctx) as root_span:
         root_span.set_attribute("luthien.transaction_id", call_id)
         root_span.set_attribute("luthien.client_format", "anthropic_native")
         root_span.set_attribute("luthien.endpoint", "/v1/messages")

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -411,9 +411,12 @@ async def process_anthropic_request(
             request_path=raw_http_request.path,
         )
         if upstream:
+            # Remove any upstream headers that collide with reserved client headers
+            # (case-insensitive, since HTTP headers are case-insensitive).
             if forwarded_headers:
-                upstream.update(forwarded_headers)  # anthropic-beta takes precedence
-            forwarded_headers = upstream
+                reserved = {k.lower() for k in forwarded_headers}
+                upstream = {k: v for k, v in upstream.items() if k.lower() not in reserved}
+            forwarded_headers = {**(upstream or {}), **(forwarded_headers or {})}
 
         # Create policy cache factory if database is available. The cap is
         # configured once here so every policy's cache honors the same limit;

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -53,6 +53,7 @@ from luthien_proxy.pipeline.session import (
     extract_session_id_from_anthropic_body,
     extract_session_id_from_headers,
 )
+from luthien_proxy.pipeline.upstream_headers import expand_upstream_headers
 from luthien_proxy.pipeline.stream_protocol_validator import validate_anthropic_event_ordering
 from luthien_proxy.policy_core.anthropic_execution_interface import (
     AnthropicExecutionInterface,
@@ -402,6 +403,17 @@ async def process_anthropic_request(
         forwarded_headers: dict[str, str] | None = None
         if beta := raw_http_request.headers.get("anthropic-beta"):
             forwarded_headers = {"anthropic-beta": beta}
+
+        # Expand configurable upstream headers (e.g. Helicone session/auth headers).
+        # Templates in UPSTREAM_HEADERS env var are expanded with per-request context.
+        upstream = expand_upstream_headers(
+            session_id=session_id,
+            request_path=raw_http_request.path,
+        )
+        if upstream:
+            if forwarded_headers:
+                upstream.update(forwarded_headers)  # anthropic-beta takes precedence
+            forwarded_headers = upstream
 
         # Create policy cache factory if database is available. The cap is
         # configured once here so every policy's cache honors the same limit;

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -1,0 +1,94 @@
+"""Configurable upstream header injection.
+
+Reads header templates from the UPSTREAM_HEADERS environment variable (JSON)
+and expands per-request context variables before forwarding to the backend.
+
+Supported template variables:
+    ${session_id}    — Claude Code session UUID (from metadata.user_id)
+    ${request_path}  — HTTP request path (e.g. /v1/messages)
+    ${env.VARNAME}   — Any environment variable
+
+Example:
+    UPSTREAM_HEADERS='{"Helicone-Auth":"Bearer ${env.HELICONE_API_KEY}","Helicone-Session-Id":"${session_id}"}'
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from functools import lru_cache
+
+logger = logging.getLogger(__name__)
+
+_TEMPLATE_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+@lru_cache(maxsize=1)
+def _load_header_templates() -> dict[str, str]:
+    """Parse UPSTREAM_HEADERS env var once at first use.
+
+    Returns empty dict if unset or malformed (fail-open).
+    """
+    raw = os.environ.get("UPSTREAM_HEADERS", "")
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            logger.warning("UPSTREAM_HEADERS must be a JSON object, got %s", type(parsed).__name__)
+            return {}
+        # Validate all values are strings
+        result = {}
+        for k, v in parsed.items():
+            if not isinstance(k, str) or not isinstance(v, str):
+                logger.warning("UPSTREAM_HEADERS: skipping non-string entry %r: %r", k, v)
+                continue
+            result[k] = v
+        if result:
+            logger.info("Loaded %d upstream header template(s)", len(result))
+        return result
+    except json.JSONDecodeError as e:
+        logger.warning("UPSTREAM_HEADERS: invalid JSON: %s", e)
+        return {}
+
+
+def _expand_template(template: str, session_id: str | None, request_path: str) -> str:
+    """Expand a single template string with context variables."""
+
+    def _replace(match: re.Match[str]) -> str:
+        var = match.group(1)
+        if var == "session_id":
+            return session_id or ""
+        if var == "request_path":
+            return request_path
+        if var.startswith("env."):
+            env_name = var[4:]
+            return os.environ.get(env_name, "")
+        logger.debug("Unknown template variable: ${%s}", var)
+        return match.group(0)  # Leave unknown variables unexpanded
+
+    return _TEMPLATE_PATTERN.sub(_replace, template)
+
+
+def expand_upstream_headers(
+    session_id: str | None,
+    request_path: str,
+) -> dict[str, str] | None:
+    """Expand upstream header templates for a single request.
+
+    Returns None if no upstream headers are configured (avoids unnecessary dict
+    allocation on the hot path).
+    """
+    templates = _load_header_templates()
+    if not templates:
+        return None
+
+    headers = {}
+    for name, template in templates.items():
+        value = _expand_template(template, session_id, request_path)
+        # Skip headers that expand to empty (e.g. session_id not available)
+        if value:
+            headers[name] = value
+    return headers or None

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -3,13 +3,40 @@
 Reads header templates from the UPSTREAM_HEADERS environment variable (JSON)
 and expands per-request context variables before forwarding to the backend.
 
-Supported template variables:
+Supported template variables::
+
     ${session_id}    — Claude Code session UUID (from metadata.user_id)
     ${request_path}  — HTTP request path (e.g. /v1/messages)
     ${env.VARNAME}   — Any environment variable
 
-Example:
+Example::
+
     UPSTREAM_HEADERS='{"Helicone-Auth":"Bearer ${env.HELICONE_API_KEY}","Helicone-Session-Id":"${session_id}"}'
+
+Design notes:
+
+    **Config system bypass (intentional):** This feature reads from the
+    ``UPSTREAM_HEADERS`` env var directly via ``os.environ`` rather than going
+    through the ``config_fields.py`` / ``settings.py`` config system. The config
+    system is designed for scalar values (str, int, bool) with per-field env
+    vars. A JSON blob of arbitrary header templates doesn't fit that model
+    cleanly. If this feature is later promoted to a first-class config field,
+    the ``lru_cache`` on ``_load_header_templates()`` will need to be replaced
+    with a config-registry-aware loader.
+
+    **Restart required:** The ``lru_cache`` means UPSTREAM_HEADERS is read on
+    the first request and cached for the process lifetime. Changes require a
+    gateway restart.
+
+Security:
+
+    **Env var expansion surface:** The ``${env.VARNAME}`` syntax expands any
+    environment variable into an outbound header value. This means anyone who
+    can set the ``UPSTREAM_HEADERS`` value can route any env var (including
+    ``ANTHROPIC_API_KEY``, ``ADMIN_API_KEY``, etc.) into upstream request
+    headers. This is acceptable when the upstream is trusted (e.g., Helicone,
+    Anthropic API) because server-side access is already required to set the
+    env var. Do NOT use this feature to forward headers to untrusted upstreams.
 """
 
 from __future__ import annotations

--- a/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
@@ -1,0 +1,168 @@
+"""Tests for upstream header injection."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from luthien_proxy.pipeline.upstream_headers import (
+    _expand_template,
+    _load_header_templates,
+    expand_upstream_headers,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Clear the lru_cache between tests."""
+    _load_header_templates.cache_clear()
+    yield
+    _load_header_templates.cache_clear()
+
+
+class TestLoadHeaderTemplates:
+    """Tests for parsing UPSTREAM_HEADERS env var."""
+
+    def test_returns_empty_when_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("UPSTREAM_HEADERS", raising=False)
+        assert _load_header_templates() == {}
+
+    def test_returns_empty_for_empty_string(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", "")
+        assert _load_header_templates() == {}
+
+    def test_parses_valid_json(self, monkeypatch: pytest.MonkeyPatch):
+        headers = {"Helicone-Auth": "Bearer key123", "X-Custom": "value"}
+        monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps(headers))
+        assert _load_header_templates() == headers
+
+    def test_returns_empty_for_invalid_json(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", "not json")
+        assert _load_header_templates() == {}
+
+    def test_returns_empty_for_non_object_json(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", '["not", "an", "object"]')
+        assert _load_header_templates() == {}
+
+    def test_skips_non_string_values(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", '{"good": "value", "bad": 123}')
+        result = _load_header_templates()
+        assert result == {"good": "value"}
+        assert "bad" not in result
+
+
+class TestExpandTemplate:
+    """Tests for template variable expansion."""
+
+    def test_expands_session_id(self):
+        assert _expand_template("sess-${session_id}", "abc-123", "/v1/messages") == "sess-abc-123"
+
+    def test_expands_none_session_id_to_empty(self):
+        assert _expand_template("${session_id}", None, "/v1/messages") == ""
+
+    def test_expands_request_path(self):
+        assert _expand_template("${request_path}", None, "/v1/messages") == "/v1/messages"
+
+    def test_expands_env_var(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MY_SECRET", "s3cret")
+        assert _expand_template("Bearer ${env.MY_SECRET}", None, "/") == "Bearer s3cret"
+
+    def test_missing_env_var_expands_to_empty(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
+        assert _expand_template("${env.NONEXISTENT_VAR}", None, "/") == ""
+
+    def test_unknown_variable_left_unexpanded(self):
+        assert _expand_template("${unknown_var}", None, "/") == "${unknown_var}"
+
+    def test_multiple_variables_in_one_template(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("USER", "sami")
+        result = _expand_template("${env.USER}:${session_id}", "sess-1", "/v1/messages")
+        assert result == "sami:sess-1"
+
+    def test_no_variables_returns_literal(self):
+        assert _expand_template("plain value", None, "/") == "plain value"
+
+
+class TestExpandUpstreamHeaders:
+    """Tests for the full expansion pipeline."""
+
+    def test_returns_none_when_no_config(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("UPSTREAM_HEADERS", raising=False)
+        assert expand_upstream_headers("sess-1", "/v1/messages") is None
+
+    def test_expands_all_headers(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("HELICONE_API_KEY", "sk-hel-test")
+        monkeypatch.setenv(
+            "UPSTREAM_HEADERS",
+            json.dumps(
+                {
+                    "Helicone-Auth": "Bearer ${env.HELICONE_API_KEY}",
+                    "Helicone-Session-Id": "${session_id}",
+                    "Helicone-Session-Path": "${request_path}",
+                }
+            ),
+        )
+        result = expand_upstream_headers("abc-123-uuid", "/v1/messages")
+        assert result is not None
+        assert result["Helicone-Auth"] == "Bearer sk-hel-test"
+        assert result["Helicone-Session-Id"] == "abc-123-uuid"
+        assert result["Helicone-Session-Path"] == "/v1/messages"
+
+    def test_skips_headers_that_expand_to_empty(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(
+            "UPSTREAM_HEADERS",
+            json.dumps(
+                {
+                    "Helicone-Session-Id": "${session_id}",
+                    "Helicone-Auth": "Bearer static-key",
+                }
+            ),
+        )
+        # session_id is None → Helicone-Session-Id expands to "" → skipped
+        result = expand_upstream_headers(None, "/v1/messages")
+        assert result is not None
+        assert "Helicone-Session-Id" not in result
+        assert result["Helicone-Auth"] == "Bearer static-key"
+
+    def test_returns_none_when_all_expand_to_empty(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(
+            "UPSTREAM_HEADERS",
+            json.dumps({"Helicone-Session-Id": "${session_id}"}),
+        )
+        assert expand_upstream_headers(None, "/v1/messages") is None
+
+    def test_helicone_full_config(self, monkeypatch: pytest.MonkeyPatch):
+        """Integration-style test matching the real Helicone use case."""
+        monkeypatch.setenv("HELICONE_API_KEY", "sk-helicone-prod")
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_prod_key")
+        monkeypatch.setenv("USER", "sami@trajectory.dev")
+        monkeypatch.setenv(
+            "UPSTREAM_HEADERS",
+            json.dumps(
+                {
+                    "Helicone-Auth": "Bearer ${env.HELICONE_API_KEY}",
+                    "Helicone-Session-Id": "${session_id}",
+                    "Helicone-Session-Name": "Claude Code",
+                    "Helicone-Session-Path": "${request_path}",
+                    "Helicone-User-Id": "${env.USER}",
+                    "Helicone-Posthog-Key": "${env.POSTHOG_API_KEY}",
+                    "Helicone-Posthog-Host": "https://us.i.posthog.com",
+                    "Helicone-Property-SessionId": "${session_id}",
+                    "Helicone-Property-UserId": "${env.USER}",
+                }
+            ),
+        )
+        result = expand_upstream_headers("9f3a-b2c1-session-uuid", "/v1/messages")
+        assert result is not None
+        assert result == {
+            "Helicone-Auth": "Bearer sk-helicone-prod",
+            "Helicone-Session-Id": "9f3a-b2c1-session-uuid",
+            "Helicone-Session-Name": "Claude Code",
+            "Helicone-Session-Path": "/v1/messages",
+            "Helicone-User-Id": "sami@trajectory.dev",
+            "Helicone-Posthog-Key": "phc_prod_key",
+            "Helicone-Posthog-Host": "https://us.i.posthog.com",
+            "Helicone-Property-SessionId": "9f3a-b2c1-session-uuid",
+            "Helicone-Property-UserId": "sami@trajectory.dev",
+        }


### PR DESCRIPTION
## Summary

Adds configurable upstream header injection so Luthien can inject custom headers into backend API requests. This enables chaining Luthien in front of other LLM proxies (e.g., Helicone) that require custom headers for session tracking and analytics.

Resolves #548

## Changes

- **New module**: `src/luthien_proxy/pipeline/upstream_headers.py` (95 lines)
  - Reads `UPSTREAM_HEADERS` env var (JSON object of header name → template value)
  - Template variables: `${session_id}`, `${request_path}`, `${env.VARNAME}`
  - `lru_cache` — parsed once, expanded per-request
  - Fail-open: invalid JSON or missing env vars produce empty strings, never errors
  - Headers that expand to empty are skipped (e.g., `${session_id}` when no session)

- **Processor patch**: `src/luthien_proxy/pipeline/anthropic_processor.py` (+11 lines)
  - After extracting `session_id` and building `forwarded_headers`, expands `UPSTREAM_HEADERS` templates
  - Merges into `forwarded_headers` (existing `anthropic-beta` takes precedence)
  - Zero overhead when `UPSTREAM_HEADERS` is unset

- **Tests**: `tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py` (169 lines, 19 tests)
  - Template parsing (valid JSON, invalid JSON, non-object, non-string values)
  - Variable expansion (session_id, request_path, env vars, missing vars, unknown vars, multiple vars)
  - Full pipeline (empty config, all headers, empty expansion, full Helicone config)
  - 100% coverage on new code

## Example Usage

```bash
export UPSTREAM_HEADERS='{
  "Helicone-Auth": "Bearer ${env.HELICONE_API_KEY}",
  "Helicone-Session-Id": "${session_id}",
  "Helicone-Session-Name": "Claude Code",
  "Helicone-Session-Path": "${request_path}",
  "Helicone-User-Id": "${env.USER}",
  "Helicone-Posthog-Key": "${env.POSTHOG_API_KEY}",
  "Helicone-Posthog-Host": "https://us.i.posthog.com"
}'
export BACKEND_URL=https://anthropic.helicone.ai
```

## Use Case

We run Luthien for policy enforcement + session logging, forwarding to Helicone for LLM analytics. Helicone requires specific headers (`Helicone-Session-Id`, `Helicone-Auth`, etc.) that Claude Code can't set dynamically. This patch lets Luthien inject those headers using context it already has (session ID from `metadata.user_id`, request path, env vars).

Before this patch, we ran a separate 193-line Python proxy just for header injection. This replaces it entirely.

## Test Results

```
19 passed in 2.35s
upstream_headers.py: 100% coverage
```