### PR TITLE
feat(dev_checks): add --fast inner-loop mode

### DIFF
--- a/changelog.d/dev-checks-fast-mode.md
+++ b/changelog.d/dev-checks-fast-mode.md
@@ -2,4 +2,4 @@
 category: Chores & Docs
 ---
 
-**dev_checks: `--fast` inner-loop mode**: Added `--fast` flag that skips coverage in pytest and skips report-only steps (ruff docstrings, radon). Gating checks (ruff, pyright, pytest) still run. Saves ~13s on a typical warm run (~45s → ~32s). Use while iterating; run the full gate before pushing.
+**dev_checks: `--skip-reports` / `--fast` inner-loop mode**: Added `--skip-reports` flag that skips report-only steps (ruff docstrings, radon) and pytest coverage. Gating checks (ruff, pyright, pytest) still run. `--fast` is an alias that may enable more shortcuts in the future. Saves ~13s on a typical warm run (~45s → ~32s). Use while iterating; run the full gate before pushing.

--- a/changelog.d/dev-checks-fast-mode.md
+++ b/changelog.d/dev-checks-fast-mode.md
@@ -1,0 +1,5 @@
+---
+category: Chores & Docs
+---
+
+**dev_checks: `--fast` inner-loop mode**: Added `--fast` flag that skips coverage in pytest and skips report-only steps (ruff docstrings, radon). Gating checks (ruff, pyright, pytest) still run. Saves ~13s on a typical warm run (~45s → ~32s). Use while iterating; run the full gate before pushing.

--- a/dev-README.md
+++ b/dev-README.md
@@ -73,7 +73,8 @@ Flags:
 |------|--------|
 | `--timing` | Write per-step wall-clock timings to `.dev_checks_timings.jsonl` (one JSON object per step) and print a summary at the end. Useful for diagnosing slowdowns. |
 | `--timing=PATH` | Same as `--timing` but write to a custom path. |
-| `--fast` | Inner-loop mode: skip coverage in pytest and skip report-only steps (ruff docstrings, radon). Gating checks (ruff, pyright, pytest) still run. Typical savings ~10-12s (~45s → ~34s). Use `--fast` while iterating, then run the full gate before pushing. |
+| `--skip-reports` | Skip report-only steps (ruff docstrings, radon) and pytest coverage. Gating checks (ruff, pyright, pytest) still run. Saves ~13s (~45s → ~32s). |
+| `--fast` | Alias for `--skip-reports` (may enable more inner-loop shortcuts in the future). Use while iterating; run the full gate before pushing. |
 
 Each JSONL record has `run_id`, `step`, `duration_s`, `exit_code`, `ts`. A final `__total__` record captures wall-clock for the whole run. The file is gitignored.
 

--- a/dev-README.md
+++ b/dev-README.md
@@ -73,6 +73,7 @@ Flags:
 |------|--------|
 | `--timing` | Write per-step wall-clock timings to `.dev_checks_timings.jsonl` (one JSON object per step) and print a summary at the end. Useful for diagnosing slowdowns. |
 | `--timing=PATH` | Same as `--timing` but write to a custom path. |
+| `--fast` | Inner-loop mode: skip coverage in pytest and skip report-only steps (ruff docstrings, radon). Gating checks (ruff, pyright, pytest) still run. Typical savings ~10-12s (~45s → ~34s). Use `--fast` while iterating, then run the full gate before pushing. |
 
 Each JSONL record has `run_id`, `step`, `duration_s`, `exit_code`, `ts`. A final `__total__` record captures wall-clock for the whole run. The file is gitignored.
 

--- a/scripts/dev_checks.sh
+++ b/scripts/dev_checks.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 TIMING_FILE=""
-FAST_MODE=0
+SKIP_REPORTS=0
 for arg in "$@"; do
     case "$arg" in
         --timing)
@@ -14,19 +14,26 @@ for arg in "$@"; do
         --timing=*)
             TIMING_FILE="${arg#--timing=}"
             ;;
