### PR TITLE
fix(test): use executescript in sqlite_pool fixtures to handle triggers and semicolons in comments

### DIFF
--- a/changelog.d/fix-test-registry-executescript.md
+++ b/changelog.d/fix-test-registry-executescript.md
@@ -1,0 +1,6 @@
+---
+category: Fixes
+pr: 616
+---
+
+**SQLite test fixture**: add `SqliteConnection.executescript()` public method and use it in `sqlite_pool` fixtures to correctly handle migration files containing semicolons inside SQL comments or `BEGIN...END` trigger bodies.

--- a/src/luthien_proxy/utils/db_sqlite.py
+++ b/src/luthien_proxy/utils/db_sqlite.py
@@ -188,13 +188,14 @@ class SqliteConnection:
             await self._conn.commit()
         return f"OK {cursor.rowcount}"
 
-    async def executescript(self, script: str) -> None:
-        """Run a multi-statement SQL script using SQLite's native parser.
+    async def executescript(self, sql: str) -> None:
+        """Execute a multi-statement SQL script.
 
-        Unlike :meth:`execute`, this understands trigger ``BEGIN ... END`` blocks,
-        so semicolons inside trigger bodies do not get split into broken fragments.
+        Uses SQLite's native parser, which correctly handles semicolons inside
+        comments and BEGIN...END trigger bodies. Prefer this over splitting on
+        ";" for migration files.
         """
-        await self._conn.executescript(script)
+        await self._conn.executescript(sql)
 
     @asynccontextmanager
     async def transaction(self) -> AsyncIterator[None]:

--- a/tests/luthien_proxy/unit_tests/inference/test_registry.py
+++ b/tests/luthien_proxy/unit_tests/inference/test_registry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from typing import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -37,6 +38,7 @@ from luthien_proxy.inference.registry import (
     _build_direct_api,
 )
 from luthien_proxy.utils.db import DatabasePool
+from luthien_proxy.utils.db_sqlite import SqliteConnection
 
 
 class _StubProvider(InferenceProvider):
@@ -69,20 +71,15 @@ class _CountingFactory:
 
 
 @pytest.fixture
-async def sqlite_pool() -> DatabasePool:
-    """Real in-memory SQLite with every migration applied."""
+async def sqlite_pool() -> AsyncGenerator[DatabasePool, None]:
     pool = DatabasePool("sqlite://:memory:")
     migrations_dir = Path(__file__).resolve().parents[4] / "migrations" / "sqlite"
 
     async with pool.connection() as conn:
+        sqlite_conn = conn  # type: ignore[assignment]
+        assert isinstance(sqlite_conn, SqliteConnection)
         for migration_file in sorted(migrations_dir.glob("*.sql")):
-            sql = migration_file.read_text()
-            for statement in sql.split(";"):
-                statement = statement.strip()
-                if statement and not all(
-                    line.strip().startswith("--") or not line.strip() for line in statement.split("\n")
-                ):
-                    await conn.execute(statement)
+            await sqlite_conn._conn.executescript(migration_file.read_text())
 
     yield pool
     await pool.close()

--- a/tests/luthien_proxy/unit_tests/inference/test_registry.py
+++ b/tests/luthien_proxy/unit_tests/inference/test_registry.py
@@ -72,14 +72,14 @@ class _CountingFactory:
 
 @pytest.fixture
 async def sqlite_pool() -> AsyncGenerator[DatabasePool, None]:
+    """Real in-memory SQLite with every migration applied."""
     pool = DatabasePool("sqlite://:memory:")
     migrations_dir = Path(__file__).resolve().parents[4] / "migrations" / "sqlite"
 
     async with pool.connection() as conn:
-        sqlite_conn = conn  # type: ignore[assignment]
-        assert isinstance(sqlite_conn, SqliteConnection)
+        assert isinstance(conn, SqliteConnection)
         for migration_file in sorted(migrations_dir.glob("*.sql")):
-            await sqlite_conn._conn.executescript(migration_file.read_text())
+            await conn.executescript(migration_file.read_text())
 
     yield pool
     await pool.close()


### PR DESCRIPTION
## Problem

Two test fixtures use a naive \`sql.split(\";\")\` approach to apply SQLite migrations:

- \`tests/luthien_proxy/unit_tests/inference/test_registry.py\`
- \`tests/luthien_proxy/unit_tests/history/test_search_regressions.py\` (already fixed on #595 branch)

This breaks when migration files contain semicolons inside SQL comments. Specifically, \`014_add_session_search_fts.sql\` contains:

\`\`\`sql
-- conversation_events; the Postgres tsvector column is deleted automatically
\`\`\`

The split produces a fragment starting with \`the Postgres...\` which passes the comment filter (because \`CREATE VIRTUAL TABLE\` appears later in the same fragment), and SQLite rejects it with \`near \"the\": syntax error\`.

This causes all tests in \`test_registry.py\` to fail in CI when the PR merge ref combines \`trajectory/week-0-merge-sami-prs\` (which doesn't have \`014_add_session_search_fts.sql\`) with \`main\` (which does).

## Fix

Replace the split-and-execute loop with \`executescript()\`, which is the correct API for multi-statement SQL files — it handles semicolons in comments and \`BEGIN...END\` trigger bodies correctly.

## Note

The same fix was already applied to \`test_search_regressions.py\` on the \`trajectory/week-0-merge-sami-prs\` branch. This PR fixes the remaining instance on \`main\`.