### PR TITLE
fix(config): snapshot env layer so DELETE reverts to default after PUT

### DIFF
--- a/changelog.d/fix-config-registry-env-leak-after-put.md
+++ b/changelog.d/fix-config-registry-env-leak-after-put.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**Config DELETE no longer reverts to a ghost ENV layer after PUT**: `ConfigRegistry._resolve_field` used to re-derive the ENV layer on every resolve by comparing `settings.<field>` to `meta.default`. Because `set_db_value` writes the coerced value back into `Settings` via `_sync_one`, any field that received a DB override would be reported as ENV-sourced on later resolves, and a subsequent `DELETE /api/admin/config/{key}` would "stick" at the DB value instead of falling back to the real default. The ENV layer is now snapshotted once at `__init__` and consulted from that immutable map.

--- a/src/luthien_proxy/config_registry.py
+++ b/src/luthien_proxy/config_registry.py
@@ -79,6 +79,33 @@ class ConfigRegistry:
         self._db_values: dict[str, str] = {}
         self._resolved: dict[str, ResolvedValue] = {}
         self._lock = asyncio.Lock()
+        # Snapshot env-layer values up front, before any DB/CLI resolution can
+        # push values back into Settings via `_sync_one`. Re-deriving the ENV
+        # layer from a mutated Settings later would falsely report a .env-file
+        # origin for DB-set values and make DELETE "stick" at the DB value.
+        self._env_values: dict[str, Any] = self._snapshot_env_values(settings)
+
+    @staticmethod
+    def _snapshot_env_values(settings: Settings) -> dict[str, Any]:
+        """Record, per field, the env/dotenv-provided value (if any).
+
+        Captured once at construction — before `_sync_one` can overwrite
+        `settings` attributes with resolved DB/CLI values. A field is
+        considered env-sourced when its env var is present in ``os.environ``
+        OR its Settings value diverges from the field default (the only way
+        a pydantic-settings .env-file value surfaces without populating
+        ``os.environ``).
+        """
+        captured: dict[str, Any] = {}
+        for meta in CONFIG_FIELDS:
+            if not hasattr(settings, meta.name):
+                continue
+            settings_val = getattr(settings, meta.name)
+            env_explicitly_set = os.environ.get(meta.env_var) is not None
+            env_from_dotenv = not env_explicitly_set and settings_val != meta.default
+            if env_explicitly_set or env_from_dotenv:
+                captured[meta.name] = settings_val
+        return captured
 
     async def initialize(self) -> None:
         """Load DB values and resolve all fields."""
@@ -131,14 +158,12 @@ class ConfigRegistry:
         if cli_val is not None:
             layers[ConfigSource.CLI] = cli_val
 
-        # ENV layer — counts if the env var is explicitly set OR the .env file
-        # provided a value (detected by comparing Settings value to the field default).
-        # pydantic-settings reads .env files directly without injecting into os.environ.
-        settings_val = getattr(self._settings, meta.name, meta.default)
-        env_explicitly_set = os.environ.get(meta.env_var) is not None
-        env_from_dotenv = not env_explicitly_set and settings_val != meta.default
-        if env_explicitly_set or env_from_dotenv:
-            layers[ConfigSource.ENV] = settings_val
+        # ENV layer — consult the startup snapshot rather than the live
+        # `_settings` object. `_sync_one` rewrites Settings attributes when
+        # DB/CLI overrides land, so a live derivation would mistake every
+        # DB-set value for a dotenv-provided one and block fallback on DELETE.
+        if meta.name in self._env_values:
+            layers[ConfigSource.ENV] = self._env_values[meta.name]
 
         # DB layer — only for db_settable fields
         if meta.db_settable and meta.name in self._db_values:

--- a/tests/luthien_proxy/unit_tests/test_config_registry.py
+++ b/tests/luthien_proxy/unit_tests/test_config_registry.py
@@ -321,6 +321,56 @@ class TestSetDbValue:
         assert exc.value.source == ConfigSource.ENV
         mock_pool.execute.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_delete_after_put_falls_back_to_default_when_no_env_set(self, monkeypatch):
