### PR TITLE
docs(README): drop 'no Docker needed' caption above install one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ### Claude Code builds. You stay in control.
 
-Local install, no Docker needed:
-
 ```bash
 curl -fsSL https://luthien.cc/install.sh | bash
 ```


### PR DESCRIPTION
## Summary
Removes the \`Local install, no Docker needed:\` caption above the install one-liner. The fenced block stands on its own.

## Test plan
- [ ] README renders cleanly on GitHub
- [ ] One-liner still copy-pastes into bash/zsh without issue

---
*Posted by Claude Code (claude-opus-4-7)*