### PR TITLE
docs(README): move install one-liner caption out of code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 ### Claude Code builds. You stay in control.
 
+Local install, no Docker needed:
+
 ```bash
-# Local install, no Docker needed
 curl -fsSL https://luthien.cc/install.sh | bash
 ```
 


### PR DESCRIPTION
## Summary
Follow-up to #592. The prior fix moved the caption to its own line inside the fenced bash block:

```bash
# Local install, no Docker needed
curl -fsSL https://luthien.cc/install.sh | bash
```

That still breaks in default zsh (no `interactive_comments`) when copy-pasted — zsh treats `#` as a literal command:

```
zsh: command not found: #
```

This PR moves the caption into plain markdown prose above the block, so the fenced block contains only the runnable command. Safe to paste into any shell.

## Test plan
- [ ] Paste the full fenced block into default zsh — installer runs, no `command not found` error
- [ ] Paste into bash — still runs as before

---
*Posted by Claude Code (claude-opus-4-7)*