### PR TITLE
docs: drop stale references after the #597/#602/#603 teardown sweep

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,9 +168,9 @@ There is no `llm/litellm_client.py` — the gateway no longer proxies via LiteLL
 
 | Module | Responsibility |
 |--------|---------------|
-| `admin/routes.py` | `/api/admin/*` — policy current/set/list, `/models`, `/test/chat`, auth config, cached credentials management, server credentials CRUD, telemetry config, gateway settings (deprecated), unified config get/put/delete |
+| `admin/routes.py` | `/api/admin/*` — policy current/set/list, `/models`, `/test/chat`, auth config, cached credentials management, server credentials CRUD, telemetry config, unified config get/put/delete |
 | `admin/policy_discovery.py` | Discovers installed policy classes for the admin UI dropdown. |
-| `ui/routes.py` | HTML pages and the SSE activity stream. Routes: `/` (landing), `/activity/monitor` (301 → `/history`), `/debug/activity` (raw SSE viewer), `/diffs`, `/policy-config`, `/config` (config dashboard), `/credentials`, `/request-logs/viewer`, `/conversation/live/{id}`, `/client-setup`, and the `GET /api/activity/stream` SSE endpoint. Also redirects deprecated `/debug/diff` and `/admin/*` paths. |
+| `ui/routes.py` | HTML pages and the SSE activity stream. Routes: `/` (landing), `/debug/activity` (raw SSE viewer), `/diffs`, `/policy-config`, `/config` (config dashboard), `/credentials`, `/request-logs/viewer`, `/conversation/live/{id}`, `/client-setup`, and the `GET /api/activity/stream` SSE endpoint. Also redirects deprecated `/admin/*` paths to `/api/admin/*`. |
 | `history/routes.py` | `/history` (list sessions), `/history/session/{id}` (session detail); `/api/history/*` JSON API. |
 | `history/service.py` | Session list + detail query builders, turn reconstruction, markdown/JSONL export. |
 | `history/models.py` | Pydantic models for session list/detail responses. |

--- a/changelog.d/docs-post-sweep-stale-references.md
+++ b/changelog.d/docs-post-sweep-stale-references.md
@@ -1,0 +1,5 @@
+---
+category: Chores & Docs
+---
+
+**Sync docs after teardown sweep**: Drop stale references to removed code from `ARCHITECTURE.md` and `dev/` context docs — `/activity/monitor` and `/debug/diff` redirects (removed in #597), the `gateway/settings` admin endpoint (removed in #602), and the `litellm_master_key` judge-key fallback (removed in #603).

--- a/dev/context/codebase_learnings.md
+++ b/dev/context/codebase_learnings.md
@@ -49,9 +49,8 @@ Current references to LiteLLM in `src/luthien_proxy/`:
   - `policies/simple_llm_utils.py` and `policies/tool_call_judge_utils.py` — call `acompletion` directly for judge decisions (these are the underlying utilities for `SimpleLLMPolicy` and `ToolCallJudgePolicy`).
   - `main.py` — sets `litellm.drop_params = True` once at startup so judge calls tolerate unknown kwargs.
   - `admin/routes.py` — reads `litellm.anthropic_models` to list available Claude models in the admin UI.
-- **Indirect references** (no `import litellm`, but tied to the judge path):
+- **Indirect reference** (no `import litellm`, but tied to the judge path):
   - `exceptions.py` — `map_litellm_error_type()` maps LiteLLM exception **class names** onto `BackendAPIError` codes via string lookup (`type(exception).__name__`).
-  - `config_fields.py` / `settings.py` — retain `litellm_master_key` as a legacy fallback when resolving judge API keys (env var name only; no module import).
 
 **Key rule**: Do not introduce new LiteLLM imports from gateway request processing, streaming, or the `pipeline/` package. Judge-LLM calls (and the startup/admin touches listed above) are the only supported entry points today.
 

--- a/dev/context/request_processing.md
+++ b/dev/context/request_processing.md
@@ -89,7 +89,7 @@ Direct `litellm` imports in `src/luthien_proxy/` are limited to:
 - **Startup config** — `main.py` sets `litellm.drop_params = True` once so judge calls tolerate unknown kwargs.
 - **Admin model listing** — `admin/routes.py` reads `litellm.anthropic_models` for the admin UI model dropdown.
 
-Indirect references (no import, still tied to the judge path): `exceptions.map_litellm_error_type()` maps LiteLLM exception class names to `BackendAPIError` codes via string lookup, and `settings.litellm_master_key` is retained as a legacy judge-key fallback.
+Indirect reference (no import, still tied to the judge path): `exceptions.map_litellm_error_type()` maps LiteLLM exception class names to `BackendAPIError` codes via string lookup.
 
 See `dev/context/codebase_learnings.md` (LiteLLM Usage Boundaries) for the complete list.
 


### PR DESCRIPTION
## Summary

Small doc sync: drop references to code that was removed in recent teardown PRs.

- `ARCHITECTURE.md` — drop `/activity/monitor` and `/debug/diff` redirect mentions (removed in #597); drop "gateway settings (deprecated)" from the admin routes summary (endpoint removed in #602).
- `dev/REQUEST_PROCESSING_ARCHITECTURE.md` + `dev/context/codebase_learnings.md` — drop the `litellm_master_key` legacy-fallback note (key removed in #603).

No code changes; pure doc cleanup.

## Test plan

- [x] `grep -rn "litellm_master_key\|/activity/monitor\|/debug/diff \|gateway/settings" src/ ARCHITECTURE.md dev/` returns no non-test matches.
- [ ] CI dev_checks green.

---
*Posted by Claude Code (claude-opus-4-7[1m])*