### PR TITLE
feat: user identity extraction and storage

### DIFF
--- a/migrations/postgres/014_add_user_id.sql
+++ b/migrations/postgres/014_add_user_id.sql
@@ -1,0 +1,15 @@
+-- ABOUTME: Adds user_id column to conversation_calls and conversation_events
+-- ABOUTME: Enables tracking which user made each request for team deployments
+-- ABOUTME: Extracted from X-Luthien-User-Id header or JWT Bearer token sub claim
+
+-- Add user_id to conversation_calls (one row per API call)
+ALTER TABLE conversation_calls ADD COLUMN IF NOT EXISTS user_id TEXT;
+
+-- Index for filtering calls by user
+CREATE INDEX IF NOT EXISTS idx_conversation_calls_user ON conversation_calls(user_id) WHERE user_id IS NOT NULL;
+
+-- Add user_id to conversation_events (one row per event within a call)
+ALTER TABLE conversation_events ADD COLUMN IF NOT EXISTS user_id TEXT;
+
+-- Index for filtering events by user
+CREATE INDEX IF NOT EXISTS idx_conversation_events_user ON conversation_events(user_id) WHERE user_id IS NOT NULL;

--- a/migrations/sqlite/014_add_user_id.sql
+++ b/migrations/sqlite/014_add_user_id.sql
@@ -1,0 +1,11 @@
+-- ABOUTME: Adds user_id column to conversation_calls and conversation_events
+-- ABOUTME: Enables tracking which user made each request for team deployments
+-- ABOUTME: Extracted from X-Luthien-User-Id header or JWT Bearer token sub claim
+
+-- Add user_id to conversation_calls (one row per API call)
+ALTER TABLE conversation_calls ADD COLUMN user_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_conversation_calls_user ON conversation_calls(user_id) WHERE user_id IS NOT NULL;
+
+-- Add user_id to conversation_events (one row per event within a call)
+ALTER TABLE conversation_events ADD COLUMN user_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_conversation_events_user ON conversation_events(user_id) WHERE user_id IS NOT NULL;

--- a/src/luthien_proxy/history/models.py
+++ b/src/luthien_proxy/history/models.py
@@ -77,6 +77,7 @@ class SessionSummary(BaseModel):
     policy_interventions: int
     models_used: list[str]
     preview_message: str | None = None  # Preview of session (last user message, truncated)
+    user_id: str | None = None  # User identity extracted from X-Luthien-User-Id or JWT sub claim
 
 
 class SessionListResponse(BaseModel):

--- a/src/luthien_proxy/history/routes.py
+++ b/src/luthien_proxy/history/routes.py
@@ -82,14 +82,19 @@ async def list_sessions(
         ge=0,
         description="Number of sessions to skip for pagination",
     ),
+    user_id: str | None = Query(
+        default=None,
+        description="Filter sessions by user identity (from X-Luthien-User-Id header or JWT sub claim)",
+    ),
 ) -> SessionListResponse:
     """List recent sessions with summaries.
 
     Returns a list of session summaries ordered by most recent activity,
     including turn counts, policy interventions, and models used.
     Supports pagination via limit and offset parameters.
+    Optionally filter by user_id to see sessions for a specific user.
     """
-    return await fetch_session_list(limit, db_pool, offset)
+    return await fetch_session_list(limit, db_pool, offset, user_id=user_id)
 
 
 @api_router.get("/sessions/{session_id}", response_model=SessionDetail)

--- a/src/luthien_proxy/history/service.py
+++ b/src/luthien_proxy/history/service.py
@@ -344,49 +344,84 @@ def _extract_preview_message(payload: dict[str, Any] | str | None) -> str | None
     return None
 
 
-async def fetch_session_list(limit: int, db_pool: DatabasePool, offset: int = 0) -> SessionListResponse:
+async def fetch_session_list(
+    limit: int,
+    db_pool: DatabasePool,
+    offset: int = 0,
+    user_id: str | None = None,
+) -> SessionListResponse:
     """Fetch list of recent sessions with summaries.
 
     Args:
         limit: Maximum number of sessions to return
         db_pool: Database connection pool
         offset: Number of sessions to skip for pagination
+        user_id: Optional user identity filter — only return sessions for this user
 
     Returns:
         List of session summaries ordered by most recent activity
     """
     if db_pool.is_sqlite:
-        return await _fetch_session_list_sqlite(limit, db_pool, offset)
-    return await _fetch_session_list_pg(limit, db_pool, offset)
+        return await _fetch_session_list_sqlite(limit, db_pool, offset, user_id=user_id)
+    return await _fetch_session_list_pg(limit, db_pool, offset, user_id=user_id)
 
 
-async def _fetch_session_list_pg(limit: int, db_pool: DatabasePool, offset: int = 0) -> SessionListResponse:
+async def _fetch_session_list_pg(
+    limit: int,
+    db_pool: DatabasePool,
+    offset: int = 0,
+    user_id: str | None = None,
+) -> SessionListResponse:
     """PostgreSQL version using PG-specific features (FILTER, DISTINCT ON, array_agg)."""
