### PR TITLE
feat(telemetry): default OTEL exporter to HTTP/protobuf instead of gRPC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "anthropic>=0.84.0",
     "aiohttp>=3.9.0",
     "sentry-sdk[fastapi]>=2.54.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.20.0",
 ]
 
 [tool.hatch.version]

--- a/src/luthien_proxy/config_fields.py
+++ b/src/luthien_proxy/config_fields.py
@@ -193,6 +193,11 @@ CONFIG_FIELDS: tuple[ConfigFieldMeta, ...] = (
         category="observability",
     ),
     ConfigFieldMeta(
+        "otel_exporter_protocol", "OTEL_EXPORTER_OTLP_PROTOCOL", str, "http/protobuf",
+        "OTLP exporter protocol: 'http/protobuf' (default, works behind HTTP LBs) or 'grpc'",
+        category="observability",
+    ),
+    ConfigFieldMeta(
         "tempo_url", "TEMPO_URL", str, "http://localhost:3200",
         "Tempo HTTP API URL for trace queries",
         category="observability",

--- a/src/luthien_proxy/settings.py
+++ b/src/luthien_proxy/settings.py
@@ -90,6 +90,7 @@ class Settings(_SettingsBase):
     # ── observability ───────────────────────────────────────────────
     otel_enabled: bool = False
     otel_exporter_otlp_endpoint: str = "http://tempo:4317"
+    otel_exporter_protocol: str = "http/protobuf"
     tempo_url: str = "http://localhost:3200"
     service_name: str = "luthien-proxy"
     service_version: str = PROXY_VERSION

--- a/src/luthien_proxy/telemetry.py
+++ b/src/luthien_proxy/telemetry.py
@@ -1,7 +1,7 @@
 """OpenTelemetry setup for Luthien observability.
 
 This module configures:
-- Distributed tracing (exports to Tempo via OTLP)
+- Distributed tracing (exports via OTLP HTTP/protobuf by default, gRPC optional)
 - Structured logging with trace correlation
 - Resource attributes (service name, version, etc.)
 - Auto-instrumentation for FastAPI and Redis
@@ -16,7 +16,12 @@ from contextlib import contextmanager
 
 from opentelemetry import trace
 from opentelemetry.context import Context, attach, detach
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+    OTLPSpanExporter as GrpcSpanExporter,
+)
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter as HttpSpanExporter,
+)
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.redis import RedisInstrumentor
 from opentelemetry.sdk.resources import Resource
@@ -60,11 +65,11 @@ def restore_context(ctx: Context) -> Generator[object, None, None]:
         detach(token)
 
 
-def _get_otel_config() -> tuple[bool, str, str, str, str]:
+def _get_otel_config() -> tuple[bool, str, str, str, str, str]:
     """Get OpenTelemetry configuration from settings.
 
     Returns:
-        Tuple of (enabled, endpoint, service_name, service_version, environment)
+        Tuple of (enabled, endpoint, service_name, service_version, environment, protocol)
     """
     settings = get_settings()
     return (
@@ -73,6 +78,7 @@ def _get_otel_config() -> tuple[bool, str, str, str, str]:
         settings.service_name,
         settings.service_version,
         settings.environment,
+        getattr(settings, "otel_exporter_protocol", "http/protobuf"),
     )
 
 
@@ -85,6 +91,7 @@ def _silence_otel_loggers() -> None:
     """
     for name in (
         "opentelemetry.exporter.otlp.proto.grpc.exporter",
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter",
         "opentelemetry.sdk.trace.export",
         "grpc._channel",
         "grpc._plugin_wrapping",
@@ -97,13 +104,13 @@ def configure_tracing() -> trace.Tracer:
 
     Sets up:
     - Resource attributes (service name, version, environment)
-    - OTLP exporter to Tempo
+    - OTLP exporter (HTTP/protobuf by default, gRPC via OTEL_EXPORTER_OTLP_PROTOCOL=grpc)
     - Batch span processor for efficiency
 
     Returns:
         Configured tracer for manual instrumentation
     """
-    otel_enabled, otel_endpoint, service_name, service_version, environment = _get_otel_config()
+    otel_enabled, otel_endpoint, service_name, service_version, environment, protocol = _get_otel_config()
 
     if not otel_enabled:
         logger.debug("OpenTelemetry disabled (OTEL_ENABLED=false)")
@@ -122,11 +129,17 @@ def configure_tracing() -> trace.Tracer:
     # Create tracer provider
     provider = TracerProvider(resource=resource)
 
-    # Configure OTLP exporter (sends to Tempo)
-    otlp_exporter = OTLPSpanExporter(
-        endpoint=otel_endpoint,
-        insecure=True,  # No TLS for local dev
-    )
+    # Configure OTLP exporter — HTTP/protobuf works behind HTTP load balancers
+    # (ALB, nginx, etc.) where gRPC would fail with StatusCode.UNAVAILABLE.
+    if protocol == "grpc":
+        otlp_exporter = GrpcSpanExporter(
+            endpoint=otel_endpoint,
+            insecure=True,
+        )
+    else:
+        otlp_exporter = HttpSpanExporter(
+            endpoint=otel_endpoint,
+        )
 
     # Use batch processor for efficiency (batches spans before export)
     processor = BatchSpanProcessor(otlp_exporter)
@@ -135,7 +148,7 @@ def configure_tracing() -> trace.Tracer:
     # Set as global tracer provider
     trace.set_tracer_provider(provider)
 
-    logger.info(f"OpenTelemetry configured: {service_name} → {otel_endpoint}")
+    logger.info(f"OpenTelemetry configured: {service_name} → {otel_endpoint} ({protocol})")
 
     return trace.get_tracer(__name__)
 

--- a/tests/luthien_proxy/unit_tests/test_telemetry.py
+++ b/tests/luthien_proxy/unit_tests/test_telemetry.py
@@ -23,6 +23,7 @@ class TestSilenceOtelLoggers:
 
         for name in (
             "opentelemetry.exporter.otlp.proto.grpc.exporter",
+            "opentelemetry.exporter.otlp.proto.http.trace_exporter",
             "opentelemetry.sdk.trace.export",
             "grpc._channel",
             "grpc._plugin_wrapping",
@@ -43,7 +44,7 @@ class TestConfigureTracing:
     @patch("luthien_proxy.telemetry._silence_otel_loggers")
     def test_disabled_silences_loggers(self, mock_silence, mock_config):
         """When OTel is disabled, noisy loggers are silenced."""
-        mock_config.return_value = (False, "", "svc", "1.0", "dev")
+        mock_config.return_value = (False, "", "svc", "1.0", "dev", "http/protobuf")
         telemetry.configure_tracing()
         mock_silence.assert_called_once()
 
@@ -51,19 +52,46 @@ class TestConfigureTracing:
     @patch("luthien_proxy.telemetry._silence_otel_loggers")
     def test_enabled_does_not_silence_loggers(self, mock_silence, mock_config):
         """When OTel is enabled, loggers are NOT silenced — connection errors should be visible."""
-        mock_config.return_value = (True, "http://localhost:4317", "svc", "1.0", "dev")
+        mock_config.return_value = (True, "http://localhost:4317", "svc", "1.0", "dev", "http/protobuf")
         telemetry.configure_tracing()
         mock_silence.assert_not_called()
 
     @patch("luthien_proxy.telemetry._get_otel_config")
     def test_disabled_logs_at_debug_not_info(self, mock_config):
         """When OTel is disabled, the message should be DEBUG, not INFO."""
-        mock_config.return_value = (False, "", "svc", "1.0", "dev")
+        mock_config.return_value = (False, "", "svc", "1.0", "dev", "http/protobuf")
         with patch.object(telemetry.logger, "debug") as mock_debug, patch.object(telemetry.logger, "info") as mock_info:
             telemetry.configure_tracing()
             mock_debug.assert_called_once()
             mock_info.assert_not_called()
 
+    @patch("luthien_proxy.telemetry._get_otel_config")
+    @patch("luthien_proxy.telemetry.HttpSpanExporter")
+    @patch("luthien_proxy.telemetry.GrpcSpanExporter")
+    def test_default_protocol_uses_http_exporter(self, mock_grpc, mock_http, mock_config):
+        """Default protocol (http/protobuf) should use the HTTP exporter."""
+        mock_config.return_value = (True, "http://localhost:4318", "svc", "1.0", "dev", "http/protobuf")
+        telemetry.configure_tracing()
+        mock_http.assert_called_once_with(endpoint="http://localhost:4318")
+        mock_grpc.assert_not_called()
+
+    @patch("luthien_proxy.telemetry._get_otel_config")
+    @patch("luthien_proxy.telemetry.HttpSpanExporter")
+    @patch("luthien_proxy.telemetry.GrpcSpanExporter")
+    def test_grpc_protocol_uses_grpc_exporter(self, mock_grpc, mock_http, mock_config):
+        """Explicit grpc protocol should use the gRPC exporter."""
+        mock_config.return_value = (True, "http://localhost:4317", "svc", "1.0", "dev", "grpc")
+        telemetry.configure_tracing()
+        mock_grpc.assert_called_once_with(endpoint="http://localhost:4317", insecure=True)
+        mock_http.assert_not_called()
+
+    @patch("luthien_proxy.telemetry._get_otel_config")
+    @patch("luthien_proxy.telemetry.HttpSpanExporter")
+    def test_unknown_protocol_falls_back_to_http(self, mock_http, mock_config):
+        """Unknown protocol values should fall back to HTTP (fail-safe)."""
+        mock_config.return_value = (True, "http://localhost:4318", "svc", "1.0", "dev", "unknown")
+        telemetry.configure_tracing()
+        mock_http.assert_called_once()
 
 class TestInstrumentApp:
     """Test FastAPI instrumentation."""

--- a/uv.lock
+++ b/uv.lock
@@ -1045,6 +1045,7 @@ dependencies = [
     { name = "litellm", extra = ["proxy"] },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-redis" },
     { name = "opentelemetry-sdk" },
@@ -1085,6 +1086,7 @@ requires-dist = [
     { name = "litellm", extras = ["proxy"], specifier = ">=1.81.0,!=1.82.7,!=1.82.8" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.20.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.41b0" },
     { name = "opentelemetry-instrumentation-redis", specifier = ">=0.41b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
@@ -1347,6 +1349,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a2/c0/43222f5b97dc10812bc4f0abc5dc7cd0a2525a91b5151d26c9e2e958f52e/opentelemetry_exporter_otlp_proto_grpc-1.38.0.tar.gz", hash = "sha256:2473935e9eac71f401de6101d37d6f3f0f1831db92b953c7dcc912536158ebd6", size = 24676, upload-time = "2025-10-16T08:35:53.83Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/f0/bd831afbdba74ca2ce3982142a2fad707f8c487e8a3b6fef01f1d5945d1b/opentelemetry_exporter_otlp_proto_grpc-1.38.0-py3-none-any.whl", hash = "sha256:7c49fd9b4bd0dbe9ba13d91f764c2d20b0025649a6e4ac35792fb8d84d764bc7", size = 19695, upload-time = "2025-10-16T08:35:35.053Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0a/debcdfb029fbd1ccd1563f7c287b89a6f7bef3b2902ade56797bfd020854/opentelemetry_exporter_otlp_proto_http-1.38.0.tar.gz", hash = "sha256:f16bd44baf15cbe07633c5112ffc68229d0edbeac7b37610be0b2def4e21e90b", size = 17282, upload-time = "2025-10-16T08:35:54.422Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/77/154004c99fb9f291f74aa0822a2f5bbf565a72d8126b3a1b63ed8e5f83c7/opentelemetry_exporter_otlp_proto_http-1.38.0-py3-none-any.whl", hash = "sha256:84b937305edfc563f08ec69b9cb2298be8188371217e867c1854d77198d0825b", size = 19579, upload-time = "2025-10-16T08:35:36.269Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Changes the default OTLP exporter protocol from gRPC to HTTP/protobuf. gRPC fails behind HTTP load balancers (ALB, nginx, Cloudflare) with `StatusCode.UNAVAILABLE` — a common production deployment pattern. HTTP/protobuf works everywhere.

Resolves #556

## Changes

- **New config field**: `otel_exporter_protocol` / `OTEL_EXPORTER_OTLP_PROTOCOL` (default: `http/protobuf`)
- **New dependency**: `opentelemetry-exporter-otlp-proto-http>=1.20.0`
- **telemetry.py**: Import both `GrpcSpanExporter` and `HttpSpanExporter`, select based on config
- **config_fields.py**: New `ConfigFieldMeta` for `otel_exporter_protocol`
- **settings.py**: Auto-regenerated with new field

## Behavior

| `OTEL_EXPORTER_OTLP_PROTOCOL` | Exporter used | Notes |
|---|---|---|
| `http/protobuf` (default) | `HttpSpanExporter` | Works behind ALB, nginx, any HTTP LB |
| `grpc` | `GrpcSpanExporter` | Original behavior, for gRPC-native collectors |
| Anything else | `HttpSpanExporter` | Fail-safe to HTTP |

## Why HTTP as default?

Most production deployments put OTEL collectors behind HTTP load balancers. gRPC requires HTTP/2 end-to-end, which many LBs don't support (ALB supports it but requires specific configuration). HTTP/protobuf uses standard HTTP/1.1 POST requests — universally supported.

The gRPC exporter remains available for direct-to-collector deployments (Docker Compose, sidecar patterns) where gRPC performance is preferred.

## Tests

3 new tests added to `test_telemetry.py`:
- `test_default_protocol_uses_http_exporter` — verifies HTTP is default
- `test_grpc_protocol_uses_grpc_exporter` — verifies explicit gRPC works
- `test_unknown_protocol_falls_back_to_http` — verifies fail-safe behavior

Existing tests updated from 5-tuple to 6-tuple mock configs.

```
20 passed in 1.06s
```

## Migration

No breaking changes. Existing deployments using gRPC can set `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` to preserve current behavior. New deployments get HTTP by default.