### PR TITLE
chore: migrate admin UI off deprecated /gateway/settings endpoint

### DIFF
--- a/changelog.d/migrate-off-deprecated-gateway-settings-endpoint.md
+++ b/changelog.d/migrate-off-deprecated-gateway-settings-endpoint.md
@@ -1,0 +1,5 @@
+---
+category: Refactors
+---
+
+**Remove deprecated `/api/admin/gateway/settings` endpoint**: The policy config UI now reads/writes `inject_policy_context` and `dogfood_mode` via the canonical `/api/admin/config` and `/api/admin/config/{key}` endpoints. The superseded `GET`/`PUT /api/admin/gateway/settings` handlers have been deleted.

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -617,60 +617,6 @@ async def update_telemetry_config(
     return {"success": True, "enabled": body.enabled}
 
 
-# === Gateway Settings ===
-
-
-class GatewaySettingsResponse(BaseModel):
-    """Response with current gateway settings."""
-
-    inject_policy_context: bool
-    dogfood_mode: bool
-
-
-class GatewaySettingsUpdateRequest(BaseModel):
-    """Request to update gateway settings."""
-
-    inject_policy_context: bool | None = None
-    dogfood_mode: bool | None = None
-
-
-@router.get("/gateway/settings", response_model=GatewaySettingsResponse, deprecated=True)
-async def get_gateway_settings(
-    _: str = Depends(verify_admin_token),
-):
-    """Get current gateway settings.
-
-    Deprecated: use GET /api/admin/config instead for all config with provenance.
-    """
-    settings = get_settings()
-    return GatewaySettingsResponse(
-        inject_policy_context=settings.inject_policy_context,
-        dogfood_mode=settings.dogfood_mode,
-    )
-
-
-@router.put("/gateway/settings", response_model=GatewaySettingsResponse, deprecated=True)
-async def update_gateway_settings(
-    body: GatewaySettingsUpdateRequest,
-    _: str = Depends(verify_admin_token),
-    registry: ConfigRegistry = Depends(require_config_registry),
-):
-    """Update gateway settings at runtime.
-
-    Deprecated: use PUT /api/admin/config/{key} instead.
-    Persists to DB via the config registry so values survive restarts.
-    """
-    if body.inject_policy_context is not None:
-        await registry.set_db_value("inject_policy_context", body.inject_policy_context)
-    if body.dogfood_mode is not None:
-        await registry.set_db_value("dogfood_mode", body.dogfood_mode)
-    settings = get_settings()
-    return GatewaySettingsResponse(
-        inject_policy_context=settings.inject_policy_context,
-        dogfood_mode=settings.dogfood_mode,
-    )
-
-
 # === Unified Config Dashboard ===
 
 

--- a/src/luthien_proxy/static/policy_config.js
+++ b/src/luthien_proxy/static/policy_config.js
@@ -181,9 +181,11 @@ async function loadModels() {
 
 async function loadGatewaySettings() {
     try {
-        const data = await apiCall('/api/admin/gateway/settings');
-        document.getElementById('set-inject').checked = data.inject_policy_context;
-        document.getElementById('set-dogfood').checked = data.dogfood_mode;
+        // Canonical config API returns { config: [ { name, value, ... }, ... ] }
+        const data = await apiCall('/api/admin/config');
+        const byName = Object.fromEntries((data.config || []).map(f => [f.name, f.value]));
+        document.getElementById('set-inject').checked = Boolean(byName.inject_policy_context);
+        document.getElementById('set-dogfood').checked = Boolean(byName.dogfood_mode);
     } catch (e) {
         console.warn('Failed to load gateway settings:', e);
     }
@@ -230,9 +232,9 @@ function defaultConfigFor(policy) {
 
 async function saveGatewaySetting(field, value) {
     try {
-        await apiCall('/api/admin/gateway/settings', {
+        await apiCall(`/api/admin/config/${encodeURIComponent(field)}`, {
             method: 'PUT',
-            body: JSON.stringify({ [field]: value })
+            body: JSON.stringify({ value })
         });
     } catch (e) {
         console.error('Failed to save gateway setting:', e);

--- a/tests/luthien_proxy/e2e_tests/test_mock_auth.py
+++ b/tests/luthien_proxy/e2e_tests/test_mock_auth.py
@@ -118,6 +118,6 @@ async def test_admin_endpoint_accepts_admin_key(gateway_healthy, gateway_url, ad
 # NOTE: A test for "admin endpoints require auth in non-localhost mode" is not
 # implemented here because mock_e2e tests run against an out-of-process gateway,
 # making in-process patching of is_localhost_request ineffective.
-# To test this properly: add localhost_auth_bypass to the admin settings API
-# (PUT /api/admin/gateway/settings), then toggle it off, assert 401, toggle back.
+# To test this properly: add localhost_auth_bypass to the admin config API
+# (PUT /api/admin/config/{key}), then toggle it off, assert 401, toggle back.
 # Alternatively, implement as a sqlite_e2e test where the gateway runs in-process.


### PR DESCRIPTION
## Summary

- Policy config UI now reads/writes `inject_policy_context` and `dogfood_mode` via the canonical config API (`GET /api/admin/config`, `PUT /api/admin/config/{key}`) instead of the `deprecated=True`-marked `/api/admin/gateway/settings` handlers.
- Deleted the now-unused `GET`/`PUT /api/admin/gateway/settings` handlers and their `GatewaySettingsResponse` / `GatewaySettingsUpdateRequest` models from `admin/routes.py`. The `deprecated=True` marker was docs-only — the admin UI JS was still the live caller.
- Updated a stale comment in `tests/luthien_proxy/e2e_tests/test_mock_auth.py` that referenced the removed endpoint.

The canonical `GET /api/admin/config` returns `{"config": [{name, value, source, ...}, ...]}`, so the JS builds a `{name: value}` lookup and pulls out the two fields it needs. `PUT /api/admin/config/{key}` takes `{"value": <new>}`.

No unit tests exercised the deprecated pair, so none were deleted.

## Test plan

- [x] `./scripts/dev_checks.sh` — format, lint, tests, pyright all clean
- [x] `uv run pytest tests/luthien_proxy/unit_tests/test_admin_routes.py` — all 64 admin route tests pass
- [x] Curl smoke test on dockerless gateway (sqlite): `GET /api/admin/config` returns both fields; `PUT /api/admin/config/dogfood_mode {"value": true}` persists; old `GET /api/admin/gateway/settings` now 404s
- [x] Browser smoke test via Playwright: loaded `/policy-config`, both toggles hydrated from the canonical API, flipped `inject_policy_context` off through the UI handler (`saveGatewaySetting`), reloaded, confirmed the off state persisted

---
*Posted by Claude Code (Opus 4.7 1M context)*