+        """Regression: PUT followed by DELETE must revert to the field default.
+
+        `set_db_value` writes the new value back to Settings via `_sync_one`,
+        which used to poison the `env_from_dotenv` heuristic in `_resolve_field`
+        — a subsequent DELETE then resolved to the sync'd value under a ghost
+        ENV layer instead of falling back to the default. This test pins the
+        correct behavior: with no real env override, DELETE must reach DEFAULT.
+        """
+        monkeypatch.delenv("DOGFOOD_MODE", raising=False)
+        mock_pool = MagicMock()
+        mock_pool.execute = AsyncMock()
+        mock_db = MagicMock()
+        mock_db.get_pool = AsyncMock(return_value=mock_pool)
+
+        settings = _make_settings()
+        registry = ConfigRegistry(settings=settings, db_pool=mock_db)
+        registry._resolve_all()
+
+        put_result = await registry.set_db_value("dogfood_mode", True)
+        assert put_result.source == ConfigSource.DB
+        assert put_result.value is True
+
+        delete_result = await registry.delete_db_value("dogfood_mode")
+        assert delete_result.source == ConfigSource.DEFAULT
+        assert delete_result.value is False
+
+    def test_env_snapshot_survives_set_db_value_sync_back(self, monkeypatch):
+        """The startup env snapshot must not be overwritten by `_sync_one`.
+
+        Even after a PUT mutates `_settings.<field>` to the DB value, the
+        ENV snapshot captured at `__init__` must still reflect the original
+        env value — otherwise the ENV layer would drift toward the latest
+        DB write on every resolve.
+        """
+        monkeypatch.setenv("DOGFOOD_MODE", "true")
+        settings = _make_settings(dogfood_mode=True)
+        registry = _make_registry(settings=settings)
+
+        assert registry._env_values.get("dogfood_mode") is True
+
+        # Simulate `_sync_one` pushing a different value back into Settings
+        # (exactly what `set_db_value` does after writing the DB row).
+        registry._sync_one("dogfood_mode", False)
+        assert settings.dogfood_mode is False
+
+        # Snapshot is immutable by design; the ENV value hasn't changed.
+        assert registry._env_values.get("dogfood_mode") is True
+
 
 class TestCoerce:
     def test_bool_from_string_true(self):


### PR DESCRIPTION
## Summary

`DELETE /api/admin/config/{key}` silently reverts to the previously `PUT` value instead of the actual default, and reports a fake `env` source. Root cause: `ConfigRegistry._resolve_field` re-derived the ENV layer on every resolve by comparing `settings.<field>` to `meta.default`, but `set_db_value` mutates `settings` via `_sync_one`, so the heuristic misfires for every field that received a DB override.

Fix: snapshot env-sourced fields once at `__init__` (before any `_sync_one` can mutate Settings) and consult that immutable map from `_resolve_field`.

## RCA/COE

### Bug: Admin config DELETE silently reverts to the previously PUT value instead of the actual default

**Impact:** Any operator who clears a DB override via the `/config` dashboard (or `DELETE /api/admin/config/{key}`) after having set one via the toggle/PUT sees the UI respond success while the value stays at the DB-set value and the dashboard reports a fake `env` source. Blast radius: every DB-settable field — notably `dogfood_mode`, `inject_policy_context`, `validate_credentials`, `auth_mode`, the telemetry toggle. For `dogfood_mode` this means a user who enables dogfood safety cannot disable it from the dashboard. Silent success is the worst shape: user believes they reverted, tells downstream consumers they reverted, behavior doesn't change — erodes trust in the whole dashboard. No data loss; recoverable via restart or env/CLI.

