### PR TITLE
docs(README): fix install one-liner for zsh users

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ### Claude Code builds. You stay in control.
 
 ```bash
-curl -fsSL https://luthien.cc/install.sh | bash  # local install, no Docker needed
+# Local install, no Docker needed
+curl -fsSL https://luthien.cc/install.sh | bash
 ```
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/luthien-proxy-oneclick)


### PR DESCRIPTION
## Summary
- The README's install one-liner had a trailing inline shell comment:
  `curl -fsSL https://luthien.cc/install.sh | bash  # local install, no Docker needed`
- Copy-pasting that into zsh (default config, no `interactive_comments`) breaks with:
  ```
  bash: #: No such file or directory
  ```
  because zsh passes `#` and the trailing words as arguments to `bash`, which then tries to execute a script named `#`.
- Moved the comment onto its own line above the command so it works in both bash and zsh.

## Test plan
- [ ] Paste the updated block into a default zsh shell — the installer runs, no `bash: #` error
- [ ] Paste into bash — still runs as before

---
*Posted by Claude Code (claude-opus-4-7)*