### PR TITLE
refactor: ConversationLinkPolicy → Pydantic config, drop legacy JS renderer

### DIFF
--- a/changelog.d/conversation-link-pydantic-config.md
+++ b/changelog.d/conversation-link-pydantic-config.md
@@ -1,0 +1,6 @@
+---
+category: Refactors
+---
+
+**ConversationLinkPolicy uses Pydantic config**: Constructor now accepts `ConversationLinkPolicyConfig` (matching the rest of the codebase) instead of a scalar `base_url` kwarg, making the admin UI render it via the Pydantic form path.
+  - Removed the legacy JS config-form renderer (`renderLegacyConfigFormInner` / `bindLegacyConfigInputs`) from `policy_config.js` — `ConversationLinkPolicy` was its last consumer.

--- a/src/luthien_proxy/policies/conversation_link_policy.py
+++ b/src/luthien_proxy/policies/conversation_link_policy.py
@@ -52,9 +52,9 @@ class _ConversationLinkState:
 class ConversationLinkPolicy(SimplePolicy):
     """Injects a conversation viewer link into the first response of each conversation."""
 
-    def __init__(self, base_url: str = "http://localhost:8000", **kwargs: object) -> None:
-        """Initialize with base URL for building viewer links."""
-        self.config = ConversationLinkPolicyConfig(base_url=base_url)
+    def __init__(self, config: ConversationLinkPolicyConfig | dict | None = None) -> None:
+        """Initialize with optional config. Accepts dict or Pydantic model."""
+        self.config = self._init_config(config, ConversationLinkPolicyConfig)
 
     @property
     def short_policy_name(self) -> str:

--- a/src/luthien_proxy/static/policy_config.js
+++ b/src/luthien_proxy/static/policy_config.js
@@ -503,36 +503,28 @@ function renderChainItemConfig(i) {
     if (!container) return;
 
     const schema = p.config_schema || {};
-    const hasPydanticSchema = Object.values(schema).some(
-        ps => ps && (ps.properties || ps.$defs || ps['x-sub-policy-list'] ||
-            (ps.type === 'array' && ps.items?.type === 'array'))
-    );
+    if (!window.FormRenderer) return;
 
-    if (hasPydanticSchema && window.FormRenderer) {
-        const formData = window.FormRenderer.getDefaultValue(schema, schema);
-        for (const [key, value] of Object.entries(p.example_config || {})) {
-            if (value !== null) formData[key] = value;
-        }
-        for (const [key, value] of Object.entries(item.config || {})) {
-            if (value !== null && value !== undefined) formData[key] = value;
-        }
-        item.config = formData;
-
-        const formHtml = window.FormRenderer.generateForm(schema);
-        const escapedFormData = JSON.stringify(formData)
-            .replace(/&/g, '&amp;').replace(/"/g, '&quot;')
-            .replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
-        container.innerHTML = `
-            <div class="config-form" x-data="{ formData: ${escapedFormData} }"
-                 x-init="$watch('formData', value => updateChainConfig(${i}, value))">
-                ${formHtml}
-            </div>`;
-        if (window.Alpine) Alpine.initTree(container);
-    } else {
-        container.innerHTML = `<div class="config-form">${renderLegacyConfigFormInner(p, item.config, 'chain-' + i)}</div>`;
-        bindLegacyConfigInputs('chain-' + i);
+    const formData = window.FormRenderer.getDefaultValue(schema, schema);
+    for (const [key, value] of Object.entries(p.example_config || {})) {
+        if (value !== null) formData[key] = value;
     }
+    for (const [key, value] of Object.entries(item.config || {})) {
+        if (value !== null && value !== undefined) formData[key] = value;
+    }
+    item.config = formData;
+
+    const formHtml = window.FormRenderer.generateForm(schema);
+    const escapedFormData = JSON.stringify(formData)
+        .replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+    container.innerHTML = `
+        <div class="config-form" x-data="{ formData: ${escapedFormData} }"
+             x-init="$watch('formData', value => updateChainConfig(${i}, value))">
+            ${formHtml}
+        </div>`;
+    if (window.Alpine) Alpine.initTree(container);
 }
 
 function updateChainConfig(index, data) {
@@ -540,95 +532,6 @@ function updateChainConfig(index, data) {
         state.chain[index].config = data;
         updateActivateButton();
     }
-}
-
-// ============================================================
-// Config form rendering (legacy fallback for non-Pydantic schemas)
-// ============================================================
-function renderLegacyConfigFormInner(policy, config, prefix) {
-    const schema = policy.config_schema || {};
-    const keys = Object.keys(schema);
-    if (keys.length === 0) return '';
-
-    let html = '';
-    for (const key of keys) {
-        const ps = schema[key];
-        const val = config[key] ?? ps.default ?? '';
-        const isComplex = ps.type === 'object' || ps.type === 'array';
-        const isPassword = ps.type === 'string' && key.toLowerCase().includes('key');
-
-        if (ps.type === 'boolean') {
-            const checked = (config[key] ?? ps.default ?? false) ? 'checked' : '';
-            html += `<div class="checkbox-row">
-                <input type="checkbox" data-prefix="${prefix}" data-key="${key}" ${checked}>
-                <label>${esc(key)}</label>
-            </div>`;
-        } else if (ps.type === 'number' || ps.type === 'integer') {
-            const step = ps.type === 'number' ? ' step="any"' : '';
-            html += `<label>${esc(key)}</label>`;
-            html += `<input type="number"${step} data-prefix="${prefix}" data-key="${key}" value="${esc(val)}">`;
-            if (ps.nullable) html += `<span class="config-hint">${esc(ps.type)} (optional)</span>`;
-        } else if (isComplex) {
-            html += `<label>${esc(key)}</label>`;
-            const jsonVal = JSON.stringify(config[key] ?? ps.default ?? null, null, 2);
-            html += `<textarea data-prefix="${prefix}" data-key="${key}" data-json="true">${esc(jsonVal)}</textarea>`;
-            html += `<div class="config-error-msg" data-error-for="${prefix}-${key}">Invalid JSON</div>`;
-            html += `<span class="config-hint">${esc(ps.type)}</span>`;
-        } else {
-            html += `<label>${esc(key)}</label>`;
-            const inputType = isPassword ? 'password' : 'text';
-            const placeholder = ps.nullable ? '(optional)' : '';
-            html += `<input type="${inputType}" data-prefix="${prefix}" data-key="${key}" value="${esc(val)}" placeholder="${placeholder}">`;
-            if (ps.nullable) html += `<span class="config-hint">${esc(ps.type)} (optional)</span>`;
-        }
-    }
-    return html;
-}
-
-function bindLegacyConfigInputs(prefix) {
-    document.querySelectorAll(`[data-prefix="${prefix}"][data-key]`).forEach(el => {
-        el.addEventListener('input', () => {
-            const key = el.dataset.key;
-            const isJson = el.dataset.json === 'true';
-            const isCheckbox = el.type === 'checkbox';
-            const isNumber = el.type === 'number';
-            const fieldId = `${prefix}-${key}`;
-
-            let val;
-            if (isCheckbox) {
-                val = el.checked;
-            } else if (isJson) {
-                try {
-                    val = JSON.parse(el.value);
-                    el.classList.remove('invalid');
-                    const errEl = document.querySelector(`[data-error-for="${fieldId}"]`);
-                    if (errEl) errEl.classList.remove('visible');
-                    state.invalidFields.delete(fieldId);
-                } catch {
-                    el.classList.add('invalid');
-                    const errEl = document.querySelector(`[data-error-for="${fieldId}"]`);
-                    if (errEl) errEl.classList.add('visible');
-                    state.invalidFields.add(fieldId);
-                    updateActivateButton();
-                    return;
-                }
-            } else if (isNumber) {
-                val = el.value === '' ? null : Number(el.value);
-            } else {
-                val = el.value;
-            }
-
-            if (prefix.startsWith('chain-')) {
-                const idx = parseInt(prefix.split('-')[1]);
-                state.chain[idx].config[key] = val;
-            }
-            updateActivateButton();
-        });
-
-        if (el.type === 'checkbox') {
-            el.addEventListener('change', () => el.dispatchEvent(new Event('input')));
-        }
-    });
 }
 
 function updateActivateButton() {

--- a/src/luthien_proxy/static/policy_config.js
+++ b/src/luthien_proxy/static/policy_config.js
@@ -76,7 +76,6 @@ const EXAMPLES = {
 const state = {
     policies: [],
     currentPolicy: null,
-    invalidFields: new Set(),
     chain: [],
     availableModels: [],
     selectedModel: DEFAULT_MODEL,
@@ -267,7 +266,6 @@ function addToChain(classRef, event) {
     if (!p) return;
     state.chain.push({ classRef, config: defaultConfigFor(p) });
     state.expandedChainIndex = state.chain.length - 1;
-    state.invalidFields.clear();
     renderAll();
 }
 
@@ -537,14 +535,6 @@ function updateChainConfig(index, data) {
 function updateActivateButton() {
     const btn = document.getElementById('btn-activate');
     if (!btn) return;
-
-    if (state.invalidFields.size > 0) {
-        btn.disabled = true;
-        btn.textContent = 'Fix errors to activate';
-        btn.classList.add('error-state');
-        return;
-    }
-    btn.classList.remove('error-state');
 
     btn.disabled = state.isActivating;
     const label = state.chain.length > 1
@@ -822,10 +812,6 @@ async function runTest(side) {
 async function handleActivateChain() {
     if (state.chain.length === 0) return;
     if (state.isActivating) return;
-    if (state.invalidFields.size > 0) {
-        showStatus('proposed-status', 'error', 'Fix errors before activating');
-        return;
-    }
 
     state.isActivating = true;
     updateActivateButton();

--- a/tests/luthien_proxy/unit_tests/policies/test_conversation_link_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_conversation_link_policy.py
@@ -52,7 +52,7 @@ class TestConversationLinkPolicy:
 
     @pytest.mark.asyncio
     async def test_injects_link_on_first_turn(self):
-        policy = ConversationLinkPolicy(base_url="http://localhost:8000")
+        policy = ConversationLinkPolicy({"base_url": "http://localhost:8000"})
         ctx = self._make_context(session_id="sess-abc")
 
         result = await self._run_first_turn(policy, ctx)
@@ -63,7 +63,7 @@ class TestConversationLinkPolicy:
     @pytest.mark.asyncio
     async def test_preflight_does_not_consume_injection(self):
         """Regression: preflight call (max_tokens=1) shouldn't prevent real turn from getting link."""
-        policy = ConversationLinkPolicy(base_url="http://localhost:8000")
+        policy = ConversationLinkPolicy({"base_url": "http://localhost:8000"})
         preflight_ctx = self._make_context(session_id="sess-pre")
         real_ctx = self._make_context(session_id="sess-pre")
 
@@ -81,7 +81,7 @@ class TestConversationLinkPolicy:
 
     @pytest.mark.asyncio
     async def test_no_injection_on_subsequent_turn(self):
-        policy = ConversationLinkPolicy(base_url="http://localhost:8000")
+        policy = ConversationLinkPolicy({"base_url": "http://localhost:8000"})
         ctx = self._make_context(session_id="sess-abc")
 
         result = await self._run_subsequent_turn(policy, ctx)
@@ -90,7 +90,7 @@ class TestConversationLinkPolicy:
 
     @pytest.mark.asyncio
     async def test_no_injection_without_session_id(self):
-        policy = ConversationLinkPolicy(base_url="http://localhost:8000")
+        policy = ConversationLinkPolicy({"base_url": "http://localhost:8000"})
         ctx = self._make_context(session_id=None)
 
         result = await self._run_first_turn(policy, ctx)
@@ -100,7 +100,7 @@ class TestConversationLinkPolicy:
     @pytest.mark.asyncio
     async def test_independent_sessions_both_get_link(self):
         """Each first-turn call gets a link — no cross-session state."""
-        policy = ConversationLinkPolicy(base_url="http://localhost:8000")
+        policy = ConversationLinkPolicy({"base_url": "http://localhost:8000"})
         ctx1 = self._make_context(session_id="sess-1")
         ctx2 = self._make_context(session_id="sess-2")
 
@@ -112,7 +112,7 @@ class TestConversationLinkPolicy:
 
     @pytest.mark.asyncio
     async def test_session_id_with_special_chars_is_url_encoded(self):
-        policy = ConversationLinkPolicy(base_url="http://localhost:8000")
+        policy = ConversationLinkPolicy({"base_url": "http://localhost:8000"})
         ctx = self._make_context(session_id="sess with spaces#fragment")
 
         result = await self._run_first_turn(policy, ctx)
@@ -123,7 +123,7 @@ class TestConversationLinkPolicy:
     @pytest.mark.asyncio
     async def test_multi_text_block_only_first_gets_link(self):
         """When a response has multiple text blocks, only the first is injected."""
-        policy = ConversationLinkPolicy(base_url="http://localhost:8000")
+        policy = ConversationLinkPolicy({"base_url": "http://localhost:8000"})
         ctx = self._make_context(session_id="sess-multi")
         await policy.on_anthropic_request(_first_turn_request(), ctx)
 
@@ -137,7 +137,7 @@ class TestConversationLinkPolicy:
 
     @pytest.mark.asyncio
     async def test_request_passes_through(self):
-        policy = ConversationLinkPolicy(base_url="http://localhost:8000")
+        policy = ConversationLinkPolicy({"base_url": "http://localhost:8000"})
         ctx = self._make_context()
 
         result = await policy.simple_on_request("user message", ctx)
@@ -146,12 +146,12 @@ class TestConversationLinkPolicy:
 
     def test_freeze_configured_state_passes(self):
         """Policy must pass the singleton state validation."""
-        policy = ConversationLinkPolicy(base_url="http://localhost:8000")
+        policy = ConversationLinkPolicy({"base_url": "http://localhost:8000"})
         policy.freeze_configured_state()
 
     def test_get_config_returns_base_url(self):
         """Config should be visible via get_config() for admin API."""
-        policy = ConversationLinkPolicy(base_url="http://example.com:9000")
+        policy = ConversationLinkPolicy({"base_url": "http://example.com:9000"})
 
         config = policy.get_config()
 
@@ -166,7 +166,7 @@ class TestConversationLinkPolicyIntegration:
 
     @pytest.mark.asyncio
     async def test_on_anthropic_response_injects_into_first_text_block(self):
-        policy = ConversationLinkPolicy(base_url="http://localhost:8000")
+        policy = ConversationLinkPolicy({"base_url": "http://localhost:8000"})
         ctx = self._make_context(session_id="sess-resp")
         request = _first_turn_request()
         response = {
@@ -185,7 +185,7 @@ class TestConversationLinkPolicyIntegration:
     @pytest.mark.asyncio
     async def test_tool_use_blocks_pass_through(self):
         """Tool use blocks are not affected by the link injection."""
-        policy = ConversationLinkPolicy(base_url="http://localhost:8000")
+        policy = ConversationLinkPolicy({"base_url": "http://localhost:8000"})
         ctx = self._make_context(session_id="sess-tool")
         request = _first_turn_request()
         response = {
@@ -207,7 +207,7 @@ class TestConversationLinkPolicyIntegration:
     @pytest.mark.asyncio
     async def test_no_injection_on_subsequent_turn_via_response(self):
         """Full integration: subsequent turn through on_anthropic_response."""
-        policy = ConversationLinkPolicy(base_url="http://localhost:8000")
+        policy = ConversationLinkPolicy({"base_url": "http://localhost:8000"})
         ctx = self._make_context(session_id="sess-nope")
         request = _subsequent_turn_request()
         response = {

--- a/tests/luthien_proxy/unit_tests/policies/test_conversation_link_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_conversation_link_policy.py
@@ -157,6 +157,14 @@ class TestConversationLinkPolicy:
 
         assert config["base_url"] == "http://example.com:9000"
 
+    def test_no_args_uses_default_config(self):
+        """ConversationLinkPolicy() with no args should use default base_url."""
+        policy = ConversationLinkPolicy()
+
+        config = policy.get_config()
+
+        assert config["base_url"] == "http://localhost:8000"
+
 
 class TestConversationLinkPolicyIntegration:
     """Test through the real SimplePolicy entry point (on_anthropic_response)."""


### PR DESCRIPTION
## Summary

- `ConversationLinkPolicy.__init__` now takes a `ConversationLinkPolicyConfig` (matching every other Pydantic policy), instead of a scalar `base_url` kwarg. The existing `ConversationLinkPolicyConfig` model was already in the file, just unused by the constructor.
- Its generated JSON schema now exposes `properties`, so the admin UI renders it via the standard Pydantic `FormRenderer` path with field labels, descriptions, and Alpine data binding.
- With the last consumer gone, the legacy config-form renderer (`renderLegacyConfigFormInner` + `bindLegacyConfigInputs`) and the `hasPydanticSchema` gate in `src/luthien_proxy/static/policy_config.js` are removed. ~95 lines of dead JS deleted.

Behavior is preserved. Tests updated to pass config as a dict (`ConversationLinkPolicy({"base_url": ...})`) — the idiomatic pattern used by other policy tests (e.g. `test_onboarding_policy.py`).

## Test plan

- [x] `uv run pytest tests/luthien_proxy/unit_tests/policies/test_conversation_link_policy.py` — 13 passed
- [x] `./scripts/dev_checks.sh` — all gating checks green (2157 unit tests pass)
- [x] `grep` confirms no remaining references to `renderLegacyConfigFormInner`, `bindLegacyConfigInputs`, or `hasPydanticSchema` in the repo
- [x] Smoke-tested via browser at `/policy-config`:
  - ConversationLinkPolicy appears in Available list
  - Adding it to the chain expands a Pydantic form with `Base url` label, description text, and default `http://localhost:8000`
  - Changed value to `http://example.com:9000`, clicked Activate
  - `/api/admin/policy/current` confirmed `config.base_url = "http://example.com:9000"` persisted correctly
  - Verified the form uses `x-model="formData.config.base_url"` (Pydantic path) rather than the legacy `data-prefix`/`data-key` bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)