-    async with db_pool.connection() as conn:
-        total_count = await conn.fetchval(
-            """
-            SELECT COUNT(DISTINCT session_id)
-            FROM conversation_events
-            WHERE session_id IS NOT NULL
-            """
-        )
+    # Build optional user_id filter clause for conversation_calls join
+    user_filter_clause = "AND cc.user_id = $3" if user_id is not None else ""
+    count_user_filter = "AND cc.user_id = $1" if user_id is not None else ""
 
-        rows = await conn.fetch(
-            """
-            WITH session_stats AS (
-                SELECT
-                    session_id,
-                    MIN(created_at) as first_ts,
-                    MAX(created_at) as last_ts,
-                    COUNT(*) as total_events,
-                    COUNT(DISTINCT call_id) as turn_count,
-                    COUNT(*) FILTER (
-                        WHERE event_type LIKE 'policy.%'
-                        AND event_type NOT LIKE 'policy.judge.evaluation%'
-                    ) as policy_interventions
+    async with db_pool.connection() as conn:
+        if user_id is not None:
+            total_count = await conn.fetchval(
+                f"""
+                SELECT COUNT(DISTINCT ce.session_id)
+                FROM conversation_events ce
+                JOIN conversation_calls cc ON ce.call_id = cc.call_id
+                WHERE ce.session_id IS NOT NULL
+                {count_user_filter}
+                """,
+                user_id,
+            )
+        else:
+            total_count = await conn.fetchval(
+                """
+                SELECT COUNT(DISTINCT session_id)
                 FROM conversation_events
                 WHERE session_id IS NOT NULL
-                GROUP BY session_id
+                """
+            )
+
+        query_args: list = [limit, offset]
+        if user_id is not None:
+            query_args.append(user_id)
+
+        rows = await conn.fetch(
+            f"""
+            WITH session_stats AS (
+                SELECT
+                    ce.session_id,
+                    MIN(ce.created_at) as first_ts,
+                    MAX(ce.created_at) as last_ts,
+                    COUNT(*) as total_events,
+                    COUNT(DISTINCT ce.call_id) as turn_count,
+                    COUNT(*) FILTER (
+                        WHERE ce.event_type LIKE 'policy.%%'
+                        AND ce.event_type NOT LIKE 'policy.judge.evaluation%%'
+                    ) as policy_interventions,
+                    -- Take first non-null user_id across all calls in this session
+                    MIN(cc.user_id) as user_id
+                FROM conversation_events ce
+                LEFT JOIN conversation_calls cc ON ce.call_id = cc.call_id
+                WHERE ce.session_id IS NOT NULL
+                {user_filter_clause}
+                GROUP BY ce.session_id
             ),
             session_models AS (
                 SELECT DISTINCT
@@ -416,6 +451,7 @@ async def _fetch_session_list_pg(limit: int, db_pool: DatabasePool, offset: int 
                 s.total_events,
                 s.turn_count,
                 s.policy_interventions,
+                s.user_id,
                 COALESCE(
                     array_agg(DISTINCT m.model) FILTER (WHERE m.model IS NOT NULL),
                     ARRAY[]::text[]
@@ -426,12 +462,11 @@ async def _fetch_session_list_pg(limit: int, db_pool: DatabasePool, offset: int 
             LEFT JOIN session_first_message f ON s.session_id = f.session_id
             GROUP BY s.session_id, s.first_ts, s.last_ts,
                      s.total_events, s.turn_count, s.policy_interventions,
-                     f.request_payload
+                     s.user_id, f.request_payload
             ORDER BY s.last_ts DESC
             LIMIT $1 OFFSET $2
             """,
-            limit,
-            offset,
+            *query_args,
         )
 
     sessions = [
@@ -444,6 +479,7 @@ async def _fetch_session_list_pg(limit: int, db_pool: DatabasePool, offset: int 
             policy_interventions=int(row["policy_interventions"]),  # type: ignore[arg-type]
             models_used=list(row["models"]) if row["models"] else [],  # type: ignore[arg-type]
             preview_message=_extract_preview_message(cast(_PreviewPayload, row["request_payload"])),
+            user_id=str(row["user_id"]) if row["user_id"] else None,
         )
         for row in rows
     ]
@@ -454,43 +490,70 @@ async def _fetch_session_list_pg(limit: int, db_pool: DatabasePool, offset: int 
     return SessionListResponse(sessions=sessions, total=total, offset=offset, has_more=has_more)
 
 
-async def _fetch_session_list_sqlite(limit: int, db_pool: DatabasePool, offset: int = 0) -> SessionListResponse:
+async def _fetch_session_list_sqlite(
+    limit: int,
+    db_pool: DatabasePool,
+    offset: int = 0,
+    user_id: str | None = None,
+) -> SessionListResponse:
     """SQLite version: 3 queries total (vs PostgreSQL's 2).
 
     Avoids N+1 by batching models and previews for the whole page in one
     query each, then merging in Python. PostgreSQL uses array_agg/DISTINCT ON
     in a single CTE; SQLite lacks those, so we use IN (session_ids) instead.
     """
+    # Build optional user_id filter clause for conversation_calls join
+    user_filter_clause = "AND cc.user_id = $3" if user_id is not None else ""
+    count_user_filter = "AND cc.user_id = $1" if user_id is not None else ""
+
     async with db_pool.connection() as conn:
-        total_count = await conn.fetchval(
-            """
-            SELECT COUNT(DISTINCT session_id)
-            FROM conversation_events
-            WHERE session_id IS NOT NULL
-            """
-        )
+        if user_id is not None:
+            total_count = await conn.fetchval(
+                f"""
+                SELECT COUNT(DISTINCT ce.session_id)
+                FROM conversation_events ce
+                JOIN conversation_calls cc ON ce.call_id = cc.call_id
+                WHERE ce.session_id IS NOT NULL
+                {count_user_filter}
+                """,
+                user_id,
+            )
+        else:
+            total_count = await conn.fetchval(
+                """
+                SELECT COUNT(DISTINCT session_id)
+                FROM conversation_events
+                WHERE session_id IS NOT NULL
+                """
+            )
+
+        query_args: list = [limit, offset]
+        if user_id is not None:
+            query_args.append(user_id)
 
         rows = await conn.fetch(
-            """
+            f"""
             SELECT
-                session_id,
-                MIN(created_at) as first_ts,
-                MAX(created_at) as last_ts,
+                ce.session_id,
+                MIN(ce.created_at) as first_ts,
+                MAX(ce.created_at) as last_ts,
                 COUNT(*) as total_events,
-                COUNT(DISTINCT call_id) as turn_count,
+                COUNT(DISTINCT ce.call_id) as turn_count,
                 SUM(CASE
-                    WHEN event_type LIKE 'policy.%'
-                    AND event_type NOT LIKE 'policy.judge.evaluation%'
+                    WHEN ce.event_type LIKE 'policy.%'
+                    AND ce.event_type NOT LIKE 'policy.judge.evaluation%'
                     THEN 1 ELSE 0
-                END) as policy_interventions
-            FROM conversation_events
-            WHERE session_id IS NOT NULL
-            GROUP BY session_id
+                END) as policy_interventions,
+                MIN(cc.user_id) as user_id
+            FROM conversation_events ce
+            LEFT JOIN conversation_calls cc ON ce.call_id = cc.call_id
+            WHERE ce.session_id IS NOT NULL
+            {user_filter_clause}
+            GROUP BY ce.session_id
             ORDER BY last_ts DESC
             LIMIT $1 OFFSET $2
             """,
-            limit,
-            offset,
+            *query_args,
         )
 
         total = int(total_count) if total_count is not None else 0  # type: ignore[arg-type]
@@ -554,6 +617,7 @@ async def _fetch_session_list_sqlite(limit: int, db_pool: DatabasePool, offset: 
             policy_interventions=int(row["policy_interventions"]),  # type: ignore[arg-type]
             models_used=models_by_session.get(str(row["session_id"]), []),
             preview_message=preview_by_session.get(str(row["session_id"])),
+            user_id=str(row["user_id"]) if row["user_id"] else None,
         )
         for row in rows
     ]

--- a/src/luthien_proxy/observability/emitter.py
+++ b/src/luthien_proxy/observability/emitter.py
@@ -228,43 +228,47 @@ class EventEmitter:
     ) -> None:
         """Write event to PostgreSQL.
 
-        Session ID Propagation Convention:
-            The session_id is extracted from the event data dict if present.
-            Callers (e.g., processor.py) should include {"session_id": value}
-            in their event data to persist the session_id to the database.
-            This convention allows session tracking without modifying the
+        Session ID and User ID Propagation Convention:
+            The session_id and user_id are extracted from the event data dict if present.
+            Callers (e.g., processor.py) should include {"session_id": value, "user_id": value}
+            in their event data to persist these fields to the database.
+            This convention allows session and user tracking without modifying the
             EventEmitter interface.
         """
         db_pool = cast(DatabasePool, self._db_pool)
-        # Extract session_id from data if present (set by processor via convention above)
+        # Extract session_id and user_id from data if present (set by processor via convention above)
         session_id = data.get("session_id") if isinstance(data, dict) else None
+        user_id = data.get("user_id") if isinstance(data, dict) else None
 
         try:
             async with db_pool.connection() as conn:
-                # Ensure call row exists with session_id
+                # Ensure call row exists with session_id and user_id
                 await conn.execute(
                     """
-                    INSERT INTO conversation_calls (call_id, created_at, session_id)
-                    VALUES ($1, $2, $3)
+                    INSERT INTO conversation_calls (call_id, created_at, session_id, user_id)
+                    VALUES ($1, $2, $3, $4)
                     ON CONFLICT (call_id) DO UPDATE SET
-                        session_id = COALESCE(conversation_calls.session_id, EXCLUDED.session_id)
+                        session_id = COALESCE(conversation_calls.session_id, EXCLUDED.session_id),
+                        user_id = COALESCE(conversation_calls.user_id, EXCLUDED.user_id)
                     """,
                     transaction_id,
                     timestamp,
                     session_id,
+                    user_id,
                 )
 
-                # Insert event with session_id, ordering by created_at
+                # Insert event with session_id and user_id, ordering by created_at
                 await conn.execute(
                     """
-                    INSERT INTO conversation_events (call_id, event_type, payload, created_at, session_id)
-                    VALUES ($1, $2, $3, $4, $5)
+                    INSERT INTO conversation_events (call_id, event_type, payload, created_at, session_id, user_id)
+                    VALUES ($1, $2, $3, $4, $5, $6)
                     """,
                     transaction_id,
                     event_type,
                     json.dumps(data),
                     timestamp,
                     session_id,
+                    user_id,
                 )
 
             logger.debug(f"Wrote event to db: {event_type} (transaction_id={transaction_id})")

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -52,6 +52,8 @@ from luthien_proxy.pipeline.policy_context_injection import inject_policy_awaren
 from luthien_proxy.pipeline.session import (
     extract_session_id_from_anthropic_body,
     extract_session_id_from_headers,
+    extract_user_id_from_bearer_token,
+    extract_user_id_from_headers,
 )
 from luthien_proxy.pipeline.stream_protocol_validator import validate_anthropic_event_ordering
 from luthien_proxy.policy_core.anthropic_execution_interface import (
@@ -100,6 +102,7 @@ class _AnthropicPolicyIO(AnthropicPolicyIOProtocol):
         emitter: EventEmitterProtocol,
         call_id: str,
         session_id: str | None,
+        user_id: str | None,
         request_log_recorder: RequestLogRecorder,
         is_streaming: bool,
         extra_headers: dict[str, str] | None = None,
@@ -110,6 +113,7 @@ class _AnthropicPolicyIO(AnthropicPolicyIOProtocol):
         self._emitter = emitter
         self._call_id = call_id
         self._session_id = session_id
+        self._user_id = user_id
         self._request_log_recorder = request_log_recorder
         self._is_streaming = is_streaming
         self._extra_headers = extra_headers
@@ -151,6 +155,7 @@ class _AnthropicPolicyIO(AnthropicPolicyIOProtocol):
                 "original_request": dict(self._initial_request),
                 "final_request": dict(effective_request),
                 "session_id": self._session_id,
+                "user_id": self._user_id,
             },
         )
         self._request_recorded = True
@@ -163,7 +168,7 @@ class _AnthropicPolicyIO(AnthropicPolicyIOProtocol):
         self._emitter.record(
             self._call_id,
             "pipeline.backend_request",
-            {"payload": request_payload, "session_id": self._session_id},
+            {"payload": request_payload, "session_id": self._session_id, "user_id": self._user_id},
         )
         self._request_log_recorder.record_outbound_request(
             body=request_payload,
@@ -368,7 +373,7 @@ async def process_anthropic_request(
         root_span.set_attribute("luthien.endpoint", "/v1/messages")
 
         # Phase 1: Process incoming request
-        anthropic_request, raw_http_request, session_id = await _process_request(
+        anthropic_request, raw_http_request, session_id, user_id = await _process_request(
             request=request,
             call_id=call_id,
             emitter=emitter,
@@ -383,6 +388,8 @@ async def process_anthropic_request(
         root_span.set_attribute("luthien.stream", is_streaming)
         if session_id:
             root_span.set_attribute("luthien.session_id", session_id)
+        if user_id:
+            root_span.set_attribute("luthien.user_id", user_id)
         if usage_collector:
             usage_collector.record_session(session_id)
 
@@ -417,6 +424,7 @@ async def process_anthropic_request(
             emitter=emitter,
             raw_http_request=raw_http_request,
             session_id=session_id,
+            user_id=user_id,
             user_credential=user_credential,
             credential_manager=credential_manager,
             policy_cache_factory=policy_cache_factory,
@@ -452,7 +460,7 @@ async def _process_request(
     request: Request,
     call_id: str,
     emitter: EventEmitterProtocol,
-) -> tuple[AnthropicRequest, RawHttpRequest, str | None]:
+) -> tuple[AnthropicRequest, RawHttpRequest, str | None, str | None]:
     """Process and validate incoming Anthropic request.
 
     Args:
@@ -461,7 +469,7 @@ async def _process_request(
         emitter: Event emitter
 
     Returns:
-        Tuple of (AnthropicRequest, RawHttpRequest with original data, session_id)
+        Tuple of (AnthropicRequest, RawHttpRequest with original data, session_id, user_id)
 
     Raises:
         HTTPException: On request size exceeded or invalid format
@@ -496,6 +504,14 @@ async def _process_request(
         # fall back to x-session-id header (OAuth passthrough mode)
         session_id = extract_session_id_from_anthropic_body(body) or extract_session_id_from_headers(headers)
 
+        # Extract user identity: X-Luthien-User-Id header takes precedence,
+        # fall back to JWT Bearer token sub claim (no signature verification —
+        # used for attribution only, not authentication)
+        bearer_token = headers.get("authorization", "")
+        if bearer_token.lower().startswith("bearer "):
+            bearer_token = bearer_token[7:]
+        user_id = extract_user_id_from_headers(headers) or extract_user_id_from_bearer_token(bearer_token)
+
         # Validate required fields
         if "model" not in body:
             raise HTTPException(status_code=400, detail="Missing required field: model")
@@ -511,12 +527,16 @@ async def _process_request(
             span.set_attribute("luthien.session_id", session_id)
             logger.debug(f"[{call_id}] Extracted session_id: {session_id}")
 
+        if user_id:
+            span.set_attribute("luthien.user_id", user_id)
+            logger.debug(f"[{call_id}] Extracted user_id: {user_id}")
+
         logger.info(
             f"[{call_id}] /v1/messages (native): model={anthropic_request['model']}, "
             f"stream={anthropic_request.get('stream', False)}"
         )
 
-        return anthropic_request, raw_http_request, session_id
+        return anthropic_request, raw_http_request, session_id, user_id
 
 
 async def _run_policy_hooks(
@@ -565,6 +585,7 @@ async def _execute_anthropic_policy(
         emitter=emitter,
         call_id=call_id,
         session_id=policy_ctx.session_id,
+        user_id=policy_ctx.user_id,
         request_log_recorder=request_log_recorder,
         is_streaming=is_streaming,
         extra_headers=extra_headers,
@@ -721,6 +742,7 @@ async def _handle_execution_streaming(
                                 else dict(reconstructed),
                                 "final_response": dict(reconstructed),
                                 "session_id": policy_ctx.session_id,
+                                "user_id": policy_ctx.user_id,
                             },
                         )
                     request_log_recorder.record_inbound_response(status=final_status)
@@ -810,6 +832,7 @@ async def _handle_execution_non_streaming(
             "original_response": original_response_payload,
             "final_response": dict(final_response),
             "session_id": policy_ctx.session_id,
+            "user_id": policy_ctx.user_id,
         },
     )
 
@@ -820,7 +843,7 @@ async def _handle_execution_non_streaming(
         emitter.record(
             call_id,
             "pipeline.client_response",
-            {"payload": final_response_payload, "session_id": policy_ctx.session_id},
+            {"payload": final_response_payload, "session_id": policy_ctx.session_id, "user_id": policy_ctx.user_id},
         )
         request_log_recorder.record_outbound_response(body=final_response_payload, status=200)
         request_log_recorder.record_inbound_response(status=200, body=final_response_payload)

--- a/src/luthien_proxy/pipeline/session.py
+++ b/src/luthien_proxy/pipeline/session.py
@@ -1,17 +1,22 @@
-"""Session ID extraction from client requests.
+"""Session ID and user identity extraction from client requests.
 
-Extracts session identifiers from incoming requests to enable tracking
-conversations across multiple API calls.
+Extracts session identifiers and user identities from incoming requests to enable
+tracking conversations across multiple API calls and attributing requests to users.
 """
 
 from __future__ import annotations
 
+import base64
 import json
 import re
 from typing import Any
 
 # Header name for clients to provide session ID (used by Claude Code and other integrations)
 SESSION_ID_HEADER = "x-session-id"
+
+# Header name for clients or upstream proxies to provide user identity.
+# Takes precedence over JWT sub claim extraction.
+USER_ID_HEADER = "x-luthien-user-id"
 
 # Pattern to extract session UUID from Anthropic metadata.user_id
 # Format: user_<hash>_account__session_<uuid>
@@ -75,8 +80,67 @@ def extract_session_id_from_headers(headers: dict[str, str]) -> str | None:
     return value if value else None
 
 
+def extract_user_id_from_headers(headers: dict[str, str]) -> str | None:
+    """Extract user identity from the X-Luthien-User-Id request header.
+
+    Clients or upstream proxies can set this header to identify the user making
+    the request. This takes precedence over JWT sub claim extraction.
+
+    Args:
+        headers: Request headers (keys should be lowercase)
+
+    Returns:
+        User ID string if header present and non-empty, None otherwise
+    """
+    value = headers.get(USER_ID_HEADER)
+    # Normalize empty strings to None for consistent handling
+    return value if value else None
+
+
+def extract_user_id_from_bearer_token(token: str | None) -> str | None:
+    """Extract user identity from the ``sub`` claim of a Bearer JWT token.
+
+    Decodes the JWT payload without signature verification — this is used for
+    identity attribution only, not authentication. Malformed or opaque tokens
+    (e.g. Anthropic API keys) return None gracefully.
+
+    Args:
+        token: Raw Bearer token string (without "Bearer " prefix), or None
+
+    Returns:
+        The ``sub`` claim string if present and valid, None otherwise
+    """
+    if not token:
+        return None
+
+    # JWTs have exactly three dot-separated parts
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+
+    payload_b64 = parts[1]
+    try:
+        # Add padding back — JWT base64url strips trailing '='
+        padding = 4 - len(payload_b64) % 4
+        if padding != 4:
+            payload_b64 += "=" * padding
+        payload_bytes = base64.urlsafe_b64decode(payload_b64)
+        payload = json.loads(payload_bytes)
+    except Exception:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    sub = payload.get("sub")
+    return sub if isinstance(sub, str) and sub else None
+
+
 __all__ = [
     "SESSION_ID_HEADER",
+    "USER_ID_HEADER",
     "extract_session_id_from_anthropic_body",
     "extract_session_id_from_headers",
+    "extract_user_id_from_bearer_token",
+    "extract_user_id_from_headers",
 ]

--- a/src/luthien_proxy/policy_core/policy_context.py
+++ b/src/luthien_proxy/policy_core/policy_context.py
@@ -55,6 +55,7 @@ class PolicyContext:
         emitter: EventEmitterProtocol | None = None,
         raw_http_request: RawHttpRequest | None = None,
         session_id: str | None = None,
+        user_id: str | None = None,
         user_credential: Credential | None = None,
         credential_manager: "CredentialManager | None" = None,
         policy_cache_factory: "PolicyCacheFactory | None" = None,
@@ -69,6 +70,8 @@ class PolicyContext:
             raw_http_request: Optional raw HTTP request data before any processing.
                               Contains original headers, body, method, and path.
             session_id: Optional session identifier extracted from client request.
+            user_id: Optional user identity extracted from X-Luthien-User-Id header
+                     or JWT Bearer token sub claim. Used for attribution only.
             user_credential: The credential extracted from the incoming request
                              (accounts for x-anthropic-api-key overrides).
             credential_manager: Shared credential manager for auth provider
@@ -80,6 +83,7 @@ class PolicyContext:
         self.request: Any | None = request
         self.raw_http_request: RawHttpRequest | None = raw_http_request
         self.session_id: str | None = session_id
+        self.user_id: str | None = user_id
         self.user_credential: Credential | None = user_credential
         self._credential_manager: "CredentialManager | None" = credential_manager
         self._policy_cache_factory: "PolicyCacheFactory | None" = policy_cache_factory
@@ -164,6 +168,8 @@ class PolicyContext:
         payload = dict(data)
         if self.session_id and "session_id" not in payload:
             payload["session_id"] = self.session_id
+        if self.user_id and "user_id" not in payload:
+            payload["user_id"] = self.user_id
         self._emitter.record(self.transaction_id, event_type, payload)
 
     @contextmanager
@@ -269,6 +275,7 @@ class PolicyContext:
         # Shared: non-copyable infrastructure and immutable request metadata
         new_ctx.transaction_id = self.transaction_id
         new_ctx.session_id = self.session_id
+        new_ctx.user_id = self.user_id
         new_ctx.raw_http_request = self.raw_http_request  # read-only after creation
         new_ctx.user_credential = self.user_credential  # frozen dataclass
         new_ctx._credential_manager = self._credential_manager  # holds db/cache pools

--- a/src/luthien_proxy/utils/sqlite_migrations/014_add_user_id.sql
+++ b/src/luthien_proxy/utils/sqlite_migrations/014_add_user_id.sql
@@ -1,0 +1,11 @@
+-- ABOUTME: Adds user_id column to conversation_calls and conversation_events
+-- ABOUTME: Enables tracking which user made each request for team deployments
+-- ABOUTME: Extracted from X-Luthien-User-Id header or JWT Bearer token sub claim
+
+-- Add user_id to conversation_calls (one row per API call)
+ALTER TABLE conversation_calls ADD COLUMN user_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_conversation_calls_user ON conversation_calls(user_id) WHERE user_id IS NOT NULL;
+
+-- Add user_id to conversation_events (one row per event within a call)
+ALTER TABLE conversation_events ADD COLUMN user_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_conversation_events_user ON conversation_events(user_id) WHERE user_id IS NOT NULL;

--- a/tests/luthien_proxy/unit_tests/history/test_routes.py
+++ b/tests/luthien_proxy/unit_tests/history/test_routes.py
@@ -6,7 +6,7 @@ These tests focus on the HTTP layer - ensuring routes properly:
 - Return correct response models
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -65,7 +65,7 @@ class TestListSessionsRoute:
             assert result.has_more is True
             assert len(result.sessions) == 1
             assert result.sessions[0].session_id == "session-1"
-            mock_fetch.assert_called_once_with(50, mock_db_pool, 0)
+            mock_fetch.assert_called_once_with(50, mock_db_pool, 0, user_id=ANY)
 
     @pytest.mark.asyncio
     async def test_list_sessions_custom_limit(self):
@@ -78,7 +78,7 @@ class TestListSessionsRoute:
             return_value=SessionListResponse(sessions=[], total=0),
         ) as mock_fetch:
             await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=100, offset=0)
-            mock_fetch.assert_called_once_with(100, mock_db_pool, 0)
+            mock_fetch.assert_called_once_with(100, mock_db_pool, 0, user_id=ANY)
 
     @pytest.mark.asyncio
     async def test_list_sessions_with_offset(self):
@@ -100,7 +100,7 @@ class TestListSessionsRoute:
 
             assert result.offset == 50
             assert result.has_more is True
-            mock_fetch.assert_called_once_with(50, mock_db_pool, 50)
+            mock_fetch.assert_called_once_with(50, mock_db_pool, 50, user_id=ANY)
 
     @pytest.mark.asyncio
     async def test_list_sessions_empty(self):

--- a/tests/luthien_proxy/unit_tests/history/test_service.py
+++ b/tests/luthien_proxy/unit_tests/history/test_service.py
@@ -925,6 +925,7 @@ class TestFetchSessionList:
                 "policy_interventions": 1,
                 "models": ["gpt-4", "claude-3"],
                 "request_payload": {"final_request": {"messages": [{"role": "user", "content": "Hello world"}]}},
+                "user_id": "alice@example.com",
             },
         ]
 
@@ -947,6 +948,7 @@ class TestFetchSessionList:
         assert result.sessions[0].policy_interventions == 1
         assert "gpt-4" in result.sessions[0].models_used
         assert result.sessions[0].preview_message == "Hello world"
+        assert result.sessions[0].user_id == "alice@example.com"
 
     @pytest.mark.asyncio
     async def test_fetch_with_offset(self):
@@ -961,6 +963,7 @@ class TestFetchSessionList:
                 "policy_interventions": 0,
                 "models": ["gpt-4"],
                 "request_payload": None,  # Test with no first message
+                "user_id": None,
             },
         ]
 

--- a/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
@@ -173,7 +173,7 @@ class TestProcessRequest:
             mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
             mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
 
-            anthropic_request, raw_http_request, session_id = await _process_request(
+            anthropic_request, raw_http_request, session_id, _user_id = await _process_request(
                 request=mock_request,
                 call_id="test-call-id",
                 emitter=mock_emitter,
@@ -204,7 +204,7 @@ class TestProcessRequest:
             mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
             mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
 
-            _anthropic_request, _raw_http_request, session_id = await _process_request(
+            _anthropic_request, _raw_http_request, session_id, _user_id = await _process_request(
                 request=mock_request,
                 call_id="test-call-id",
                 emitter=mock_emitter,
@@ -226,7 +226,7 @@ class TestProcessRequest:
             mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
             mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
 
-            _anthropic_request, _raw_http_request, session_id = await _process_request(
+            _anthropic_request, _raw_http_request, session_id, _user_id = await _process_request(
                 request=mock_request,
                 call_id="test-call-id",
                 emitter=mock_emitter,
@@ -2021,6 +2021,7 @@ class TestAnthropicPolicyIOBuffering:
             emitter=MagicMock(),
             call_id="test-call",
             session_id=None,
+            user_id=None,
             request_log_recorder=MagicMock(),
             is_streaming=is_streaming,
         )

--- a/tests/luthien_proxy/unit_tests/pipeline/test_session.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_session.py
@@ -2,8 +2,11 @@
 
 from luthien_proxy.pipeline.session import (
     SESSION_ID_HEADER,
+    USER_ID_HEADER,
     extract_session_id_from_anthropic_body,
     extract_session_id_from_headers,
+    extract_user_id_from_bearer_token,
+    extract_user_id_from_headers,
 )
 
 
@@ -157,3 +160,122 @@ class TestExtractSessionIdFromHeaders:
     def test_header_name_constant(self):
         """Test the header name constant is correct."""
         assert SESSION_ID_HEADER == "x-session-id"
+
+
+class TestExtractUserIdFromHeaders:
+    """Tests for extract_user_id_from_headers function."""
+
+    def test_extracts_user_id_from_header(self):
+        """Test extraction from X-Luthien-User-Id header."""
+        headers = {
+            "content-type": "application/json",
+            USER_ID_HEADER: "alice@example.com",
+        }
+        user_id = extract_user_id_from_headers(headers)
+        assert user_id == "alice@example.com"
+
+    def test_returns_none_when_header_missing(self):
+        """Test returns None when X-Luthien-User-Id header is missing."""
+        headers = {
+            "content-type": "application/json",
+            "authorization": "Bearer token",
+        }
+        user_id = extract_user_id_from_headers(headers)
+        assert user_id is None
+
+    def test_returns_none_if_header_empty(self):
+        """Test returns None if header value is empty."""
+        headers = {USER_ID_HEADER: ""}
+        user_id = extract_user_id_from_headers(headers)
+        assert user_id is None
+
+    def test_preserves_arbitrary_user_id_format(self):
+        """Test arbitrary user ID formats are preserved."""
+        for uid in ["user-123", "alice", "alice@corp.example.com", "sub:abc123"]:
+            headers = {USER_ID_HEADER: uid}
+            assert extract_user_id_from_headers(headers) == uid
+
+    def test_header_name_constant(self):
+        """Test the header name constant is correct."""
+        assert USER_ID_HEADER == "x-luthien-user-id"
+
+
+class TestExtractUserIdFromBearerToken:
+    """Tests for extract_user_id_from_bearer_token function."""
+
+    def test_extracts_sub_from_valid_jwt(self):
+        """Test extraction of sub claim from a valid JWT."""
+        import base64
+        import json
+
+        # Build a minimal JWT: header.payload.signature (signature not verified)
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256", "typ": "JWT"}).encode()).rstrip(b"=").decode()
+        payload = (
+            base64.urlsafe_b64encode(json.dumps({"sub": "user-abc-123", "email": "alice@example.com"}).encode())
+            .rstrip(b"=")
+            .decode()
+        )
+        token = f"{header}.{payload}.fakesignature"
+
+        user_id = extract_user_id_from_bearer_token(token)
+        assert user_id == "user-abc-123"
+
+    def test_returns_none_when_no_sub_claim(self):
+        """Test returns None when JWT has no sub claim."""
+        import base64
+        import json
+
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).rstrip(b"=").decode()
+        payload = base64.urlsafe_b64encode(json.dumps({"email": "alice@example.com"}).encode()).rstrip(b"=").decode()
+        token = f"{header}.{payload}.fakesig"
+
+        user_id = extract_user_id_from_bearer_token(token)
+        assert user_id is None
+
+    def test_returns_none_for_non_jwt_token(self):
+        """Test returns None for opaque (non-JWT) tokens."""
+        user_id = extract_user_id_from_bearer_token("sk-ant-api03-someapikey")
+        assert user_id is None
+
+    def test_returns_none_for_empty_token(self):
+        """Test returns None for empty token string."""
+        user_id = extract_user_id_from_bearer_token("")
+        assert user_id is None
+
+    def test_returns_none_for_malformed_jwt_payload(self):
+        """Test returns None when JWT payload is not valid base64 JSON."""
+        token = "header.notvalidbase64!!.signature"
+        user_id = extract_user_id_from_bearer_token(token)
+        assert user_id is None
+
+    def test_returns_none_when_sub_is_not_string(self):
+        """Test returns None when sub claim is not a string."""
+        import base64
+        import json
+
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).rstrip(b"=").decode()
+        payload = base64.urlsafe_b64encode(json.dumps({"sub": 12345}).encode()).rstrip(b"=").decode()
+        token = f"{header}.{payload}.fakesig"
+
+        user_id = extract_user_id_from_bearer_token(token)
+        assert user_id is None
+
+    def test_returns_none_for_none_token(self):
+        """Test returns None when token is None."""
+        user_id = extract_user_id_from_bearer_token(None)
+        assert user_id is None
+
+    def test_handles_jwt_without_padding(self):
+        """Test handles JWT base64 without padding (standard JWT format)."""
+        import base64
+        import json
+
+        # JWT payloads often lack = padding
+        payload_data = {"sub": "user-xyz", "iss": "https://auth.example.com"}
+        payload_bytes = json.dumps(payload_data).encode()
+        # Deliberately strip padding as real JWTs do
+        payload = base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode()
+        token = f"eyJhbGciOiJSUzI1NiJ9.{payload}.fakesig"
+
+        user_id = extract_user_id_from_bearer_token(token)
+        assert user_id == "user-xyz"


### PR DESCRIPTION
## Summary

Closes LuthienResearch/luthien-proxy#554

Adds user identity extraction and storage to enable team-wide attribution of API requests to individual users. For a 10-30 developer team deployment, operators can now answer "whose session is this?" directly from the history UI and API.

## Changes

### Extraction (pipeline/session.py)
- extract_user_id_from_headers(): reads X-Luthien-User-Id header (highest priority)
- extract_user_id_from_bearer_token(): decodes JWT Bearer token to extract sub claim without signature verification (attribution only, not authentication)

### Propagation
- _process_request() extracts user_id and sets luthien.user_id OTEL span attribute
- PolicyContext gains user_id field, propagated through fork() and injected into emitter event payloads
- _AnthropicPolicyIO passes user_id through to all emitter.record() calls

### Storage (migration 014)
- user_id TEXT column added to conversation_calls AND conversation_events (both tables, following session_id pattern)
- Postgres and SQLite migrations with partial indexes on non-null user_id
- EventEmitter._write_db() extracts user_id from event data dict and persists via COALESCE upsert

### History API
- SessionSummary model gains user_id field
- GET /api/history/sessions accepts optional user_id query param for filtering
- Both PG and SQLite fetch_session_list variants join conversation_calls to surface user_id per session

## Tests
- Unit tests for all new extraction functions (TDD-first)
- Updated existing tests for changed signatures
- 1950 unit tests pass, 44 SQLite e2e tests pass
- Pyright: 0 errors, Ruff: all checks passed

## Design Decisions
- X-Luthien-User-Id takes precedence over JWT sub (explicit > implicit)
- JWT decode without signature verification is safe (attribution, not authentication)
- user_id on both conversation_calls and conversation_events for maximum debugging granularity