### PR TITLE
fix(history): read session preview from original_request

### DIFF
--- a/changelog.d/fix-preview-from-original-request.md
+++ b/changelog.d/fix-preview-from-original-request.md
@@ -1,0 +1,9 @@
+---
+category: Fixes
+---
+
+**History session previews now reflect user input, not gateway-injected content**:
+  `_extract_preview_message` now reads from `original_request` instead of
+  `final_request`, so previews show the actual user message even when
+  `inject_policy_awareness_anthropic` (or any future injector) prepends content
+  to the first user message. Falls back to `final_request` for older payloads.

--- a/src/luthien_proxy/history/service.py
+++ b/src/luthien_proxy/history/service.py
@@ -294,7 +294,10 @@ def _extract_preview_message(payload: dict[str, Any] | str | None) -> str | None
     """Extract the first meaningful user message from a request payload for preview.
 
     Used to generate a session preview/title. Returns truncated text.
-    Skips system-reminders and other non-meaningful content to find actual user intent.
+    Reads from ``original_request`` so the preview reflects what the user typed,
+    not gateway-injected content (e.g. ``<policy-context>`` from
+    ``inject_policy_awareness_anthropic``). Falls back to ``final_request`` for
+    older payloads recorded before ``original_request`` was stored.
     """
     if not payload:
         return None
@@ -305,8 +308,7 @@ def _extract_preview_message(payload: dict[str, Any] | str | None) -> str | None
         if not payload:
             return None
 
-    # Get the final request (prefer this as it's what was actually sent)
-    request = payload.get("final_request") or payload.get("original_request") or {}
+    request = payload.get("original_request") or payload.get("final_request") or {}
 
     # Skip probe requests structurally: Claude Code sends internal probes
     # (token counting, quota checks) with max_tokens=1. No real conversation

--- a/tests/luthien_proxy/unit_tests/history/test_service.py
+++ b/tests/luthien_proxy/unit_tests/history/test_service.py
@@ -109,10 +109,34 @@ class TestExtractPreviewMessage:
         payload_str = json.dumps(payload_dict)
         assert _extract_preview_message(payload_str) == "From JSON"
 
-    def test_falls_back_to_original_request(self):
-        """Test fallback to original_request when final_request missing."""
-        payload = {"original_request": {"messages": [{"role": "user", "content": "Fallback message"}]}}
-        assert _extract_preview_message(payload) == "Fallback message"
+    def test_prefers_original_request_over_final_request(self):
+        """Preview reflects what the user typed, not gateway-injected content.
+
+        When inject_policy_awareness_anthropic (or any future injection) modifies
+        the first user message in final_request, the preview must still show the
+        user's original text — otherwise every session looks identical.
+        """
+        payload = {
+            "original_request": {"messages": [{"role": "user", "content": "What is the capital of France?"}]},
+            "final_request": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": (
+                            "<policy-context>Your responses may be modified by the following active "
+                            "policies before reaching the user: TestPolicy.</policy-context>\n\n"
+                            "What is the capital of France?"
+                        ),
+                    }
+                ]
+            },
+        }
+        assert _extract_preview_message(payload) == "What is the capital of France?"
+
+    def test_falls_back_to_final_request_when_original_missing(self):
+        """Older payloads (recorded before original_request was stored) still produce a preview."""
+        payload = {"final_request": {"messages": [{"role": "user", "content": "Legacy payload"}]}}
+        assert _extract_preview_message(payload) == "Legacy payload"
 
     @pytest.mark.parametrize(
         "probe_content",


### PR DESCRIPTION
Closes #559. Alternative to #575.

## Summary

When `inject_policy_awareness_anthropic` is enabled, the gateway prepends `<policy-context>...</policy-context>` to the first user message before sending to the backend. The history session list previews were extracted from `final_request.messages` (post-injection), so every session showed the policy boilerplate instead of the user's actual text — making sessions indistinguishable.

## Fix

`_extract_preview_message` now reads from `original_request` first, falling back to `final_request` for older payloads recorded before `original_request` was stored. The pre-injection request is already recorded by `anthropic_processor.ensure_request_recorded` (`src/luthien_proxy/pipeline/anthropic_processor.py:151`), so this is a one-line precedence flip in code that already had `payload.get("final_request") or payload.get("original_request")`.

```python
# before
request = payload.get("final_request") or payload.get("original_request") or {}
# after
request = payload.get("original_request") or payload.get("final_request") or {}
```

## Why this shape, not a regex

PR #575 proposed a `_POLICY_CONTEXT_PATTERN` regex stripping the tag at the read site, mirroring the existing `_SYSTEM_REMINDER_PATTERN`. That approach has issues:

1. **Breaks the system-reminder strip in the common case.** The `<system-reminder>` branch is gated on `content.startswith("<system-reminder>")`. After injection prepends policy-context, the gate fails — system-reminder is never stripped. Net result: previews show `<system-reminder>...` boilerplate instead of `<policy-context>...` boilerplate. Same bug, different tag.
2. **Fixes the list, not the conversation viewer.** `_parse_request_messages` (the body renderer) has no stripping; clicking into a "fixed" session still shows the full policy-context blob in the first message. The conversation viewer already has `original_request_messages` populated when injection runs, so a frontend follow-up can address that surface — but the list-side fix should be at the same layer.
3. **Cements a strip-at-read pattern.** Two regex special-cases is a coincidence. Three is a pattern. The next injection source needs another regex in another reader.
4. **Eats legitimate user content.** Messages containing user-typed `<policy-context>` text get the regex applied and content silently deleted.

Reading from `original_request` sidesteps all four. It's immune to whatever future injection sources prepend, and the data is already on disk.

## Tests

- New: `test_prefers_original_request_over_final_request` — when `final_request` contains injected policy-context and `original_request` does not, the preview reflects the user's text.
- Renamed: `test_falls_back_to_original_request` → `test_falls_back_to_final_request_when_original_missing`. Semantics flipped to match new precedence.

## Out of scope

The conversation viewer's first-message rendering (`_parse_request_messages` → `request_messages`) still shows `final_request` content by default, with `original_request_messages` populated when modified. That surface needs a frontend or convention change and is tracked separately.

## Test plan

- [x] Unit tests in `tests/luthien_proxy/unit_tests/history/test_service.py` pass
- [ ] CI green
- [ ] Manual: enable `inject_policy_awareness_anthropic` policy, hit `/history` — preview shows user's text, not `<policy-context>...`