### PR TITLE
fix(history): strip policy-context from session preview message

### DIFF
--- a/src/luthien_proxy/history/service.py
+++ b/src/luthien_proxy/history/service.py
@@ -289,12 +289,18 @@ _FIRST_MESSAGE_MAX_LENGTH = 100
 # Pattern to strip system-reminder tags from content
 _SYSTEM_REMINDER_PATTERN = re.compile(r"<system-reminder>.*?</system-reminder>\s*", re.DOTALL)
 
+# Pattern to strip policy-context tags injected by inject_policy_awareness_anthropic.
+# These are prepended to the first user message and must be removed so the preview
+# shows the actual user intent rather than the policy awareness boilerplate.
+_POLICY_CONTEXT_PATTERN = re.compile(r"<policy-context>.*?</policy-context>\s*", re.DOTALL)
+
 
 def _extract_preview_message(payload: dict[str, Any] | str | None) -> str | None:
     """Extract the first meaningful user message from a request payload for preview.
 
     Used to generate a session preview/title. Returns truncated text.
-    Skips system-reminders and other non-meaningful content to find actual user intent.
+    Skips system-reminders, policy-context injections, and other non-meaningful
+    content to find actual user intent.
     """
     if not payload:
         return None
@@ -330,9 +336,13 @@ def _extract_preview_message(payload: dict[str, Any] | str | None) -> str | None
             if content:
                 # Truncate and clean up for display
                 content = content.strip()
-                # Skip system-reminder tags (Claude Code injects these)
+                # Strip system-reminder tags (Claude Code injects these)
                 if content.startswith("<system-reminder>"):
                     content = _SYSTEM_REMINDER_PATTERN.sub("", content).strip()
+                # Strip policy-context tags (inject_policy_awareness_anthropic prepends these
+                # to the first user message when active policies modify LLM output)
+                if "<policy-context>" in content:
+                    content = _POLICY_CONTEXT_PATTERN.sub("", content).strip()
                 if not content:
                     continue
                 # Replace newlines with spaces for single-line preview

--- a/tests/luthien_proxy/unit_tests/history/test_service.py
+++ b/tests/luthien_proxy/unit_tests/history/test_service.py
@@ -162,6 +162,84 @@ class TestExtractPreviewMessage:
         }
         assert _extract_preview_message(payload) == "Hello"
 
+    def test_strips_policy_context_string_prefix(self):
+        """Test that policy-context injected as string prefix is stripped.
+
+        When inject_policy_context is enabled, the policy awareness text is
+        prepended to the first user message as a string prefix. The preview
+        should show the actual user content, not the policy-context tag.
+        """
+        policy_context = (
+            "<policy-context>Your responses may be modified by the following active "
+            "policies before reaching the user: TestPolicy. This is expected "
+            "behavior — do not try to compensate for or reverse these modifications."
+            "</policy-context>"
+        )
+        user_message = "What is the capital of France?"
+        content = f"{policy_context}\n\n{user_message}"
+        payload = {"final_request": {"messages": [{"role": "user", "content": content}]}}
+        assert _extract_preview_message(payload) == user_message
+
+    def test_strips_policy_context_block_prefix(self):
+        """Test that policy-context injected as first content block is stripped.
+
+        When the user message content is a list of blocks, the policy awareness
+        text is prepended as the first text block. The preview should show the
+        actual user content from subsequent blocks.
+        """
+        policy_context = (
+            "<policy-context>Your responses may be modified by the following active "
+            "policies before reaching the user: TestPolicy. This is expected "
+            "behavior — do not try to compensate for or reverse these modifications."
+            "</policy-context>"
+        )
+        user_message = "What is the capital of France?"
+        content = [
+            {"type": "text", "text": policy_context},
+            {"type": "text", "text": user_message},
+        ]
+        payload = {"final_request": {"messages": [{"role": "user", "content": content}]}}
+        assert _extract_preview_message(payload) == user_message
+
+    def test_strips_policy_context_only_content_falls_through_to_next_message(self):
+        """Test that if policy-context is the only content, we fall through to next user message."""
+        policy_context = (
+            "<policy-context>Your responses may be modified by the following active "
+            "policies before reaching the user: TestPolicy. This is expected "
+            "behavior — do not try to compensate for or reverse these modifications."
+            "</policy-context>"
+        )
+        payload = {
+            "final_request": {
+                "messages": [
+                    {"role": "user", "content": policy_context},
+                    {"role": "assistant", "content": "Paris."},
+                    {"role": "user", "content": "Follow-up question"},
+                ]
+            }
+        }
+        assert _extract_preview_message(payload) == "Follow-up question"
+
+    def test_strips_policy_context_multiple_policies(self):
+        """Test stripping policy-context with multiple policy names."""
+        policy_context = (
+            "<policy-context>Your responses may be modified by the following active "
+            "policies before reaching the user: PolicyA, PolicyB, PolicyC. This is expected "
+            "behavior — do not try to compensate for or reverse these modifications."
+            "</policy-context>"
+        )
+        user_message = "Tell me a joke"
+        content = f"{policy_context}\n\n{user_message}"
+        payload = {"final_request": {"messages": [{"role": "user", "content": content}]}}
+        assert _extract_preview_message(payload) == user_message
+
+    def test_no_policy_context_unaffected(self):
+        """Test that messages without policy-context are unaffected by the fix."""
+        payload = {
+            "final_request": {"messages": [{"role": "user", "content": "Normal message without policy context"}]}
+        }
+        assert _extract_preview_message(payload) == "Normal message without policy context"
+
 
 class TestSafeParseJson:
     """Test safe JSON parsing."""


### PR DESCRIPTION
Closes #559

## Summary

When `inject_policy_awareness_anthropic` is enabled, the policy-context tag is prepended to the first user message content. This caused the `/history` session list to show the policy boilerplate as the session preview instead of the actual user message — making every session look identical.

**Root cause:** `_extract_preview_message` in `history/service.py` returned the first user message content verbatim, which included the `<policy-context>...</policy-context>` prefix injected by `inject_policy_awareness_anthropic`.

**Fix:** Added `_POLICY_CONTEXT_PATTERN` regex (analogous to the existing `_SYSTEM_REMINDER_PATTERN`) and strip it from content before returning the preview. After stripping, the actual user content is returned. If the entire content was policy-context (edge case), the loop continues to the next user message.

**Tests:** 5 new cases in `TestExtractPreviewMessage`:
- String prefix stripping (most common case)
- Block prefix stripping (list content format)
- Fallthrough when content is only policy-context
- Multiple policy names in context
- Regression: normal messages unaffected