**Repro Steps (before this fix):**
1. Check out commit \`59f187fd\` (pre-fix tip of \`main\`).
2. Start a fresh gateway with no \`DOGFOOD_MODE\` / \`INJECT_POLICY_CONTEXT\` in env: \`./scripts/start_gateway.sh\`.
3. \`curl -X PUT -H "Authorization: Bearer \$ADMIN_API_KEY" -H "Content-Type: application/json" -d '{"value": true}' http://localhost:8000/api/admin/config/dogfood_mode\`
4. \`curl -X DELETE -H "Authorization: Bearer \$ADMIN_API_KEY" http://localhost:8000/api/admin/config/dogfood_mode\`
5. Observe: DELETE returns \`{"success": true, "name": "dogfood_mode", "value": true, "source": "env"}\` — value stuck at \`true\`, source lies about \`env\`. GET confirms \`value=true, source=env\`, and DogfoodSafetyPolicy keeps wrapping.

**Timeline:**

| Date | Event |
|------|-------|
| 2026-04-10 | Bug introduced in PR #519 (unified config with provenance tracking) — \`_resolve_field\` re-derived ENV layer from \`settings.<field> != meta.default\`, and \`set_db_value\` began mutating \`settings\` via \`_sync_one\`. |
| 2026-04-23 | Bug discovered while writing a mock_e2e regression test for \`PUT /api/admin/config/{key}\` as follow-up after #602 removed the deprecated \`/gateway/settings\` endpoint. The round-trip test failed at the DELETE assertion. |
| 2026-04-23 | Fix shipped (this PR). |

**5 Whys:**
1. Why does DELETE return the previous PUT value? → \`_resolve_field\` adds an ENV layer that takes precedence over DEFAULT.
2. Why does ENV fire when the env var wasn't set? → \`env_from_dotenv\` heuristic returns true whenever \`settings.<field> != meta.default\`, intended to detect pydantic-settings's silent \`.env\` loading.
3. Why is \`settings.<field> != default\` after DELETE if env never set it? → \`set_db_value\` calls \`_sync_one(name, resolved.value)\`, writing the DB-resolved value back into Settings. After PUT of \`True\`, \`settings.dogfood_mode\` is \`True\` until restart; heuristic mis-fires on every later resolve.
4. Why did unit tests not catch this? → \`TestSetDbValue.test_delete_db_value\` sets up state by directly assigning \`registry._db_values\` and calling \`_resolve_all()\`, bypassing \`_sync_one\`. The PUT→DELETE lifecycle through the public API was untested.
5. Why? → The ENV layer was defined by runtime inference against a mutable Settings object that also serves as the sync target for DB/CLI writes. Two responsibilities aliased onto one data structure. The inference is only valid at boot; \`_sync_one\` silently invalidates it. Root cause: provenance oracle was derived lazily on every resolve instead of captured once at the layer-resolution boundary.

**The Pattern:**

| PR | Date | What went wrong | How discovered |
|----|------|----------------|----------------|
| This PR | 2026-04-23 | DB-set value poisons future ENV-layer inference; DELETE sticks at DB value | Writing regression test for the new PUT endpoint after \`/gateway/settings\` deprecation |
| #519 | 2026-04-10 | Introduced both the \`env_from_dotenv\` heuristic and \`_sync_one\` without coupling them via a stable snapshot | (original feature PR) |

No prior COE in this family — first bug in the unified config layer-resolution logic. Shape adjacent to streaming-invariant-over-mutable-buffer family (#134, #356) but mechanism is different.

**Detection gap:**
1. Discovered by writing the regression e2e test flagged as follow-up to #602 (\`test_config_put_round_trips_through_gateway\`).
2. *Should* have been caught by: (a) a unit test exercising \`set_db_value\` → \`delete_db_value\` through the public API; the existing \`test_delete_db_value\` was a "happy path" that accidentally skipped the sync step; (b) an e2e test against a live gateway covering the dashboard round-trip, which did not exist for this endpoint.

**What else could break? (Sweep)**

| Search | Files checked | Result |
|--------|--------------|--------|
| \`!= meta.default\` / \`!= .*\.default\` provenance inference | \`rg\` across \`src/\` | Only 1 hit, in the line this PR fixes. No other sites. |
| Other code paths reading Settings post-\`_sync_one\` to infer state | \`rg\` across \`src/luthien_proxy/\` | Only \`_snapshot_env_values\` and the old \`_resolve_field\` block (now removed). No external provenance inference off Settings. |
| Callers of \`_sync_one\` | \`rg "_sync_one" config_registry.py\` | \`_sync_to_settings\` (startup, pre-snapshot, safe), \`set_db_value\` (PUT), \`delete_db_value\` (DELETE). All three now safe because ENV layer no longer depends on sync'd value. |
| \`get_settings()\` consumers of DB-settable fields | \`rg "get_settings\(\)\."\` across \`src/\` | Consumers correctly receive resolved value because \`_sync_one\` still pushes the right value. The bug was only in *provenance*, not in the value propagated to legacy readers after a successful PUT. DELETE was the only path where the wrong value reached consumers. |

**Class-level analysis:**

Failure class: **"lazy provenance inference over a mutable oracle"** — using a computed signal to recover meta-information about where a value came from, when the underlying data structure can be mutated by other code paths. Heuristic only valid at boot; silently decays afterward.

Only one instance in the codebase (swept above). General mitigation — capture provenance at the moment it's knowable, never re-derive — applied here via \`_snapshot_env_values\` at \`__init__\`.

**Fixes Applied:**

| Issue | Fix | File |
|-------|-----|------|
| ENV layer re-derived on every resolve from mutable Settings | Snapshot env-sourced fields once at \`__init__\` (\`_snapshot_env_values\`), before any \`_sync_one\` call can mutate Settings | \`src/luthien_proxy/config_registry.py\` |
| \`_resolve_field\` consulted \`self._settings\` for env detection | \`_resolve_field\` now consults the immutable \`self._env_values\` snapshot | \`src/luthien_proxy/config_registry.py\` |
| No unit test covering PUT→DELETE through the public API | Added \`test_delete_after_put_falls_back_to_default_when_no_env_set\` (exact failure mode) and \`test_env_snapshot_survives_set_db_value_sync_back\` (invariant test) | \`tests/luthien_proxy/unit_tests/test_config_registry.py\` |

**Action items:**

| Action | Owner | Due date | Type |
|--------|-------|----------|------|
| Land this fix and its unit regression tests | this PR | 2026-04-23 | Architectural |
| Stack the e2e regression test (\`test_mock_admin_config.py\`, PUT→GET→DELETE→GET round-trip) that originally surfaced this bug so the dashboard has full-stack coverage | @Jai | 2026-04-24 | Detection |
| Audit the registry for other "computed signals over mutable state" — consider freezing \`self._settings\` (or wrapping it in a read-only view after \`_sync_to_settings\`) so future inference can never lazily drift | @Jai / next toucher of config_registry.py | 2026-05-07 | Architectural |

**Completeness gate:**

> "If a similar but slightly different version of this bug appeared tomorrow in an adjacent area, would this fix prevent it?"

Partial. Eliminates the specific instance and documents the failure class, but \`_sync_one\` still mutates \`self._settings\`. Anyone adding a new runtime-derived signal over Settings could reintroduce the same shape. The action-item "audit / freeze the settings oracle" is the broader prevention. Recorded for the next person touching \`config_registry.py\`.

## Test plan

- [x] \`uv run pytest tests/luthien_proxy/unit_tests/test_config_registry.py tests/luthien_proxy/unit_tests/test_admin_routes.py\` — 109/109 pass locally.
- [x] Manual repro sequence above now returns \`{"success": true, "name": "dogfood_mode", "value": false, "source": "default"}\` after DELETE.
- [ ] CI dev_checks green.
- [ ] Stacked PR with full e2e round-trip regression test to follow.

---
*Posted by Claude Code (claude-opus-4-7[1m])*