### PR TITLE
chore: remove deprecated UI redirects

### DIFF
--- a/changelog.d/remove-deprecated-ui-redirects.md
+++ b/changelog.d/remove-deprecated-ui-redirects.md
@@ -1,5 +1,6 @@
 ---
 category: Chores & Docs
+pr: 597
 ---
 
 **Remove deprecated UI redirect routes**: Dropped legacy backwards-compat redirects with no internal callers.

--- a/changelog.d/remove-deprecated-ui-redirects.md
+++ b/changelog.d/remove-deprecated-ui-redirects.md
@@ -1,0 +1,8 @@
+---
+category: Chores & Docs
+---
+
+**Remove deprecated UI redirect routes**: Dropped legacy backwards-compat redirects with no internal callers.
+  - `GET /activity/monitor` (previously redirected to `/history`)
+  - `GET /debug/diff` (previously redirected to `/diffs`)
+  - `GET /history/session/{session_id}` (previously redirected to `/conversation/live/{session_id}`)

--- a/src/luthien_proxy/history/routes.py
+++ b/src/luthien_proxy/history/routes.py
@@ -11,10 +11,9 @@ from __future__ import annotations
 
 import logging
 import os
-from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from fastapi.responses import FileResponse, PlainTextResponse, RedirectResponse
+from fastapi.responses import FileResponse, PlainTextResponse
 
 from luthien_proxy.auth import check_auth_or_redirect, verify_admin_token
 from luthien_proxy.dependencies import get_admin_key, get_db_pool
@@ -53,15 +52,6 @@ async def history_list_page(
     if redirect:
         return redirect
     return FileResponse(os.path.join(STATIC_DIR, "history_list.html"))
-
-
-@router.get("/session/{session_id}")
-async def deprecated_history_detail_redirect(session_id: str):
-    """Redirect old history detail path to live conversation view.
-
-    No auth check here — the redirect target handles auth.
-    """
-    return RedirectResponse(url=f"/conversation/live/{quote(session_id, safe='')}", status_code=301)
 
 
 # --- JSON API Endpoints ---

--- a/src/luthien_proxy/ui/routes.py
+++ b/src/luthien_proxy/ui/routes.py
@@ -188,7 +188,6 @@ async def client_setup(request: Request):
     return HTMLResponse(html)
 
 
-# Redirect handlers for deprecated paths
 @router.get("/admin/{path:path}")
 async def deprecated_admin_redirect(path: str):
     """Redirect old admin paths to new API location."""

--- a/src/luthien_proxy/ui/routes.py
+++ b/src/luthien_proxy/ui/routes.py
@@ -63,12 +63,6 @@ async def landing_page():
     return FileResponse(os.path.join(STATIC_DIR, "index.html"))
 
 
-@router.get("/activity/monitor")
-async def deprecated_activity_monitor_redirect():
-    """Redirect old activity monitor path to history."""
-    return RedirectResponse(url="/history", status_code=301)
-
-
 @router.get("/debug/activity")
 async def debug_activity_monitor(
     request: Request,
@@ -195,12 +189,6 @@ async def client_setup(request: Request):
 
 
 # Redirect handlers for deprecated paths
-@router.get("/debug/diff")
-async def deprecated_diff_redirect():
-    """Redirect old debug diff path to new location."""
-    return RedirectResponse(url="/diffs", status_code=301)
-
-
 @router.get("/admin/{path:path}")
 async def deprecated_admin_redirect(path: str):
     """Redirect old admin paths to new API location."""

--- a/tests/luthien_proxy/unit_tests/history/test_routes.py
+++ b/tests/luthien_proxy/unit_tests/history/test_routes.py
@@ -258,25 +258,3 @@ class TestExportSessionRoute:
             assert ">" not in disposition
             assert "(" not in disposition
             assert ")" not in disposition
-
-
-class TestDeprecatedHistoryDetailRedirect:
-    """Test deprecated /history/session/{id} redirects to live view."""
-
-    @pytest.mark.asyncio
-    async def test_redirects_to_conversation_live(self):
-        from luthien_proxy.history.routes import deprecated_history_detail_redirect
-
-        result = await deprecated_history_detail_redirect("test-session-123")
-        assert result.status_code == 301
-        assert result.headers["location"] == "/conversation/live/test-session-123"
-
-    @pytest.mark.asyncio
-    async def test_url_encodes_special_characters(self):
-        from luthien_proxy.history.routes import deprecated_history_detail_redirect
-
-        result = await deprecated_history_detail_redirect("id with spaces#fragment")
-        location = result.headers["location"]
-        assert " " not in location
-        assert "#" not in location
-        assert "id%20with%20spaces%23fragment" in location

--- a/tests/luthien_proxy/unit_tests/ui/test_routes.py
+++ b/tests/luthien_proxy/unit_tests/ui/test_routes.py
@@ -84,16 +84,6 @@ class TestClientSetup:
         assert "https://test" in response.text
 
 
-class TestDeprecatedRedirects:
-    """Test redirect handlers for consolidated views."""
-
-    @pytest.mark.asyncio
-    async def test_activity_monitor_redirects_to_history(self, client: AsyncClient):
-        response = await client.get("/activity/monitor", follow_redirects=False)
-        assert response.status_code == 301
-        assert response.headers["location"] == "/history"
-
-
 class TestLandingPage:
     """Test landing page includes client-setup link."""
 


### PR DESCRIPTION
## Summary

Removes three legacy backwards-compat redirect routes that have no internal callers.

**Removed routes:**
- `GET /activity/monitor` -> previously redirected to `/history` (301)
- `GET /debug/diff` -> previously redirected to `/diffs` (301)
- `GET /history/session/{session_id}` -> previously redirected to `/conversation/live/{session_id}` (301)

Also drops the corresponding redirect unit tests in `tests/luthien_proxy/unit_tests/ui/test_routes.py` and `tests/luthien_proxy/unit_tests/history/test_routes.py`, and unused `RedirectResponse` / `urllib.parse.quote` imports in `src/luthien_proxy/history/routes.py`.

The `/admin/{path:path}` -> `/api/admin/{path}` redirect is intentionally left in place (separate concern tracked elsewhere).

## Impact

- **Internal code:** none — verified via `rg` across `src/` and `tests/`; remaining matches in `test_auth.py` / `test_session.py` only use `/activity/monitor` as an arbitrary sample path for generic URL validation, not to exercise the route.
- **External:** user bookmarks pointing at the old paths will 404. Acceptable per the code-review pass that flagged these as dead.

## Test plan

- [x] `scripts/dev_checks.sh` passed all lint / type / unit test checks locally
- [ ] CI green on this branch

---
*Posted by Claude Code (Claude Opus 4.7 (1M context))*