### PR TITLE
fix: replace generic Railway deploy link with real template

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 curl -fsSL https://luthien.cc/install.sh | bash  # local install, no Docker needed
 ```
 
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/luthien-proxy-oneclick)
+
 [What does it look like?](#what-does-it-look-like) | [What can it do?](#what-can-it-do) | [How does it work?](#how-does-it-work) | [Quick start](#quick-start)
 
 Open-source proxy that sits between Claude Code and the Anthropic API.

--- a/changelog.d/railway-template.md
+++ b/changelog.d/railway-template.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**Fix Railway one-click deploy button**: Replace generic GitHub-URL deploy link with a published Railway template that deploys a minimal proxy-only service (SQLite, passthrough auth, no API keys required)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -7,7 +7,7 @@ setup required — just deploy, generate a domain, and point Claude Code at it.
 
 ### 1. Deploy
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template?template=https://github.com/LuthienResearch/luthien-proxy)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/5pk_06)
 
 ### 2. Generate a domain
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -7,7 +7,7 @@ setup required — just deploy, generate a domain, and point Claude Code at it.
 
 ### 1. Deploy
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/5pk_06)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/luthien-proxy-oneclick)
 
 ### 2. Generate a domain
 

--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,5 @@
 # Railway deployment configuration for Luthien Proxy
-# Deploy: https://railway.com/deploy/5pk_06
+# Deploy: https://railway.com/deploy/luthien-proxy-oneclick
 #
 # One-click deploy: the app detects Railway and boots with sensible defaults:
 #   - SQLite database (no Postgres needed for single-user)

--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,5 @@
 # Railway deployment configuration for Luthien Proxy
-# Deploy: https://railway.app/new/template?template=https://github.com/luthienresearch/luthien-proxy
+# Deploy: https://railway.com/deploy/5pk_06
 #
 # One-click deploy: the app detects Railway and boots with sensible defaults:
 #   - SQLite database (no Postgres needed for single-user)


### PR DESCRIPTION
## Summary

- The "Deploy on Railway" button in `deploy/README.md` previously linked to Railway's generic new-project form (`railway.app/new/template?template=<github-url>`), which just prefilled the repo URL — no services, no env vars, no configuration
- Created a proper Railway template (`luthien-proxy-oneclick`) via the Railway template composer: single proxy service, auto-generated `ADMIN_API_KEY` via `${{secret(32)}}`, no other prompts
- Updated button URL to `railway.com/deploy/luthien-proxy-oneclick` and migrated `railway.app` → `railway.com` (the old domain 301-redirects)

### Railway infra created

- **Template**: `luthien-proxy-oneclick` (published via Railway template composer)
- **Deploy URL**: https://railway.com/deploy/luthien-proxy-oneclick
- Each deployment gets a unique `ADMIN_API_KEY` auto-generated by Railway, visible in the deployer's dashboard (service → Variables tab)

## Test plan

- [x] Deploy URL returns 200
- [x] Template deploys with auto-generated ADMIN_API_KEY
- [x] Health check passing on live deployment
- [ ] Manual: click deploy button, verify Railway shows one-service deploy form with no required user input

---
*Posted by Claude Code (Claude Opus 4.6)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)