+        --skip-reports)
+            SKIP_REPORTS=1
+            ;;
         --fast)
-            FAST_MODE=1
+            # --fast is shorthand for the current fastest inner-loop combo.
+            # Today that's just --skip-reports. Additional knobs may be added
+            # here in the future without breaking --skip-reports' meaning.
+            SKIP_REPORTS=1
             ;;
         --help|-h)
             cat <<'USAGE'
-Usage: dev_checks.sh [--timing[=PATH]] [--fast]
+Usage: dev_checks.sh [--timing[=PATH]] [--skip-reports] [--fast]
 
   --timing[=PATH]  Record per-step wall-clock timings as JSONL
                    (default path: .dev_checks_timings.jsonl).
-  --fast           Inner-loop mode: skip coverage in pytest and skip
-                   report-only steps (ruff docstrings, radon). Gating
-                   checks (ruff, pyright, pytest) still run. Typical
-                   savings: ~20s (~45s -> ~25s).
+  --skip-reports   Skip report-only steps (ruff docstrings, radon) and
+                   pytest coverage. Gating checks (ruff, pyright, pytest)
+                   still run. Saves ~13s.
+  --fast           Alias for --skip-reports (may enable more inner-loop
+                   shortcuts in the future).
 USAGE
             exit 0
             ;;
@@ -170,7 +177,7 @@ fi
 echo "== Ruff lint (E/F/I/D gating) =="
 step "ruff_check" uv run ruff check
 
-if [[ $FAST_MODE -eq 0 ]]; then
+if [[ $SKIP_REPORTS -eq 0 ]]; then
     echo "== Ruff docstrings (report-only) =="
     run_ruff_docstrings() { uv run ruff check --select D --exit-zero || true; }
     step "ruff_docstrings" run_ruff_docstrings
@@ -216,7 +223,7 @@ pyright_start=$(now_epoch)
 PYRIGHT_PID=$!
 
 pytest_start=$(now_epoch)
-if [[ $FAST_MODE -eq 1 ]]; then
+if [[ $SKIP_REPORTS -eq 1 ]]; then
     ( set +e; uv run -m pytest -q --no-cov > "$PYTEST_LOG" 2>&1; rc=$?; now_epoch > "$PYTEST_END_FILE"; exit "$rc" ) &
 else
     ( set +e; uv run -m pytest -q > "$PYTEST_LOG" 2>&1; rc=$?; now_epoch > "$PYTEST_END_FILE"; exit "$rc" ) &
@@ -259,7 +266,7 @@ if [[ $PYRIGHT_RC -ne 0 || $PYTEST_RC -ne 0 ]]; then
     exit "$PYRIGHT_RC"
 fi
 
-if [[ $FAST_MODE -eq 0 ]]; then
+if [[ $SKIP_REPORTS -eq 0 ]]; then
     echo "== Radon complexity (report-only) =="
     run_radon() { uv run radon cc -s -a src || true; }
     step "radon" run_radon

--- a/scripts/dev_checks.sh
+++ b/scripts/dev_checks.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 TIMING_FILE=""
+FAST_MODE=0
 for arg in "$@"; do
     case "$arg" in
         --timing)
@@ -12,6 +13,22 @@ for arg in "$@"; do
             ;;
         --timing=*)
             TIMING_FILE="${arg#--timing=}"
+            ;;
+        --fast)
+            FAST_MODE=1
+            ;;
+        --help|-h)
+            cat <<'USAGE'
+Usage: dev_checks.sh [--timing[=PATH]] [--fast]
+
+  --timing[=PATH]  Record per-step wall-clock timings as JSONL
+                   (default path: .dev_checks_timings.jsonl).
+  --fast           Inner-loop mode: skip coverage in pytest and skip
+                   report-only steps (ruff docstrings, radon). Gating
+                   checks (ruff, pyright, pytest) still run. Typical
+                   savings: ~20s (~45s -> ~25s).
+USAGE
+            exit 0
             ;;
     esac
 done
