### PR TITLE
feat: webhook event export for completed conversations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,18 @@
 # TELEMETRY_ENDPOINT=https://telemetry.luthien.cc/v1/events
 
 
+# === WEBHOOK =====================================================
+
+# Endpoint URL to POST conversation completion events to (leave empty to disable)
+# WEBHOOK_URL=
+
+# Number of retry attempts for failed webhook deliveries
+# WEBHOOK_MAX_RETRIES=3
+
+# Base delay in seconds between webhook retry attempts (doubles each retry)
+# WEBHOOK_RETRY_DELAY_SECONDS=1.0
+
+
 # === SENTRY ======================================================
 
 # Enable Sentry error tracking

--- a/src/luthien_proxy/config_fields.py
+++ b/src/luthien_proxy/config_fields.py
@@ -237,6 +237,23 @@ CONFIG_FIELDS: tuple[ConfigFieldMeta, ...] = (
         category="telemetry",
     ),
 
+    # ── webhook ───────────────────────────────────────────────────────────
+    ConfigFieldMeta(
+        "webhook_url", "WEBHOOK_URL", str, "",
+        "Endpoint URL to POST conversation completion events to (leave empty to disable)",
+        category="webhook",
+    ),
+    ConfigFieldMeta(
+        "webhook_max_retries", "WEBHOOK_MAX_RETRIES", int, 3,
+        "Number of retry attempts for failed webhook deliveries",
+        category="webhook",
+    ),
+    ConfigFieldMeta(
+        "webhook_retry_delay_seconds", "WEBHOOK_RETRY_DELAY_SECONDS", float, 1.0,
+        "Base delay in seconds between webhook retry attempts (doubles each retry)",
+        category="webhook",
+    ),
+
     # ── sentry ────────────────────────────────────────────────────────────
     ConfigFieldMeta(
         "sentry_enabled", "SENTRY_ENABLED", bool, False,
@@ -275,6 +292,7 @@ CONFIG_CATEGORIES: tuple[str, ...] = (
     "security",
     "observability",
     "telemetry",
+    "webhook",
     "sentry",
 )
 

--- a/src/luthien_proxy/dependencies.py
+++ b/src/luthien_proxy/dependencies.py
@@ -19,6 +19,7 @@ from luthien_proxy.policy_core.anthropic_execution_interface import (
 from luthien_proxy.policy_manager import PolicyManager
 from luthien_proxy.usage_telemetry.collector import UsageCollector
 from luthien_proxy.utils import db
+from luthien_proxy.webhook.sender import WebhookSender
 
 
 @dataclass
@@ -43,6 +44,7 @@ class Dependencies:
     usage_collector: UsageCollector | None = field(default=None)
     config_registry: ConfigRegistry | None = field(default=None)
     last_credential_info: dict[str, Any] = field(default_factory=dict)
+    webhook_sender: WebhookSender | None = field(default=None)
 
     def get_anthropic_policy(self) -> AnthropicExecutionInterface:
         """Get the current Anthropic policy.
@@ -197,6 +199,11 @@ def get_config_registry(request: Request) -> ConfigRegistry | None:
     return get_dependencies(request).config_registry
 
 
+def get_webhook_sender(request: Request) -> WebhookSender | None:
+    """Get webhook sender from dependencies."""
+    return get_dependencies(request).webhook_sender
+
+
 async def require_config_registry(
     config_registry: ConfigRegistry | None = Depends(get_config_registry),
 ) -> ConfigRegistry:
@@ -232,4 +239,5 @@ __all__ = [
     "get_usage_collector",
     "get_config_registry",
     "require_config_registry",
+    "get_webhook_sender",
 ]

--- a/src/luthien_proxy/gateway_routes.py
+++ b/src/luthien_proxy/gateway_routes.py
@@ -22,6 +22,7 @@ from luthien_proxy.dependencies import (
     get_dependencies,
     get_emitter,
     get_usage_collector,
+    get_webhook_sender,
 )
 from luthien_proxy.llm import anthropic_client_cache
 from luthien_proxy.llm.anthropic_client import AnthropicClient
@@ -32,6 +33,7 @@ from luthien_proxy.policy_core.anthropic_execution_interface import (
 )
 from luthien_proxy.usage_telemetry.collector import UsageCollector
 from luthien_proxy.utils import db
+from luthien_proxy.webhook.sender import WebhookSender
 
 router = APIRouter(tags=["gateway"])
 security = HTTPBearer(auto_error=False)
@@ -186,6 +188,7 @@ async def anthropic_messages(
     db_pool: db.DatabasePool | None = Depends(get_db_pool),
     usage_collector: UsageCollector | None = Depends(get_usage_collector),
     credential_manager: CredentialManager | None = Depends(get_credential_manager),
+    webhook_sender: WebhookSender | None = Depends(get_webhook_sender),
 ):
     """Anthropic Messages API endpoint (native Anthropic path)."""
     anthropic_client, forwarding_credential = client_and_credential
@@ -200,6 +203,7 @@ async def anthropic_messages(
         usage_collector=usage_collector,
         user_credential=forwarding_credential,
         credential_manager=credential_manager,
+        webhook_sender=webhook_sender,
     )
 
 

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -65,6 +65,7 @@ from luthien_proxy.utils.credential_cache import (
 from luthien_proxy.utils.migration_check import check_migrations
 from luthien_proxy.utils.url import sanitize_url_for_logging
 from luthien_proxy.version import PROXY_DISPLAY_VERSION
+from luthien_proxy.webhook.sender import WebhookSender
 
 # Configure OpenTelemetry tracing and logging EARLY (before app creation)
 # This ensures the tracer provider is set up before any spans are created
@@ -280,6 +281,18 @@ def create_app(
         else:
             logger.info("Usage telemetry disabled")
 
+        # Initialize webhook sender
+        _webhook_url = settings.webhook_url or None
+        _webhook_sender = WebhookSender(
+            url=_webhook_url,
+            max_retries=settings.webhook_max_retries,
+            retry_delay_seconds=settings.webhook_retry_delay_seconds,
+        )
+        if _webhook_sender.enabled:
+            logger.info("Webhook event export enabled (url=%s)", _webhook_url)
+        else:
+            logger.info("Webhook event export disabled (set WEBHOOK_URL to enable)")
+
         # Create Dependencies container with all services
         _dependencies = Dependencies(
             db_pool=db_pool,
@@ -294,6 +307,7 @@ def create_app(
             enable_request_logging=_enable_request_logging,
             usage_collector=_usage_collector,
             config_registry=_config_registry,
+            webhook_sender=_webhook_sender,
         )
 
         # Store dependencies container in app state

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import time
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Literal, TypedDict, TypeGuard, cast
@@ -69,6 +70,7 @@ from luthien_proxy.usage_telemetry.collector import UsageCollector
 from luthien_proxy.utils import db
 from luthien_proxy.utils.constants import MAX_REQUEST_PAYLOAD_BYTES
 from luthien_proxy.utils.policy_cache import PolicyCache
+from luthien_proxy.webhook.sender import WebhookSender
 
 
 class _ErrorDetail(TypedDict):
@@ -330,6 +332,7 @@ async def process_anthropic_request(
     usage_collector: UsageCollector | None = None,
     user_credential: Credential | None = None,
     credential_manager: CredentialManager | None = None,
+    webhook_sender: WebhookSender | None = None,
 ) -> FastAPIStreamingResponse | JSONResponse:
     """Process an Anthropic API request through the native pipeline.
 
@@ -345,6 +348,7 @@ async def process_anthropic_request(
         usage_collector: Optional usage telemetry collector for counting requests
         user_credential: The credential extracted from the incoming request
         credential_manager: Shared credential manager for auth provider resolution
+        webhook_sender: Optional webhook sender for conversation completion events
 
     Returns:
         StreamingResponse or JSONResponse depending on stream parameter
@@ -357,6 +361,7 @@ async def process_anthropic_request(
         raise TypeError(f"Policy must implement AnthropicExecutionInterface, got {type(policy).__name__}.")
 
     call_id = str(uuid.uuid4())
+    request_start_time = time.monotonic()
     request_log_recorder = create_recorder(db_pool, call_id, enable_request_logging)
 
     if usage_collector:
@@ -437,6 +442,8 @@ async def process_anthropic_request(
             request_log_recorder=request_log_recorder,
             extra_headers=forwarded_headers,
             usage_collector=usage_collector,
+            webhook_sender=webhook_sender,
+            request_start_time=request_start_time,
         )
 
         # Propagate policy summaries if set
@@ -557,6 +564,8 @@ async def _execute_anthropic_policy(
     request_log_recorder: RequestLogRecorder,
     extra_headers: dict[str, str] | None = None,
     usage_collector: UsageCollector | None = None,
+    webhook_sender: WebhookSender | None = None,
+    request_start_time: float | None = None,
 ) -> FastAPIStreamingResponse | JSONResponse:
     """Execute an Anthropic policy using the hook-based runtime."""
     io = _AnthropicPolicyIO(
@@ -581,6 +590,8 @@ async def _execute_anthropic_policy(
             request_log_recorder=request_log_recorder,
             emitter=emitter,
             usage_collector=usage_collector,
+            webhook_sender=webhook_sender,
+            request_start_time=request_start_time,
         )
 
     return await _handle_execution_non_streaming(
@@ -591,6 +602,8 @@ async def _execute_anthropic_policy(
         call_id=call_id,
         request_log_recorder=request_log_recorder,
         usage_collector=usage_collector,
+        webhook_sender=webhook_sender,
+        request_start_time=request_start_time,
     )
 
 
@@ -603,6 +616,8 @@ async def _handle_execution_streaming(
     request_log_recorder: RequestLogRecorder,
     emitter: EventEmitterProtocol,
     usage_collector: UsageCollector | None = None,
+    webhook_sender: WebhookSender | None = None,
+    request_start_time: float | None = None,
 ) -> FastAPIStreamingResponse:
     """Handle streaming response flow for execution-oriented policies."""
     parent_context = get_current()
@@ -734,6 +749,23 @@ async def _handle_execution_streaming(
                                 input_tokens=usage.get("input_tokens", 0),
                                 output_tokens=usage.get("output_tokens", 0),
                             )
+                    if webhook_sender and webhook_sender.enabled and final_status == 200:
+                        _input_tokens = 0
+                        _output_tokens = 0
+                        if reconstructed is not None and "usage" in reconstructed:
+                            _usage = reconstructed["usage"]
+                            _input_tokens = _usage.get("input_tokens", 0)
+                            _output_tokens = _usage.get("output_tokens", 0)
+                        _duration_ms = int((time.monotonic() - request_start_time) * 1000) if request_start_time else 0
+                        webhook_sender.fire_and_forget(
+                            session_id=policy_ctx.session_id,
+                            transaction_id=call_id,
+                            model=io.request.get("model", "unknown"),
+                            input_tokens=_input_tokens,
+                            output_tokens=_output_tokens,
+                            duration_ms=_duration_ms,
+                            is_streaming=True,
+                        )
 
     return FastAPIStreamingResponse(
         streaming_with_spans(),
@@ -754,6 +786,8 @@ async def _handle_execution_non_streaming(
     call_id: str,
     request_log_recorder: RequestLogRecorder,
     usage_collector: UsageCollector | None = None,
+    webhook_sender: WebhookSender | None = None,
+    request_start_time: float | None = None,
 ) -> JSONResponse:
     """Handle non-streaming response flow for execution-oriented policies."""
     final_response: AnthropicResponse | None = None
@@ -834,6 +868,19 @@ async def _handle_execution_non_streaming(
                     input_tokens=usage.get("input_tokens", 0),
                     output_tokens=usage.get("output_tokens", 0),
                 )
+
+        if webhook_sender and webhook_sender.enabled:
+            _ns_usage = final_response.get("usage") or {}
+            _duration_ms = int((time.monotonic() - request_start_time) * 1000) if request_start_time else 0
+            webhook_sender.fire_and_forget(
+                session_id=policy_ctx.session_id,
+                transaction_id=call_id,
+                model=final_response.get("model") or io.request.get("model", "unknown"),
+                input_tokens=_ns_usage.get("input_tokens", 0),
+                output_tokens=_ns_usage.get("output_tokens", 0),
+                duration_ms=_duration_ms,
+                is_streaming=False,
+            )
 
         return JSONResponse(
             content=final_response_payload,

--- a/src/luthien_proxy/settings.py
+++ b/src/luthien_proxy/settings.py
@@ -101,6 +101,11 @@ class Settings(_SettingsBase):
     usage_telemetry: bool | None = None
     telemetry_endpoint: str = "https://telemetry.luthien.cc/v1/events"
 
+    # ── webhook ─────────────────────────────────────────────────────
+    webhook_url: str = ""
+    webhook_max_retries: int = 3
+    webhook_retry_delay_seconds: float = 1.0
+
     # ── sentry ──────────────────────────────────────────────────────
     sentry_enabled: bool = False
     sentry_dsn: str = ""

--- a/src/luthien_proxy/webhook/__init__.py
+++ b/src/luthien_proxy/webhook/__init__.py
@@ -1,0 +1,1 @@
+"""Webhook event export for completed conversations."""

--- a/src/luthien_proxy/webhook/sender.py
+++ b/src/luthien_proxy/webhook/sender.py
@@ -1,0 +1,221 @@
+"""Webhook sender for conversation completion events.
+
+Fires a POST request to a configurable endpoint when a conversation completes.
+Supports exponential-backoff retry logic for failed deliveries.
+Failures are logged and discarded — never block the response path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import TypedDict
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+SEND_TIMEOUT_SECONDS = 10
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_RETRY_DELAY_SECONDS = 1.0
+
+
+class _UsageCounts(TypedDict):
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+
+
+class ConversationCompletedPayload(TypedDict):
+    """Payload sent to the webhook endpoint on conversation completion."""
+
+    session_id: str | None
+    transaction_id: str
+    model: str
+    usage: _UsageCounts
+    duration_ms: int
+    is_streaming: bool
+    timestamp: str
+
+
+def build_payload(
+    *,
+    session_id: str | None,
+    transaction_id: str,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    duration_ms: int,
+    is_streaming: bool,
+) -> ConversationCompletedPayload:
+    """Build the JSON payload for a conversation completion webhook.
+
+    Args:
+        session_id: Session identifier (from metadata.user_id or x-session-id header).
+        transaction_id: Unique transaction/call ID for this request.
+        model: Model name used for the conversation.
+        input_tokens: Number of input tokens consumed.
+        output_tokens: Number of output tokens generated.
+        duration_ms: Total request duration in milliseconds.
+        is_streaming: Whether the response was streamed.
+
+    Returns:
+        Typed payload dict ready for JSON serialisation.
+    """
+    return ConversationCompletedPayload(
+        session_id=session_id,
+        transaction_id=transaction_id,
+        model=model,
+        usage=_UsageCounts(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=input_tokens + output_tokens,
+        ),
+        duration_ms=duration_ms,
+        is_streaming=is_streaming,
+        timestamp=datetime.now(UTC).isoformat(),
+    )
+
+
+class WebhookSender:
+    """Fire-and-forget webhook delivery with retry logic.
+
+    Instances are singletons created at startup. The ``fire_and_forget`` method
+    dispatches a background asyncio task so the response path is never blocked.
+
+    Args:
+        url: Webhook endpoint URL. If ``None`` or empty, the sender is disabled.
+        max_retries: Number of retry attempts after the initial failure (default 3).
+        retry_delay_seconds: Base delay between retries in seconds (default 1.0).
+            Each retry doubles the delay (exponential backoff).
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str | None,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        retry_delay_seconds: float = DEFAULT_RETRY_DELAY_SECONDS,
+    ) -> None:
+        """Initialize the webhook sender.
+
+        Args:
+            url: Webhook endpoint URL. If ``None`` or empty, the sender is disabled.
+            max_retries: Number of retry attempts after the initial failure.
+            retry_delay_seconds: Base delay between retries in seconds.
+        """
+        self._url = url or None
+        self._max_retries = max_retries
+        self._retry_delay_seconds = retry_delay_seconds
+
+    @property
+    def enabled(self) -> bool:
+        """True if a webhook URL is configured."""
+        return bool(self._url)
+
+    async def _attempt_send(self, payload: ConversationCompletedPayload) -> bool:
+        """Attempt a single POST delivery.
+
+        Args:
+            payload: Conversation completion payload to send.
+
+        Returns:
+            True on success (2xx response), False on any failure.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=SEND_TIMEOUT_SECONDS) as client:
+                response = await client.post(self._url, json=dict(payload))  # type: ignore[arg-type]
+                if response.status_code >= 400:
+                    logger.warning(
+                        "Webhook delivery failed: HTTP %d from %s",
+                        response.status_code,
+                        self._url,
+                    )
+                    return False
+                return True
+        except Exception:
+            logger.warning("Webhook delivery error to %s", self._url, exc_info=True)
+            return False
+
+    async def _send_with_retries(self, payload: ConversationCompletedPayload) -> None:
+        """Deliver payload with exponential-backoff retries.
+
+        Attempts delivery up to ``1 + max_retries`` times total. Failures after
+        all retries are logged and silently discarded.
+
+        Args:
+            payload: Conversation completion payload to send.
+        """
+        delay = self._retry_delay_seconds
+        for attempt in range(1 + self._max_retries):
+            try:
+                success = await self._attempt_send(payload)
+            except Exception:
+                logger.error(
+                    "Unexpected error in webhook delivery (attempt %d/%d)",
+                    attempt + 1,
+                    1 + self._max_retries,
+                    exc_info=True,
+                )
+                success = False
+
+            if success:
+                if attempt > 0:
+                    logger.info("Webhook delivered successfully on attempt %d", attempt + 1)
+                return
+
+            if attempt < self._max_retries:
+                logger.debug(
+                    "Webhook delivery attempt %d/%d failed, retrying in %.1fs",
+                    attempt + 1,
+                    1 + self._max_retries,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2  # Exponential backoff
+
+        logger.error(
+            "Webhook delivery to %s failed after %d attempts — giving up",
+            self._url,
+            1 + self._max_retries,
+        )
+
+    def fire_and_forget(
+        self,
+        *,
+        session_id: str | None,
+        transaction_id: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        duration_ms: int,
+        is_streaming: bool,
+    ) -> None:
+        """Dispatch a webhook delivery as a background task.
+
+        Returns immediately — never blocks the response path. If the sender is
+        disabled (no URL configured), this is a no-op.
+
+        Args:
+            session_id: Session identifier.
+            transaction_id: Unique transaction ID.
+            model: Model name.
+            input_tokens: Input token count.
+            output_tokens: Output token count.
+            duration_ms: Request duration in milliseconds.
+            is_streaming: Whether the response was streamed.
+        """
+        if not self.enabled:
+            return
+
+        payload = build_payload(
+            session_id=session_id,
+            transaction_id=transaction_id,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            duration_ms=duration_ms,
+            is_streaming=is_streaming,
+        )
+        asyncio.create_task(self._send_with_retries(payload))

--- a/tests/luthien_proxy/unit_tests/webhook/test_sender.py
+++ b/tests/luthien_proxy/unit_tests/webhook/test_sender.py
@@ -1,0 +1,280 @@
+"""Tests for webhook sender module."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from luthien_proxy.webhook.sender import (
+    ConversationCompletedPayload,
+    WebhookSender,
+    build_payload,
+)
+
+# ── Payload builder tests ──────────────────────────────────────────────────────
+
+
+def test_build_payload_non_streaming():
+    """build_payload returns correct structure for non-streaming response."""
+    payload = build_payload(
+        session_id="sess-123",
+        transaction_id="txn-abc",
+        model="claude-3-5-sonnet-20241022",
+        input_tokens=100,
+        output_tokens=50,
+        duration_ms=1234,
+        is_streaming=False,
+    )
+    assert payload["session_id"] == "sess-123"
+    assert payload["transaction_id"] == "txn-abc"
+    assert payload["model"] == "claude-3-5-sonnet-20241022"
+    assert payload["usage"]["input_tokens"] == 100
+    assert payload["usage"]["output_tokens"] == 50
+    assert payload["usage"]["total_tokens"] == 150
+    assert payload["duration_ms"] == 1234
+    assert payload["is_streaming"] is False
+    assert "timestamp" in payload
+
+
+def test_build_payload_streaming():
+    """build_payload marks streaming correctly."""
+    payload = build_payload(
+        session_id=None,
+        transaction_id="txn-xyz",
+        model="claude-opus-4-5",
+        input_tokens=200,
+        output_tokens=300,
+        duration_ms=5000,
+        is_streaming=True,
+    )
+    assert payload["session_id"] is None
+    assert payload["is_streaming"] is True
+    assert payload["usage"]["total_tokens"] == 500
+
+
+def test_build_payload_zero_tokens():
+    """build_payload handles zero token counts."""
+    payload = build_payload(
+        session_id="s",
+        transaction_id="t",
+        model="m",
+        input_tokens=0,
+        output_tokens=0,
+        duration_ms=0,
+        is_streaming=False,
+    )
+    assert payload["usage"]["total_tokens"] == 0
+
+
+# ── WebhookSender tests ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def sender():
+    return WebhookSender(url="https://example.com/webhook")
+
+
+@pytest.fixture
+def sender_with_retries():
+    return WebhookSender(url="https://example.com/webhook", max_retries=3, retry_delay_seconds=0.01)
+
+
+@pytest.mark.asyncio
+async def test_send_success(sender):
+    """Successful delivery returns True and makes one POST."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        payload: ConversationCompletedPayload = {
+            "session_id": "s",
+            "transaction_id": "t",
+            "model": "m",
+            "usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+            "duration_ms": 100,
+            "is_streaming": False,
+            "timestamp": "2026-01-01T00:00:00+00:00",
+        }
+        result = await sender._attempt_send(payload)
+        assert result is True
+        mock_client.post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_http_error_returns_false(sender):
+    """4xx/5xx response returns False (will be retried)."""
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_client
+
+        payload: ConversationCompletedPayload = {
+            "session_id": None,
+            "transaction_id": "t",
+            "model": "m",
+            "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            "duration_ms": 0,
+            "is_streaming": False,
+            "timestamp": "2026-01-01T00:00:00+00:00",
+        }
+        result = await sender._attempt_send(payload)
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_send_network_error_returns_false(sender):
+    """Network errors return False (will be retried)."""
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+        mock_client_cls.return_value = mock_client
+
+        payload: ConversationCompletedPayload = {
+            "session_id": None,
+            "transaction_id": "t",
+            "model": "m",
+            "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            "duration_ms": 0,
+            "is_streaming": False,
+            "timestamp": "2026-01-01T00:00:00+00:00",
+        }
+        result = await sender._attempt_send(payload)
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_success(sender):
+    """fire_and_forget dispatches a background task that succeeds."""
+    with patch.object(sender, "_attempt_send", new_callable=AsyncMock) as mock_send:
+        mock_send.return_value = True
+        sender.fire_and_forget(
+            session_id="s",
+            transaction_id="t",
+            model="m",
+            input_tokens=10,
+            output_tokens=20,
+            duration_ms=500,
+            is_streaming=False,
+        )
+        # Allow the background task to run
+        await asyncio.sleep(0.05)
+        mock_send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_retries_on_failure(sender_with_retries):
+    """fire_and_forget retries up to max_retries on failure."""
+    call_count = 0
+
+    async def fail_twice_then_succeed(payload):
+        nonlocal call_count
+        call_count += 1
+        return call_count >= 3  # Fail first 2, succeed on 3rd
+
+    with patch.object(sender_with_retries, "_attempt_send", side_effect=fail_twice_then_succeed):
+        sender_with_retries.fire_and_forget(
+            session_id="s",
+            transaction_id="t",
+            model="m",
+            input_tokens=10,
+            output_tokens=20,
+            duration_ms=500,
+            is_streaming=False,
+        )
+        await asyncio.sleep(0.5)
+        assert call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_gives_up_after_max_retries(sender_with_retries):
+    """fire_and_forget stops after max_retries exhausted."""
+    call_count = 0
+
+    async def always_fail(payload):
+        nonlocal call_count
+        call_count += 1
+        return False
+
+    with patch.object(sender_with_retries, "_attempt_send", side_effect=always_fail):
+        sender_with_retries.fire_and_forget(
+            session_id="s",
+            transaction_id="t",
+            model="m",
+            input_tokens=10,
+            output_tokens=20,
+            duration_ms=500,
+            is_streaming=False,
+        )
+        await asyncio.sleep(0.5)
+        # max_retries=3 means 1 initial + 3 retries = 4 total attempts
+        assert call_count == 4
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_no_crash_on_exception(sender):
+    """fire_and_forget does not propagate exceptions to caller."""
+
+    async def raise_exception(payload):
+        raise RuntimeError("unexpected error")
+
+    with patch.object(sender, "_attempt_send", side_effect=raise_exception):
+        # Should not raise
+        sender.fire_and_forget(
+            session_id="s",
+            transaction_id="t",
+            model="m",
+            input_tokens=0,
+            output_tokens=0,
+            duration_ms=0,
+            is_streaming=False,
+        )
+        await asyncio.sleep(0.05)
+
+
+# ── WebhookSender disabled (no URL) ───────────────────────────────────────────
+
+
+def test_sender_disabled_when_no_url():
+    """WebhookSender with no URL is disabled."""
+    sender = WebhookSender(url=None)
+    assert sender.enabled is False
+
+
+def test_sender_enabled_when_url_set():
+    """WebhookSender with URL is enabled."""
+    sender = WebhookSender(url="https://example.com/hook")
+    assert sender.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_noop_when_disabled():
+    """fire_and_forget does nothing when sender is disabled."""
+    sender = WebhookSender(url=None)
+    with patch.object(sender, "_attempt_send", new_callable=AsyncMock) as mock_send:
+        sender.fire_and_forget(
+            session_id="s",
+            transaction_id="t",
+            model="m",
+            input_tokens=0,
+            output_tokens=0,
+            duration_ms=0,
+            is_streaming=False,
+        )
+        await asyncio.sleep(0.05)
+        mock_send.assert_not_called()


### PR DESCRIPTION
## Summary

Closes LuthienResearch/luthien-proxy#560

Adds a fire-and-forget webhook that POSTs a JSON payload to a configurable endpoint whenever a conversation completes (both streaming and non-streaming). This enables push-based integration with analytics pipelines, alerting systems, and audit logs without polling.

## Configuration

| Env Var | Default | Description |
|---------|---------|-------------|
| `WEBHOOK_URL` | *(empty — disabled)* | Endpoint to POST completion events to |
| `WEBHOOK_MAX_RETRIES` | `3` | Retry attempts after initial failure |
| `WEBHOOK_RETRY_DELAY_SECONDS` | `1.0` | Base delay between retries (doubles each retry) |

## Payload

```json
{
  "session_id": "sess-abc123",
  "transaction_id": "txn-uuid",
  "model": "claude-3-5-sonnet-20241022",
  "usage": {
    "input_tokens": 150,
    "output_tokens": 300,
    "total_tokens": 450
  },
  "duration_ms": 1234,
  "is_streaming": false,
  "timestamp": "2026-04-13T04:44:43+00:00"
}
```

## Design

- **Fire-and-forget**: asyncio.create_task() — never blocks the response path
- **Retry logic**: exponential backoff (1s → 2s → 4s → give up), configurable
- **Failure handling**: all failures logged and discarded — no retry storms, no impact on gateway availability
- **Disabled by default**: no-op when WEBHOOK_URL is empty
- **Both response modes**: hooks into both streaming and non-streaming handlers

## Changes

- `src/luthien_proxy/webhook/` — new module: WebhookSender, build_payload, ConversationCompletedPayload
- `src/luthien_proxy/config_fields.py` — 3 new config fields (WEBHOOK_URL, WEBHOOK_MAX_RETRIES, WEBHOOK_RETRY_DELAY_SECONDS)
- `src/luthien_proxy/settings.py` — regenerated
- `.env.example` — regenerated
- `src/luthien_proxy/dependencies.py` — webhook_sender field + get_webhook_sender() dependency
- `src/luthien_proxy/main.py` — WebhookSender initialized in lifespan
- `src/luthien_proxy/gateway_routes.py` — webhook_sender injected via Depends
- `src/luthien_proxy/pipeline/anthropic_processor.py` — webhook_sender + request_start_time threaded through pipeline; fires at conversation completion
- `tests/luthien_proxy/unit_tests/webhook/` — 13 unit tests covering payload builder, send success/failure, retry logic, disabled state

## Test Results

1950 passed, 0 failed. webhook/sender.py: 100% coverage.