### PR TITLE
feat(health): report database connectivity in /health, add /ready endpoint

### DIFF
--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -357,10 +357,11 @@ def create_app(
     # Simple utility endpoints
     @app.get("/health")
     async def health(request: Request):
-        """Health check endpoint.
+        """Health check endpoint (liveness probe).
 
-        Returns gateway status, auth mode, and last observed credential type so
-        operators and the UI can surface billing mode warnings accurately.
+        Returns gateway status including database connectivity. Always returns
+        HTTP 200 — the process is alive even if the DB is unreachable. Use
+        /ready for readiness probes that should fail when the DB is down.
         """
         deps = getattr(request.app.state, "dependencies", None)
         auth_mode = None
@@ -373,13 +374,77 @@ def create_app(
             last_credential_type = deps.last_credential_info.get("type")
             last_credential_at = deps.last_credential_info.get("timestamp")
 
-        return {
-            "status": "healthy",
+        # Ping database to report connectivity
+        db_status = "not_configured"
+        db_error = None
+        if deps and deps.db_pool:
+            try:
+                pool = await deps.db_pool.get_pool()
+                result = await pool.fetchval("SELECT 1")
+                db_status = "connected" if result == 1 else "unexpected_response"
+            except Exception as exc:
+                db_status = "unreachable"
+                db_error = str(exc)
+
+        status = "healthy" if db_status in ("connected", "not_configured") else "degraded"
+
+        response = {
+            "status": status,
             "version": PROXY_DISPLAY_VERSION,
+            "database": db_status,
             "auth_mode": auth_mode,
             "last_credential_type": last_credential_type,
             "last_credential_at": last_credential_at,
         }
+        if db_error:
+            response["database_error"] = db_error
+        return response
+
+    @app.get("/ready")
+    async def ready(request: Request):
+        """Readiness probe endpoint.
+
+        Returns HTTP 200 only when the gateway is fully ready to serve traffic:
+        database connected and policy loaded. Returns HTTP 503 otherwise.
+
+        Use this for load balancer readiness probes (ECS, Kubernetes) so traffic
+        is not routed until the gateway can actually handle requests. Use /health
+        for liveness probes.
+        """
+        deps = getattr(request.app.state, "dependencies", None)
+        reasons: list[str] = []
+
+        # Check dependencies container exists
+        if not deps:
+            return JSONResponse(
+                status_code=503,
+                content={"status": "not_ready", "reasons": ["dependencies not initialized"]},
+            )
+
+        # Check database connectivity
+        if deps.db_pool:
+            try:
+                pool = await deps.db_pool.get_pool()
+                await pool.fetchval("SELECT 1")
+            except Exception as exc:
+                reasons.append(f"database unreachable: {exc}")
+        # No db_pool is acceptable (SQLite auto-creates, or DB is optional)
+
+        # Check policy is loaded
+        try:
+            current_policy = deps.policy_manager.current_policy
+            if current_policy is None:
+                reasons.append("no policy loaded")
+        except Exception as exc:
+            reasons.append(f"policy unavailable: {exc}")
+
+        if reasons:
+            return JSONResponse(
+                status_code=503,
+                content={"status": "not_ready", "reasons": reasons},
+            )
+
+        return {"status": "ready"}
 
     # Format HTTPExceptions and validation errors as Anthropic errors on /v1/messages paths
     app.add_exception_handler(FastAPIHTTPException, http_exception_handler)

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -411,9 +411,10 @@ class TestCreateApp:
             response = client.get("/health")
             assert response.status_code == 200
             data = response.json()
-            assert data["status"] == "healthy"
+            assert data["status"] in ("healthy", "degraded")
             assert data["version"] and data["version"] != "unknown"
             assert data["auth_mode"] in ("client_key", "both", "passthrough", None)
+            assert "database" in data
             assert "last_credential_type" in data
             assert "last_credential_at" in data
 
@@ -465,6 +466,104 @@ class TestCreateApp:
             response = client.get("/health")
             assert response.json()["auth_mode"] == "passthrough"
 
+    def test_health_reports_db_connected(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Health endpoint reports database=connected when DB ping succeeds."""
+        mock_redis_client.get = AsyncMock(return_value=None)
+        # Custom mock pool: fetchval=1 for health ping, fetchrow=None so
+        # PolicyManager falls back to file-based policy loading during startup.
+        mock_pool = AsyncMock()
+        mock_pool.fetchval = AsyncMock(return_value=1)
+        mock_pool.fetchrow = AsyncMock(return_value=None)
+        mock_pool.fetch = AsyncMock(return_value=[])
+        mock_db_pool.get_pool = AsyncMock(return_value=mock_pool)
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            response = client.get("/health")
+            data = response.json()
+            assert data["status"] == "healthy"
+            assert data["database"] == "connected"
+            assert "database_error" not in data
+
+    def test_health_reports_db_unreachable(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Health endpoint reports database=unreachable when DB ping fails."""
+        mock_redis_client.get = AsyncMock(return_value=None)
+        # Start with working DB so app initializes, then break it
+        mock_pool = AsyncMock()
+        mock_pool.fetchval = AsyncMock(return_value=1)
+        mock_pool.fetchrow = AsyncMock(return_value=None)
+        mock_pool.fetch = AsyncMock(return_value=[])
+        mock_db_pool.get_pool = AsyncMock(return_value=mock_pool)
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            # Now make DB unreachable for the health check
+            mock_db_pool.get_pool = AsyncMock(side_effect=ConnectionRefusedError("Connection refused"))
+            response = client.get("/health")
+            assert response.status_code == 200  # Liveness probe always 200
+            data = response.json()
+            assert data["status"] == "degraded"
+            assert data["database"] == "unreachable"
+            assert "database_error" in data
+
+    def test_ready_returns_200_when_ready(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Readiness probe returns 200 when DB is connected and policy is loaded."""
+        mock_redis_client.get = AsyncMock(return_value=None)
+        mock_pool = AsyncMock()
+        mock_pool.fetchval = AsyncMock(return_value=1)
+        mock_pool.fetchrow = AsyncMock(return_value=None)
+        mock_pool.fetch = AsyncMock(return_value=[])
+        mock_db_pool.get_pool = AsyncMock(return_value=mock_pool)
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            response = client.get("/ready")
+            assert response.status_code == 200
+            assert response.json()["status"] == "ready"
+
+    def test_ready_returns_503_when_db_unreachable(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Readiness probe returns 503 when DB is unreachable."""
+        mock_redis_client.get = AsyncMock(return_value=None)
+        # Start with working DB so app initializes, then break it
+        mock_pool = AsyncMock()
+        mock_pool.fetchval = AsyncMock(return_value=1)
+        mock_pool.fetchrow = AsyncMock(return_value=None)
+        mock_pool.fetch = AsyncMock(return_value=[])
+        mock_db_pool.get_pool = AsyncMock(return_value=mock_pool)
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            # Now make DB unreachable for the readiness check
+            mock_db_pool.get_pool = AsyncMock(side_effect=ConnectionRefusedError("Connection refused"))
+            response = client.get("/ready")
+            assert response.status_code == 503
+            data = response.json()
+            assert data["status"] == "not_ready"
+            assert any("database" in r for r in data["reasons"])
     def test_create_app_root_endpoint(self, policy_config_file, mock_db_pool, mock_redis_client):
         """Test root endpoint returns HTML landing page."""
         app = create_app(


### PR DESCRIPTION
## Summary

Two related changes for production deployment health monitoring:

1. **`/health` now reports database connectivity** (liveness probe)
2. **New `/ready` endpoint** for readiness probes

Resolves #552, resolves #553

## /health changes

The health endpoint now pings the database via `SELECT 1` and reports connectivity status:

```json
// DB connected
{"status": "healthy", "database": "connected", "version": "...", "auth_mode": "both"}

// DB unreachable
{"status": "degraded", "database": "unreachable", "database_error": "Connection refused", "version": "...", "auth_mode": "both"}

// No DB configured
{"status": "healthy", "database": "not_configured", "version": "...", "auth_mode": "both"}
```

**Always returns HTTP 200** — this is a liveness probe. The process is alive even if the DB is temporarily unreachable. The `status` field distinguishes healthy from degraded.

Existing fields (`version`, `auth_mode`, `last_credential_type`, `last_credential_at`) are preserved — no breaking changes for ALB health check consumers.

## /ready endpoint (new)

Readiness probe that returns HTTP 200 only when the gateway is fully ready to serve traffic:

```json
// Ready
{"status": "ready"}

// Not ready
{"status": "not_ready", "reasons": ["database unreachable: Connection refused"]}
```

Checks:
- Database connected (if configured)
- Policy loaded (PolicyManager has a current policy)

Returns **HTTP 503** when not ready, so load balancers (ALB, ECS, k8s) stop routing traffic until the gateway can handle requests.

## Why this matters

Without these changes, `/health` returns `{"status": "healthy"}` immediately on startup before migrations have run or the DB is connected. Load balancers route traffic → requests fail. The `/ready` endpoint closes this race condition.

## Tests

4 new tests (1941 total, all passing):
- `test_health_reports_db_connected` — DB ping succeeds → healthy + connected
- `test_health_reports_db_unreachable` — app starts with DB, DB goes down → degraded + unreachable (HTTP 200)
- `test_ready_returns_200_when_ready` — DB connected + policy loaded → 200
- `test_ready_returns_503_when_db_unreachable` — app starts, DB goes down → 503 + reasons

```
1941 passed, 7 warnings in 18.62s
```