@@ -153,9 +170,11 @@ fi
 echo "== Ruff lint (E/F/I/D gating) =="
 step "ruff_check" uv run ruff check
 
-echo "== Ruff docstrings (report-only) =="
-run_ruff_docstrings() { uv run ruff check --select D --exit-zero || true; }
-step "ruff_docstrings" run_ruff_docstrings
+if [[ $FAST_MODE -eq 0 ]]; then
+    echo "== Ruff docstrings (report-only) =="
+    run_ruff_docstrings() { uv run ruff check --select D --exit-zero || true; }
+    step "ruff_docstrings" run_ruff_docstrings
+fi
 
 echo "== Pyright + Tests (parallel) =="
 # Pyright and pytest are independent; running them concurrently saves ~10s.
@@ -197,7 +216,11 @@ pyright_start=$(now_epoch)
 PYRIGHT_PID=$!
 
 pytest_start=$(now_epoch)
-( set +e; uv run -m pytest -q > "$PYTEST_LOG" 2>&1; rc=$?; now_epoch > "$PYTEST_END_FILE"; exit "$rc" ) &
+if [[ $FAST_MODE -eq 1 ]]; then
+    ( set +e; uv run -m pytest -q --no-cov > "$PYTEST_LOG" 2>&1; rc=$?; now_epoch > "$PYTEST_END_FILE"; exit "$rc" ) &
+else
+    ( set +e; uv run -m pytest -q > "$PYTEST_LOG" 2>&1; rc=$?; now_epoch > "$PYTEST_END_FILE"; exit "$rc" ) &
+fi
 PYTEST_PID=$!
 
 set +e
@@ -236,9 +259,11 @@ if [[ $PYRIGHT_RC -ne 0 || $PYTEST_RC -ne 0 ]]; then
     exit "$PYRIGHT_RC"
 fi
 
-echo "== Radon complexity (report-only) =="
-run_radon() { uv run radon cc -s -a src || true; }
-step "radon" run_radon
+if [[ $FAST_MODE -eq 0 ]]; then
+    echo "== Radon complexity (report-only) =="
+    run_radon() { uv run radon cc -s -a src || true; }
+    step "radon" run_radon
+fi
 
 echo "== Clean tree check (post) =="
 if ! git diff --quiet 2>/dev/null; then


### PR DESCRIPTION
## Summary

- Adds \`--fast\` flag to \`scripts/dev_checks.sh\` for the iterate-locally case
- In \`--fast\`: pytest runs with \`--no-cov\`, and the report-only steps (ruff docstrings, radon) are skipped
- Gating checks (ruff lint, pyright, pytest) still run — this is a speed knob, not a correctness knob
- Adds \`--help\` / \`-h\` output documenting all flags

## Measured savings (warm run, this worktree)

| Mode | Wall time | Notes |
|---|---|---|
| Full gate | 45.5s | Baseline after the parallel pyright/pytest PR |
| \`--fast\` | **32.5s** | -13s: pytest -10s (no coverage), skipped radon/docstrings -0.4s, rest is wall-clock alignment |

## Stack

1. #585 — timing instrumentation
2. #586 — concurrent pyright + pytest
3. **This PR** — \`--fast\` inner-loop mode

## Test plan

- [x] \`./scripts/dev_checks.sh --fast --timing\`: confirm ruff_docstrings and radon steps are skipped, pytest runs with --no-cov, total under ~35s
- [x] \`./scripts/dev_checks.sh --timing\`: confirm full-gate behavior unchanged, all steps still present
- [x] \`./scripts/dev_checks.sh --help\`: prints usage
- [ ] Introduce a failing unit test with \`--fast\`: confirm exit code propagates

## Workflow guidance

The README now explicitly calls out that \`--fast\` is for iterating and the full gate is required before pushing. This preserves CI fidelity while giving a much tighter inner-loop.

---
*Posted by Claude Code (claude-opus-4-6[1m])*