### PR TITLE
fix(cli): skip policy_config.yaml write if file already exists

### DIFF
--- a/changelog.d/no-overwrite-policy-config.md
+++ b/changelog.d/no-overwrite-policy-config.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**`luthien onboard` no longer overwrites a customized `policy_config.yaml`**: `_write_policy()` now skips the write if the file already exists, preserving any user-configured policy.

--- a/src/luthien_cli/src/luthien_cli/commands/onboard.py
+++ b/src/luthien_cli/src/luthien_cli/commands/onboard.py
@@ -166,9 +166,17 @@ def _ensure_docker_env(
 
 
 def _write_policy(repo_path: str, gateway_url: str) -> None:
-    """Write OnboardingPolicy config to the repo's config directory."""
+    """Write OnboardingPolicy config to the repo's config directory.
+
+    Skips the write if policy_config.yaml already exists to preserve
+    user customizations.
+    """
     config_dir = f"{repo_path}/config"
     os.makedirs(config_dir, exist_ok=True)
+
+    policy_path = f"{config_dir}/policy_config.yaml"
+    if os.path.exists(policy_path):
+        return
 
     # Write YAML directly to avoid dependency on pyyaml in the CLI venv.
     # The structure is simple and static — no need for a YAML library.
@@ -179,7 +187,7 @@ def _write_policy(repo_path: str, gateway_url: str) -> None:
             gateway_url: "{gateway_url}"
     """)
 
-    with open(f"{config_dir}/policy_config.yaml", "w") as f:
+    with open(policy_path, "w") as f:
         f.write(yaml_content)
 
 

--- a/tests/luthien_cli/test_onboard.py
+++ b/tests/luthien_cli/test_onboard.py
@@ -27,6 +27,18 @@ def test_write_policy(tmp_path):
     assert "http://localhost:8000" in content
 
 
+def test_write_policy_does_not_overwrite_existing(tmp_path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    policy_path = config_dir / "policy_config.yaml"
+    original = "custom user policy content"
+    policy_path.write_text(original)
+
+    _write_policy(str(tmp_path), "http://localhost:8000")
+
+    assert policy_path.read_text() == original
+
+
 def test_write_local_env(tmp_path):
     """Local env uses passthrough auth with admin key, no proxy key."""
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Summary

- `_write_policy()` in `onboard.py` unconditionally opened `policy_config.yaml` with `"w"` mode, silently overwriting any user customizations on every `luthien onboard` run
- Added an existence check: the file is only written if it doesn't already exist
- Added a regression test covering the no-overwrite behavior

## Trello

https://trello.com/c/lPr3ltPy

## Notes

Discovered during PR #545 review; kept out of scope there per the card description.