### PR TITLE
chore(dev_checks): add --timing flag for per-step instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ scripts/automated_maintenance/automated_maintenance.env.bak*
 # Claude Code runtime state
 .claude/scheduled_tasks.lock
 NEXT.md
+
+# dev_checks.sh --timing output
+.dev_checks_timings.jsonl

--- a/changelog.d/dev-checks-timing.md
+++ b/changelog.d/dev-checks-timing.md
@@ -1,0 +1,5 @@
+---
+category: Chores & Docs
+---
+
+**dev_checks: per-step timing instrumentation**: Added `--timing` / `--timing=PATH` flag to `scripts/dev_checks.sh` that writes one JSON line per step to `.dev_checks_timings.jsonl` (run_id, step, duration_s, exit_code, ts) and prints a sorted summary at the end. Added a `Testing & QA` section to `dev-README.md` documenting test tiers, dev_checks flags, and performance characteristics.

--- a/dev-README.md
+++ b/dev-README.md
@@ -61,6 +61,42 @@ Editor setup (VS Code)
 - Tests: `uv run pytest -q` with coverage for `src/luthien_proxy/**` configured in `[tool.pytest.ini_options]`.
 - Config consolidation: Ruff, Pytest, and Pyright live in `pyproject.toml` to avoid extra files.
 
+## Testing & QA
+
+### `scripts/dev_checks.sh`
+
+One script that does the full local gate: dep sync, shellcheck, config codegen, ruff format + lint (autofix + gate), pyright, unit tests, radon complexity, and a clean-tree check. Auto-stages any files the formatters rewrite. Run this before pushing.
+
+Flags:
+
+| Flag | Effect |
+|------|--------|
+| `--timing` | Write per-step wall-clock timings to `.dev_checks_timings.jsonl` (one JSON object per step) and print a summary at the end. Useful for diagnosing slowdowns. |
+| `--timing=PATH` | Same as `--timing` but write to a custom path. |
+
+Each JSONL record has `run_id`, `step`, `duration_s`, `exit_code`, `ts`. A final `__total__` record captures wall-clock for the whole run. The file is gitignored.
+
+### Test tiers
+
+| Tier | Marker | Command | Speed | When |
+|------|--------|---------|-------|------|
+| Unit | *(default)* | `uv run pytest tests/luthien_proxy/unit_tests` | Fast | Logic, edge cases, mocks |
+| sqlite_e2e | `sqlite_e2e` | `./scripts/run_e2e.sh sqlite` | Medium | Full gateway in-process, no Docker |
+| mock_e2e | `mock_e2e` | `./scripts/run_e2e.sh mock` | Medium | Deterministic streaming, policy behavior |
+| e2e | `e2e` | `./scripts/run_e2e.sh` | Slow | Real API + Docker validation |
+
+`sqlite_e2e` and `mock_e2e` must run in separate pytest sessions; `run_e2e.sh` handles this. Use `./scripts/run_e2e.sh --fresh` to rerun from scratch.
+
+### Performance notes
+
+Where `dev_checks.sh` time goes (typical warm run on this repo):
+
+- `pytest` ≈ 40s (coverage instrumentation is roughly 40% of this; drop `--cov` when iterating)
+- `pyright` ≈ 10s
+- Everything else combined ≤ 2s
+
+`pytest-xdist` with `-n auto` does **not** meaningfully speed up the unit suite — individual tests are too fast and worker-distribution overhead eats the gain. If you need a faster inner loop, run `uv run pytest tests/luthien_proxy/unit_tests --no-cov` directly.
+
 ## Architecture
 
 The gateway is a single FastAPI application:

--- a/scripts/dev_checks.sh
+++ b/scripts/dev_checks.sh
@@ -4,50 +4,96 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
+TIMING_FILE=""
+for arg in "$@"; do
+    case "$arg" in
+        --timing)
+            TIMING_FILE="$REPO_ROOT/.dev_checks_timings.jsonl"
+            ;;
+        --timing=*)
+            TIMING_FILE="${arg#--timing=}"
+            ;;
+    esac
+done
+
+if [[ -n "$TIMING_FILE" ]]; then
+    : > "$TIMING_FILE"
+    echo "Timing output: $TIMING_FILE"
+fi
+
+RUN_ID="$(date -u +%Y-%m-%dT%H:%M:%SZ)-$$"
+TOTAL_START=$(date +%s.%N)
+
+# Run a named step and optionally record its wall-clock duration + exit status
+# as one JSON line in $TIMING_FILE.
+step() {
+    local name="$1"
+    shift
+    if [[ -z "$TIMING_FILE" ]]; then
+        "$@"
+        return $?
+    fi
+    local start end dur rc
+    start=$(date +%s.%N)
+    set +e
+    "$@"
+    rc=$?
+    set -e
+    end=$(date +%s.%N)
+    dur=$(awk -v s="$start" -v e="$end" 'BEGIN { printf "%.3f", e - s }')
+    printf '{"run_id":"%s","step":"%s","duration_s":%s,"exit_code":%d,"ts":"%s"}\n' \
+        "$RUN_ID" "$name" "$dur" "$rc" "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" \
+        >> "$TIMING_FILE"
+    return $rc
+}
+
 # ── Phase 1: Fix ──────────────────────────────────────────────
 
 echo "== Dependency sync (locked) =="
-uv sync --all-groups --locked
+step "uv_sync" uv sync --all-groups --locked
 
 echo "== Shellcheck (shell scripts) =="
-if command -v shellcheck &>/dev/null; then
-    SCRIPT_DIR="$REPO_ROOT/scripts"
-    shellcheck_failed=0
+run_shellcheck() {
+    if ! command -v shellcheck &>/dev/null; then
+        echo "  ERROR: shellcheck not installed."
+        echo "  Install with: brew install shellcheck (macOS) or apt-get install shellcheck (Linux)"
+        return 1
+    fi
+    local script_dir="$REPO_ROOT/scripts"
+    local failed=0
     # Recurse into subdirs (e.g. scripts/automated_maintenance/) so nested scripts are linted.
     # `-print0` + `read -d ''` handles paths with spaces safely.
     while IFS= read -r -d '' script; do
-        rel="${script#"${SCRIPT_DIR}"/}"
+        rel="${script#"${script_dir}"/}"
         echo "  Checking ${rel}..."
         # `-P SCRIPTDIR` lets shellcheck resolve relative `# shellcheck
         # source=...` directives against the script's own directory.
         if ! shellcheck --shell=bash -x -P SCRIPTDIR "$script"; then
-            shellcheck_failed=1
+            failed=1
         fi
-    done < <(find "$SCRIPT_DIR" -type f -name '*.sh' -print0)
-    if [[ "$shellcheck_failed" -ne 0 ]]; then
+    done < <(find "$script_dir" -type f -name '*.sh' -print0)
+    if [[ "$failed" -ne 0 ]]; then
         echo "Shellcheck found issues. Please fix them before proceeding."
-        exit 1
+        return 1
     fi
     echo "  All shell scripts passed."
-else
-    echo "  ERROR: shellcheck not installed."
-    echo "  Install with: brew install shellcheck (macOS) or apt-get install shellcheck (Linux)"
-    exit 1
-fi
+}
+step "shellcheck" run_shellcheck
 
 echo "== Generate settings.py from config_fields =="
-uv run python scripts/generate_settings.py
+step "generate_settings" uv run python scripts/generate_settings.py
 
 echo "== Generate .env.example from config_fields =="
-uv run python scripts/generate_env_example.py > .env.example
+run_generate_env() { uv run python scripts/generate_env_example.py > .env.example; }
+step "generate_env_example" run_generate_env
 
 DIRTY_BEFORE=$(git diff --name-only 2>/dev/null)
 
 echo "== Ruff format (apply) =="
-uv run ruff format
+step "ruff_format" uv run ruff format
 
 echo "== Ruff lint (autofix) =="
-uv run ruff check --fix
+step "ruff_check_fix" uv run ruff check --fix
 
 DIRTY_AFTER=$(git diff --name-only 2>/dev/null)
 FORMATTER_CHANGED=$(comm -13 <(echo "$DIRTY_BEFORE" | sort) <(echo "$DIRTY_AFTER" | sort))
