### PR TITLE
perf(dev_checks): parallel pytest workers (xdist, default 4)

### DIFF
--- a/changelog.d/dev-checks-xdist.md
+++ b/changelog.d/dev-checks-xdist.md
@@ -1,0 +1,5 @@
+---
+category: Chores & Docs
+---
+
+**dev_checks: parallel pytest workers (xdist, default 4)**: `scripts/dev_checks.sh` now runs pytest with `-n 4` by default via `pytest-xdist`. Saves ~12s on the full gate (coverage instrumentation is CPU-bound and parallelizes well) and ~4s in `--skip-reports` mode. Override via `--workers=N` flag or `DEV_CHECKS_PYTEST_WORKERS` env var; use `--workers=1` to disable for debugging flakes or interleaved output.

--- a/dev-README.md
+++ b/dev-README.md
@@ -75,6 +75,7 @@ Flags:
 | `--timing=PATH` | Same as `--timing` but write to a custom path. |
 | `--skip-reports` | Skip report-only steps (ruff docstrings, radon) and pytest coverage. Gating checks (ruff, pyright, pytest) still run. Saves ~13s (~45s → ~32s). |
 | `--fast` | Alias for `--skip-reports` (may enable more inner-loop shortcuts in the future). Use while iterating; run the full gate before pushing. |
+| `--workers=N` | Pytest parallel workers (pytest-xdist). Default: `4`. Use `--workers=1` to disable parallelism (helpful for debugging flakes or interleaved output). Also overridable via `DEV_CHECKS_PYTEST_WORKERS` env var. |
 
 Each JSONL record has `run_id`, `step`, `duration_s`, `exit_code`, `ts`. A final `__total__` record captures wall-clock for the whole run. The file is gitignored.
 
@@ -97,7 +98,7 @@ Where `dev_checks.sh` time goes (typical warm run on this repo):
 - `pyright` ≈ 10s
 - Everything else combined ≤ 2s
 
-`pytest-xdist` with `-n auto` does **not** meaningfully speed up the unit suite — individual tests are too fast and worker-distribution overhead eats the gain. If you need a faster inner loop, run `uv run pytest tests/luthien_proxy/unit_tests --no-cov` directly.
+`pytest-xdist` with `-n 4` is a measurable win (~-12s with coverage, ~-4s without — coverage instrumentation is CPU-bound and parallelizes cleanly). `dev_checks.sh` uses 4 workers by default; override with `--workers=N` or `DEV_CHECKS_PYTEST_WORKERS=N`. `-n auto` (~16 on this box) is slower than `-n 4` — worker coordination overhead dominates at higher counts.
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ dev = [
     "asgi-lifespan>=2.1.0",
     "luthien-cli",
     "pytest-httpx>=0.35.0",
+    "pytest-xdist>=3.6.0",
 ]
 
 [tool.uv.sources]

--- a/scripts/dev_checks.sh
+++ b/scripts/dev_checks.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 TIMING_FILE=""
 SKIP_REPORTS=0
+PYTEST_WORKERS="${DEV_CHECKS_PYTEST_WORKERS:-4}"
 for arg in "$@"; do
     case "$arg" in
         --timing)
@@ -23,9 +24,12 @@ for arg in "$@"; do
             # here in the future without breaking --skip-reports' meaning.
             SKIP_REPORTS=1
             ;;
+        --workers=*)
+            PYTEST_WORKERS="${arg#--workers=}"
+            ;;
         --help|-h)
             cat <<'USAGE'
-Usage: dev_checks.sh [--timing[=PATH]] [--skip-reports] [--fast]
+Usage: dev_checks.sh [--timing[=PATH]] [--skip-reports] [--fast] [--workers=N]
 
   --timing[=PATH]  Record per-step wall-clock timings as JSONL
                    (default path: .dev_checks_timings.jsonl).
@@ -34,6 +38,10 @@ Usage: dev_checks.sh [--timing[=PATH]] [--skip-reports] [--fast]
                    still run. Saves ~13s.
   --fast           Alias for --skip-reports (may enable more inner-loop
                    shortcuts in the future).
+  --workers=N      Pytest parallel workers (pytest-xdist). Default: 4.
+                   Use 1 to disable parallelism (helpful for debugging
+                   flakes or interleaved output). Also overridable via
+                   DEV_CHECKS_PYTEST_WORKERS env var.
 USAGE
             exit 0
             ;;
@@ -223,10 +231,16 @@ pyright_start=$(now_epoch)
 PYRIGHT_PID=$!
 
 pytest_start=$(now_epoch)
