### PR TITLE
ci: bump Claude Code workflows to claude-opus-4-7

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,7 +51,7 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: >-
-            --model claude-opus-4-6
+            --model claude-opus-4-7
             --allowed-tools
             "Bash(gh issue view:*),
             Bash(gh search:*),

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,4 +46,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-opus-4-7'


### PR DESCRIPTION
## Summary
- Pin `.github/workflows/claude-code-review.yml` to `claude-opus-4-7` (was `claude-opus-4-6`)
- Pin `.github/workflows/claude.yml` to `claude-opus-4-7` (was using action default — `--model` line was commented out)

## Test plan
- [ ] Trigger an auto PR review on a follow-up PR; confirm it runs on Opus 4.7
- [ ] @claude mention on this PR; confirm the responder uses Opus 4.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)