@@ -66,19 +112,21 @@ fi
 # ── Phase 2: Gate ─────────────────────────────────────────────
 
 echo "== Ruff lint (E/F/I/D gating) =="
-uv run ruff check
+step "ruff_check" uv run ruff check
 
 echo "== Ruff docstrings (report-only) =="
-uv run ruff check --select D --exit-zero || true
+run_ruff_docstrings() { uv run ruff check --select D --exit-zero || true; }
+step "ruff_docstrings" run_ruff_docstrings
 
 echo "== Pyright (basic) =="
-uv run pyright
+step "pyright" uv run pyright
 
 echo "== Tests =="
-uv run -m pytest -q
+step "pytest" uv run -m pytest -q
 
 echo "== Radon complexity (report-only) =="
-uv run radon cc -s -a src || true
+run_radon() { uv run radon cc -s -a src || true; }
+step "radon" run_radon
 
 echo "== Clean tree check (post) =="
 if ! git diff --quiet 2>/dev/null; then
@@ -89,6 +137,25 @@ fi
 
 echo ""
 echo "All checks completed."
+
+if [[ -n "$TIMING_FILE" ]]; then
+    TOTAL_END=$(date +%s.%N)
+    TOTAL=$(awk -v s="$TOTAL_START" -v e="$TOTAL_END" 'BEGIN { printf "%.3f", e - s }')
+    printf '{"run_id":"%s","step":"__total__","duration_s":%s,"exit_code":0,"ts":"%s"}\n' \
+        "$RUN_ID" "$TOTAL" "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" \
+        >> "$TIMING_FILE"
+    echo ""
+    echo "── Timing summary ──"
+    awk -F'[,:]' '
+        /"step"/ {
+            for (i=1; i<=NF; i++) {
+                if ($i ~ /"step"/) { gsub(/["{} ]/, "", $(i+1)); step=$(i+1) }
+                if ($i ~ /"duration_s"/) { gsub(/["{} ]/, "", $(i+1)); dur=$(i+1) }
+            }
+            printf "  %7.2fs  %s\n", dur, step
+        }
+    ' "$TIMING_FILE" | sort -rn
+fi
 
 # Remind about staged/unpushed changes
 if ! git diff --cached --quiet 2>/dev/null; then

--- a/scripts/dev_checks.sh
+++ b/scripts/dev_checks.sh
@@ -16,13 +16,52 @@ for arg in "$@"; do
     esac
 done
 
+# Portable high-resolution epoch timestamp. `date +%N` is a GNU coreutils
+# extension; BSD/macOS `date` emits the literal 'N' instead of nanoseconds.
+# Try GNU date first, then gdate (common via `brew install coreutils`), and
+# finally fall back to whole-second resolution. The JSONL schema is unchanged.
+if date +%N 2>/dev/null | grep -qE '^[0-9]+$'; then
+    now_epoch()      { date +%s.%N; }
+    now_iso_ms_utc() { date -u +%Y-%m-%dT%H:%M:%S.%3NZ; }
+elif command -v gdate >/dev/null 2>&1 && gdate +%N 2>/dev/null | grep -qE '^[0-9]+$'; then
+    now_epoch()      { gdate +%s.%N; }
+    now_iso_ms_utc() { gdate -u +%Y-%m-%dT%H:%M:%S.%3NZ; }
+else
+    now_epoch()      { date +%s; }
+    now_iso_ms_utc() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+fi
+
 if [[ -n "$TIMING_FILE" ]]; then
     : > "$TIMING_FILE"
     echo "Timing output: $TIMING_FILE"
 fi
 
 RUN_ID="$(date -u +%Y-%m-%dT%H:%M:%SZ)-$$"
-TOTAL_START=$(date +%s.%N)
+TOTAL_START=$(now_epoch)
+
+# Always print the summary on exit (including on failure) when timing is on,
+# so slow/failing runs are the most useful to diagnose.
+print_timing_summary() {
+    [[ -z "$TIMING_FILE" ]] && return
+    [[ ! -s "$TIMING_FILE" ]] && return
+    echo ""
+    echo "── Timing summary ──"
+    # Parse JSONL via Python for correctness (field order / embedded colons).
+    # uv is already warm from earlier steps so the overhead is negligible.
+    uv run python - "$TIMING_FILE" <<'PY' | sort -rn
+import json, sys
+for line in open(sys.argv[1]):
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        rec = json.loads(line)
+    except Exception:
+        continue
+    print(f"  {float(rec['duration_s']):7.2f}s  {rec['step']}")
+PY
+}
+trap print_timing_summary EXIT
 
 # Run a named step and optionally record its wall-clock duration + exit status
 # as one JSON line in $TIMING_FILE.
@@ -34,15 +73,15 @@ step() {
         return $?
     fi
     local start end dur rc
-    start=$(date +%s.%N)
+    start=$(now_epoch)
     set +e
     "$@"
     rc=$?
     set -e
-    end=$(date +%s.%N)
+    end=$(now_epoch)
     dur=$(awk -v s="$start" -v e="$end" 'BEGIN { printf "%.3f", e - s }')
     printf '{"run_id":"%s","step":"%s","duration_s":%s,"exit_code":%d,"ts":"%s"}\n' \
-        "$RUN_ID" "$name" "$dur" "$rc" "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" \
+        "$RUN_ID" "$name" "$dur" "$rc" "$(now_iso_ms_utc)" \
         >> "$TIMING_FILE"
     return $rc
 }
@@ -139,23 +178,13 @@ echo ""
 echo "All checks completed."
 
 if [[ -n "$TIMING_FILE" ]]; then
-    TOTAL_END=$(date +%s.%N)
+    TOTAL_END=$(now_epoch)
     TOTAL=$(awk -v s="$TOTAL_START" -v e="$TOTAL_END" 'BEGIN { printf "%.3f", e - s }')
     printf '{"run_id":"%s","step":"__total__","duration_s":%s,"exit_code":0,"ts":"%s"}\n' \
-        "$RUN_ID" "$TOTAL" "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" \
+        "$RUN_ID" "$TOTAL" "$(now_iso_ms_utc)" \
         >> "$TIMING_FILE"
-    echo ""
-    echo "── Timing summary ──"
-    awk -F'[,:]' '
-        /"step"/ {
-            for (i=1; i<=NF; i++) {
-                if ($i ~ /"step"/) { gsub(/["{} ]/, "", $(i+1)); step=$(i+1) }
-                if ($i ~ /"duration_s"/) { gsub(/["{} ]/, "", $(i+1)); dur=$(i+1) }
-            }
-            printf "  %7.2fs  %s\n", dur, step
-        }
-    ' "$TIMING_FILE" | sort -rn
 fi
+# Summary itself is printed by the EXIT trap (runs on success and failure).
 
 # Remind about staged/unpushed changes
 if ! git diff --cached --quiet 2>/dev/null; then


### PR DESCRIPTION
## Summary

- Adds `--timing` / `--timing=PATH` to `scripts/dev_checks.sh` — writes one JSON line per step (`run_id`, `step`, `duration_s`, `exit_code`, `ts`) to `.dev_checks_timings.jsonl` and prints a sorted summary
- Adds `Testing & QA` section to `dev-README.md` consolidating test tiers, dev_checks flags, and performance notes
- Gitignores `.dev_checks_timings.jsonl`

## Context

First of a 3-PR stack aimed at speeding up `dev_checks.sh`. This PR adds the measurement infrastructure; follow-ups use the timings to validate perf wins.

**Current baseline (warm run, this PR's own timings):**
\`\`\`
    54.25s  __total__
    41.67s  pytest       (77%)
     9.47s  pyright      (17%)
     1.64s  shellcheck
     all else < 0.5s each
\`\`\`

## Stack

1. **This PR**: timing infrastructure
2. (Next) concurrent pyright + pytest in Phase 2
3. (Next) \`--fast\` inner-loop mode

## Test plan

- [x] Run \`./scripts/dev_checks.sh --timing\`, confirm JSONL is written and summary prints
- [x] Run \`./scripts/dev_checks.sh\` without flag, confirm behavior is identical to before
- [x] Confirm \`.dev_checks_timings.jsonl\` is gitignored

---
*Posted by Claude Code (claude-opus-4-6[1m])*