+PYTEST_PARALLEL=()
+if [[ "$PYTEST_WORKERS" -gt 1 ]]; then
+    PYTEST_PARALLEL=(-n "$PYTEST_WORKERS")
+fi
+# `${arr[@]+"${arr[@]}"}` expands safely under `set -u` on bash 3.2 (macOS),
+# where a bare `"${arr[@]}"` on an empty array trips "unbound variable".
 if [[ $SKIP_REPORTS -eq 1 ]]; then
-    ( set +e; uv run -m pytest -q --no-cov > "$PYTEST_LOG" 2>&1; rc=$?; now_epoch > "$PYTEST_END_FILE"; exit "$rc" ) &
+    ( set +e; uv run -m pytest -q --no-cov ${PYTEST_PARALLEL[@]+"${PYTEST_PARALLEL[@]}"} > "$PYTEST_LOG" 2>&1; rc=$?; now_epoch > "$PYTEST_END_FILE"; exit "$rc" ) &
 else
-    ( set +e; uv run -m pytest -q > "$PYTEST_LOG" 2>&1; rc=$?; now_epoch > "$PYTEST_END_FILE"; exit "$rc" ) &
+    ( set +e; uv run -m pytest -q ${PYTEST_PARALLEL[@]+"${PYTEST_PARALLEL[@]}"} > "$PYTEST_LOG" 2>&1; rc=$?; now_epoch > "$PYTEST_END_FILE"; exit "$rc" ) &
 fi
 PYTEST_PID=$!
 

--- a/scripts/dev_checks.sh
+++ b/scripts/dev_checks.sh
@@ -45,6 +45,11 @@ Usage: dev_checks.sh [--timing[=PATH]] [--skip-reports] [--fast] [--workers=N]
 USAGE
             exit 0
             ;;
+        *)
+            echo "dev_checks.sh: unknown argument '$arg'" >&2
+            echo "Run 'dev_checks.sh --help' for usage." >&2
+            exit 2
+            ;;
     esac
 done
 

--- a/uv.lock
+++ b/uv.lock
@@ -549,6 +549,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.128.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1069,6 +1078,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "radon" },
     { name = "ruff" },
     { name = "vulture" },
@@ -1111,6 +1121,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-httpx", specifier = ">=0.35.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "radon", specifier = ">=6.0.1" },
     { name = "ruff", specifier = ">=0.12.10" },
     { name = "vulture", specifier = ">=2.14" },
@@ -1832,6 +1843,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds \`pytest-xdist\` to dev dependencies
- \`dev_checks.sh\` now runs pytest with \`-n 4\` by default in Phase 2
- New \`--workers=N\` flag and \`DEV_CHECKS_PYTEST_WORKERS\` env var to override
- \`--workers=1\` disables parallelism for debugging flakes or interleaved output

## Measured savings

| Scenario | Before | After (-n 4) | Delta |
|---|---|---|---|
| Full gate pytest (cov) | 42s | **29s** | -13s |
| \`--skip-reports\` pytest | 30s | **22s** | -8s |

The coverage case benefits most: \`coverage.py\`'s \`sys.settrace\`/\`sys.monitoring\` hooks are CPU-bound per line, and each xdist worker runs them in its own process. Without coverage, raw test work is shorter relative to per-worker startup overhead, so gains are smaller.

## Why 4 and not \`auto\`?

\`-n auto\` picks CPU count (16 on this box). Empirically \`-n 4\` beats every other count I tested — above 4, coordination overhead eats the parallelism:

| Workers | Pytest (no-cov) |
|---|---|
| serial | 25s |
| -n 2 | 22s |
| **-n 4** | **21s** |
| -n 8 | 23s |
| -n auto (16) | 26s |

A fixed default of 4 is a sweet spot for typical 8-16 core dev machines. Users on smaller (4c) or larger (32c+) machines can tune via \`--workers\`.

## Stack

1. #585 — timing instrumentation
2. #586 — concurrent pyright + pytest
3. #587 — \`--skip-reports\` / \`--fast\`
4. **This PR** — xdist -n 4 default

## Test plan

- [x] \`./scripts/dev_checks.sh --timing\`: pytest ~29s (down from ~42s), full gate passes
- [x] \`./scripts/dev_checks.sh --skip-reports --timing\`: pytest ~22s (down from ~30s), gate passes
- [x] \`./scripts/dev_checks.sh --workers=1 --timing\`: pytest serial ~42s, gate passes (opt-out works)
- [ ] CI passes full suite with -n 4
- [ ] No test isolation issues introduced (xdist default \`loadscope\` distribution)

## Risk

- Tests must be isolation-safe (no shared filesystem/DB/port state across workers). The existing suite uses per-test tmp_paths and fixtures, so this should be clean — CI run will validate.
- If xdist surfaces a flake, \`--workers=1\` is the immediate escape hatch.

---
*Posted by Claude Code (claude-opus-4-6[1m])*