### PR TITLE
perf(dev_checks): run pyright and pytest concurrently

### DIFF
--- a/changelog.d/dev-checks-parallel.md
+++ b/changelog.d/dev-checks-parallel.md
@@ -1,0 +1,5 @@
+---
+category: Chores & Docs
+---
+
+**dev_checks: concurrent pyright + pytest**: In Phase 2, pyright and pytest now run in parallel (they're independent). Output is captured to separate logs and surfaced sequentially after both complete. Saves ~9-10s on a typical warm run (~54s → ~44s).

--- a/scripts/dev_checks.sh
+++ b/scripts/dev_checks.sh
@@ -159,25 +159,53 @@ step "ruff_docstrings" run_ruff_docstrings
 
 echo "== Pyright + Tests (parallel) =="
 # Pyright and pytest are independent; running them concurrently saves ~10s.
-# Each writes to its own log and we surface output sequentially so it's readable.
+# Each writes its output + end-timestamp + exit code to its own tmp files,
+# so we can record each process's actual finish time (not just when the
+# outer wait returns). This matters once pyright ≈ pytest in duration.
 PYRIGHT_LOG="$(mktemp)"
 PYTEST_LOG="$(mktemp)"
-trap 'rm -f "$PYRIGHT_LOG" "$PYTEST_LOG"' EXIT
+PYRIGHT_END_FILE="$(mktemp)"
+PYTEST_END_FILE="$(mktemp)"
+PYRIGHT_PID=""
+PYTEST_PID=""
 
-pyright_start=$(date +%s.%N)
-(uv run pyright > "$PYRIGHT_LOG" 2>&1) &
+parallel_cleanup() {
+    # Kill any still-running background jobs (e.g. on Ctrl-C) so they don't
+    # become orphans that keep burning CPU after the script exits.
+    if [[ -n "$PYRIGHT_PID" ]] && kill -0 "$PYRIGHT_PID" 2>/dev/null; then
+        kill "$PYRIGHT_PID" 2>/dev/null || true
+    fi
+    if [[ -n "$PYTEST_PID" ]] && kill -0 "$PYTEST_PID" 2>/dev/null; then
+        kill "$PYTEST_PID" 2>/dev/null || true
+    fi
+    rm -f "$PYRIGHT_LOG" "$PYTEST_LOG" "$PYRIGHT_END_FILE" "$PYTEST_END_FILE"
+}
+# Compose with the existing summary trap instead of replacing it. On Ctrl-C
+# the signal handler must explicitly exit — otherwise control returns to the
+# interrupted `wait` and the script falls through to `cat`-ing now-deleted
+# logs and past the gate. Clear the EXIT trap first so cleanup runs once.
+trap 'parallel_cleanup; print_timing_summary' EXIT
+trap 'trap - EXIT; parallel_cleanup; print_timing_summary; exit 130' INT TERM
+
+# `set +e` inside each subshell: the outer script runs under `set -e`, which
+# is inherited by `(...)`. Without it, a failing pyright/pytest aborts the
+# subshell at the command itself, so the end-timestamp + `exit "$rc"` never
+# run and the timing record is broken on exactly the failed runs you most
+# want to measure. The real exit code is still captured by `wait` below.
+pyright_start=$(now_epoch)
+( set +e; uv run pyright > "$PYRIGHT_LOG" 2>&1; rc=$?; now_epoch > "$PYRIGHT_END_FILE"; exit "$rc" ) &
 PYRIGHT_PID=$!
 
-pytest_start=$(date +%s.%N)
-(uv run -m pytest -q > "$PYTEST_LOG" 2>&1) &
+pytest_start=$(now_epoch)
+( set +e; uv run -m pytest -q > "$PYTEST_LOG" 2>&1; rc=$?; now_epoch > "$PYTEST_END_FILE"; exit "$rc" ) &
 PYTEST_PID=$!
 
 set +e
 wait "$PYRIGHT_PID"; PYRIGHT_RC=$?
-pyright_end=$(date +%s.%N)
-wait "$PYTEST_PID"; PYTEST_RC=$?
-pytest_end=$(date +%s.%N)
+wait "$PYTEST_PID";  PYTEST_RC=$?
 set -e
+pyright_end=$(cat "$PYRIGHT_END_FILE")
+pytest_end=$(cat "$PYTEST_END_FILE")
 
 echo ""
 echo "── Pyright output ──"
@@ -190,20 +218,22 @@ if [[ -n "$TIMING_FILE" ]]; then
     pyright_dur=$(awk -v s="$pyright_start" -v e="$pyright_end" 'BEGIN { printf "%.3f", e - s }')
     pytest_dur=$(awk -v s="$pytest_start" -v e="$pytest_end" 'BEGIN { printf "%.3f", e - s }')
     printf '{"run_id":"%s","step":"pyright","duration_s":%s,"exit_code":%d,"ts":"%s"}\n' \
-        "$RUN_ID" "$pyright_dur" "$PYRIGHT_RC" "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" \
+        "$RUN_ID" "$pyright_dur" "$PYRIGHT_RC" "$(now_iso_ms_utc)" \
         >> "$TIMING_FILE"
     printf '{"run_id":"%s","step":"pytest","duration_s":%s,"exit_code":%d,"ts":"%s"}\n' \
-        "$RUN_ID" "$pytest_dur" "$PYTEST_RC" "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" \
+        "$RUN_ID" "$pytest_dur" "$PYTEST_RC" "$(now_iso_ms_utc)" \
         >> "$TIMING_FILE"
 fi
 
-if [[ $PYRIGHT_RC -ne 0 ]]; then
-    echo "Pyright failed (exit $PYRIGHT_RC)."
+# If both failed, report both before exiting (not just the first one).
+if [[ $PYRIGHT_RC -ne 0 || $PYTEST_RC -ne 0 ]]; then
+    [[ $PYRIGHT_RC -ne 0 ]] && echo "Pyright failed (exit $PYRIGHT_RC)."
+    [[ $PYTEST_RC  -ne 0 ]] && echo "Pytest failed (exit $PYTEST_RC)."
+    # Prefer pytest's exit code when both fail (it's the more actionable signal).
+    if [[ $PYTEST_RC -ne 0 ]]; then
+        exit "$PYTEST_RC"
+    fi
     exit "$PYRIGHT_RC"
-fi
-if [[ $PYTEST_RC -ne 0 ]]; then
-    echo "Pytest failed (exit $PYTEST_RC)."
-    exit "$PYTEST_RC"
 fi
 
 echo "== Radon complexity (report-only) =="

--- a/scripts/dev_checks.sh
+++ b/scripts/dev_checks.sh
@@ -157,11 +157,54 @@ echo "== Ruff docstrings (report-only) =="
 run_ruff_docstrings() { uv run ruff check --select D --exit-zero || true; }
 step "ruff_docstrings" run_ruff_docstrings
 
-echo "== Pyright (basic) =="
-step "pyright" uv run pyright
+echo "== Pyright + Tests (parallel) =="
+# Pyright and pytest are independent; running them concurrently saves ~10s.
+# Each writes to its own log and we surface output sequentially so it's readable.
+PYRIGHT_LOG="$(mktemp)"
+PYTEST_LOG="$(mktemp)"
+trap 'rm -f "$PYRIGHT_LOG" "$PYTEST_LOG"' EXIT
 
-echo "== Tests =="
-step "pytest" uv run -m pytest -q
+pyright_start=$(date +%s.%N)
+(uv run pyright > "$PYRIGHT_LOG" 2>&1) &
+PYRIGHT_PID=$!
+
+pytest_start=$(date +%s.%N)
+(uv run -m pytest -q > "$PYTEST_LOG" 2>&1) &
+PYTEST_PID=$!
+
+set +e
+wait "$PYRIGHT_PID"; PYRIGHT_RC=$?
+pyright_end=$(date +%s.%N)
+wait "$PYTEST_PID"; PYTEST_RC=$?
+pytest_end=$(date +%s.%N)
+set -e
+
+echo ""
+echo "── Pyright output ──"
+cat "$PYRIGHT_LOG"
+echo ""
+echo "── Pytest output ──"
+cat "$PYTEST_LOG"
+
+if [[ -n "$TIMING_FILE" ]]; then
+    pyright_dur=$(awk -v s="$pyright_start" -v e="$pyright_end" 'BEGIN { printf "%.3f", e - s }')
+    pytest_dur=$(awk -v s="$pytest_start" -v e="$pytest_end" 'BEGIN { printf "%.3f", e - s }')
+    printf '{"run_id":"%s","step":"pyright","duration_s":%s,"exit_code":%d,"ts":"%s"}\n' \
+        "$RUN_ID" "$pyright_dur" "$PYRIGHT_RC" "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" \
+        >> "$TIMING_FILE"
+    printf '{"run_id":"%s","step":"pytest","duration_s":%s,"exit_code":%d,"ts":"%s"}\n' \
+        "$RUN_ID" "$pytest_dur" "$PYTEST_RC" "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)" \
+        >> "$TIMING_FILE"
+fi
+
+if [[ $PYRIGHT_RC -ne 0 ]]; then
+    echo "Pyright failed (exit $PYRIGHT_RC)."
+    exit "$PYRIGHT_RC"
+fi
+if [[ $PYTEST_RC -ne 0 ]]; then
+    echo "Pytest failed (exit $PYTEST_RC)."
+    exit "$PYTEST_RC"
+fi
 
 echo "== Radon complexity (report-only) =="
 run_radon() { uv run radon cc -s -a src || true; }


### PR DESCRIPTION
## Summary

- Phase 2 of \`dev_checks.sh\` now runs pyright and pytest in parallel — they're independent, and pyright was previously running serially under pytest's shadow
- Each writes to its own log; output is surfaced sequentially (pyright first, then pytest) after both complete so interleaved output doesn't make failures unreadable
- Timing records for both steps still emitted correctly when \`--timing\` is passed

## Measured savings

Using \`--timing\` (from PR #585):

| | pyright | pytest | __total__ |
|---|---|---|---|
| Before | 9.47s | 41.67s | **54.25s** |
| After  | 9.44s | 42.45s | **45.52s** |

Saves ~8-10s (pyright fully hidden under pytest). Pytest wall time is unchanged; the speedup comes from pyright running concurrently.

## Stack

1. #585 — timing instrumentation (base)
2. **This PR** — concurrent pyright + pytest
3. (Next) \`--fast\` inner-loop mode

## Test plan

- [x] Run \`./scripts/dev_checks.sh --timing\`, confirm both pyright and pytest duration records appear and total wall time dropped from ~54s to ~45s
- [x] Confirm pyright output still prints (captured and dumped after wait)
- [x] Confirm pytest output still prints
- [ ] Manually introduce a pyright error, confirm script exits with pyright's exit code after both complete
- [ ] Manually introduce a failing test, confirm script exits with pytest's exit code

---
*Posted by Claude Code (claude-opus-4-6[1m])*