### PR TITLE
feat(telemetry): default OTEL exporter to HTTP/protobuf instead of gRPC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,8 +96,11 @@
 # Enable OpenTelemetry distributed tracing
 # OTEL_ENABLED=false
 
-# OTLP exporter endpoint for traces
-# OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
+# OTLP exporter endpoint for traces (default targets the HTTP/protobuf receiver on tempo:4318)
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318/v1/traces
+
+# OTLP exporter protocol: 'http/protobuf' (default) or 'grpc'
+# OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
 # Tempo HTTP API URL for trace queries
 # TEMPO_URL=http://localhost:3200

--- a/changelog.d/otel-http-default.md
+++ b/changelog.d/otel-http-default.md
@@ -1,0 +1,24 @@
+---
+category: Features
+---
+
+**OTLP exporter defaults to HTTP/protobuf**: distributed tracing now exports
+via HTTP/protobuf instead of gRPC. HTTP works behind HTTP load balancers
+(ALB, nginx, Cloudflare) where gRPC fails with `StatusCode.UNAVAILABLE`.
+  - New env var `OTEL_EXPORTER_OTLP_PROTOCOL` (`http/protobuf` default; `grpc` opt-in)
+  - Default `OTEL_EXPORTER_OTLP_ENDPOINT` changed from `http://tempo:4317` to
+    `http://tempo:4318/v1/traces`
+  - `observability/tempo/tempo.yaml` and `docker-compose.yaml` now expose the
+    OTLP HTTP receiver on port 4318 alongside the gRPC receiver on 4317
+  - Unknown protocol values now raise `ValueError` at startup instead of
+    silently falling back, so typos surface immediately
+  - **Breaking** for deployments that override `OTEL_EXPORTER_OTLP_ENDPOINT`
+    without setting `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`. To preserve the prior
+    gRPC behavior set both:
+
+    ```bash
+    OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+    OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
+    ```
+
+Originally proposed in #562 (Sami Jawhar / @sjawhar).

--- a/dev-README.md
+++ b/dev-README.md
@@ -260,8 +260,9 @@ The observability stack is completely optional and does not affect core function
 OpenTelemetry is configured via the standard config system (see Configuration section above). OTel is disabled by default (`OTEL_ENABLED=false`). Key env vars:
 
 ```bash
-OTEL_ENABLED=true                           # Enable tracing
-OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
+OTEL_ENABLED=true                                       # Enable tracing
+OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318/v1/traces # HTTP/protobuf path
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf               # or 'grpc'
 SERVICE_NAME=luthien-proxy
 ENVIRONMENT=development
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -103,7 +103,8 @@ services:
       - POLICY_CONFIG=${POLICY_CONFIG:-/app/config/policy_config.yaml}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - OTEL_ENABLED=${OTEL_ENABLED:-true}
-      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://tempo:4317}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://tempo:4318/v1/traces}
+      - OTEL_EXPORTER_OTLP_PROTOCOL=${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
       - OTEL_SERVICE_NAME=luthien-gateway
       # API keys loaded from .env file only (not from shell) to prevent
       # shell environment from overriding .env values. This fixes issues
@@ -167,7 +168,8 @@ services:
       - ./observability/tempo/tempo.yaml:/etc/tempo.yaml:ro
       - ./observability/data/tempo:/var/tempo
     ports:
-      - "${TEMPO_OTLP_PORT:-4317}:4317"  # OTLP gRPC (application sends traces here)
+      - "${TEMPO_OTLP_PORT:-4317}:4317"  # OTLP gRPC (legacy/opt-in)
+      - "${TEMPO_OTLP_HTTP_PORT:-4318}:4318"  # OTLP HTTP/protobuf (default)
       - "${TEMPO_HTTP_PORT:-3200}:3200"  # Tempo HTTP API
     networks:
       - default

--- a/observability/README.md
+++ b/observability/README.md
@@ -73,7 +73,7 @@ docker compose ps tempo
 **No traces appearing:**
 - Check app has `OTEL_ENABLED=true` (default)
 - Verify Tempo is healthy: `docker compose ps tempo`
-- Check gateway can reach Tempo: `docker compose exec gateway curl -v http://tempo:4317`
+- Check gateway can reach Tempo: `docker compose exec gateway curl -v http://tempo:4318` (HTTP/protobuf default)
 
 **Disk space issues:**
 - Clean old data: `./scripts/observability.sh clean`

--- a/observability/tempo/tempo.yaml
+++ b/observability/tempo/tempo.yaml
@@ -8,6 +8,8 @@ distributor:
       protocols:
         grpc:
           endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
 
 storage:
   trace:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.20.0",
     "opentelemetry-instrumentation-fastapi>=0.41b0",
     "opentelemetry-instrumentation-redis>=0.41b0",
     "psycopg>=3.2.9",

--- a/src/luthien_proxy/config_fields.py
+++ b/src/luthien_proxy/config_fields.py
@@ -178,8 +178,13 @@ CONFIG_FIELDS: tuple[ConfigFieldMeta, ...] = (
         category="observability",
     ),
     ConfigFieldMeta(
-        "otel_exporter_otlp_endpoint", "OTEL_EXPORTER_OTLP_ENDPOINT", str, "http://tempo:4317",
-        "OTLP exporter endpoint for traces",
+        "otel_exporter_otlp_endpoint", "OTEL_EXPORTER_OTLP_ENDPOINT", str, "http://tempo:4318/v1/traces",
+        "OTLP exporter endpoint for traces (default targets the HTTP/protobuf receiver on tempo:4318)",
+        category="observability",
+    ),
+    ConfigFieldMeta(
+        "otel_exporter_otlp_protocol", "OTEL_EXPORTER_OTLP_PROTOCOL", str, "http/protobuf",
+        "OTLP exporter protocol: 'http/protobuf' (default) or 'grpc'",
         category="observability",
     ),
     ConfigFieldMeta(

--- a/src/luthien_proxy/settings.py
+++ b/src/luthien_proxy/settings.py
@@ -75,7 +75,8 @@ class Settings(_SettingsBase):
 
     # ── observability ───────────────────────────────────────────────
     otel_enabled: bool = False
-    otel_exporter_otlp_endpoint: str = "http://tempo:4317"
+    otel_exporter_otlp_endpoint: str = "http://tempo:4318/v1/traces"
+    otel_exporter_otlp_protocol: str = "http/protobuf"
     tempo_url: str = "http://localhost:3200"
     service_name: str = "luthien-proxy"
     service_version: str = PROXY_VERSION

--- a/src/luthien_proxy/telemetry.py
+++ b/src/luthien_proxy/telemetry.py
@@ -1,10 +1,15 @@
 """OpenTelemetry setup for Luthien observability.
 
 This module configures:
-- Distributed tracing (exports to Tempo via OTLP)
+- Distributed tracing (exports via OTLP HTTP/protobuf by default; gRPC opt-in)
 - Structured logging with trace correlation
 - Resource attributes (service name, version, etc.)
 - Auto-instrumentation for FastAPI and Redis
+
+TLS behavior differs between exporters:
+- gRPC uses ``insecure=True`` so plaintext local-dev endpoints work without TLS.
+- HTTP/protobuf reads TLS from the URL scheme: ``http://`` is plaintext,
+  ``https://`` verifies certificates. There is no ``insecure`` flag for HTTP.
 """
 
 from __future__ import annotations
@@ -13,20 +18,30 @@ import json
 import logging
 from collections.abc import Generator
 from contextlib import contextmanager
+from typing import Final
 
 from opentelemetry import trace
 from opentelemetry.context import Context, attach, detach
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+    OTLPSpanExporter as GrpcSpanExporter,
+)
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter as HttpSpanExporter,
+)
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.redis import RedisInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
 
 from luthien_proxy.settings import get_settings
 from luthien_proxy.utils.constants import OTEL_SPAN_ID_HEX_LENGTH, OTEL_TRACE_ID_HEX_LENGTH
 
 logger = logging.getLogger(__name__)
+
+OTLP_PROTOCOL_HTTP: Final[str] = "http/protobuf"
+OTLP_PROTOCOL_GRPC: Final[str] = "grpc"
+SUPPORTED_OTLP_PROTOCOLS: Final[frozenset[str]] = frozenset({OTLP_PROTOCOL_HTTP, OTLP_PROTOCOL_GRPC})
 
 
 @contextmanager
@@ -60,11 +75,11 @@ def restore_context(ctx: Context) -> Generator[object, None, None]:
         detach(token)
 
 
-def _get_otel_config() -> tuple[bool, str, str, str, str]:
+def _get_otel_config() -> tuple[bool, str, str, str, str, str]:
     """Get OpenTelemetry configuration from settings.
 
     Returns:
-        Tuple of (enabled, endpoint, service_name, service_version, environment)
+        Tuple of (enabled, endpoint, service_name, service_version, environment, protocol)
     """
     settings = get_settings()
     return (
@@ -73,6 +88,7 @@ def _get_otel_config() -> tuple[bool, str, str, str, str]:
         settings.service_name,
         settings.service_version,
         settings.environment,
+        settings.otel_exporter_otlp_protocol,
     )
 
 
@@ -85,6 +101,7 @@ def _silence_otel_loggers() -> None:
     """
     for name in (
         "opentelemetry.exporter.otlp.proto.grpc.exporter",
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter",
         "opentelemetry.sdk.trace.export",
         "grpc._channel",
         "grpc._plugin_wrapping",
@@ -92,18 +109,36 @@ def _silence_otel_loggers() -> None:
         logging.getLogger(name).setLevel(logging.DEBUG)
 
 
+def _build_otlp_exporter(protocol: str, endpoint: str) -> SpanExporter:
+    """Construct the OTLP span exporter for the configured protocol.
+
+    Raises:
+        ValueError: if ``protocol`` is not one of ``SUPPORTED_OTLP_PROTOCOLS``.
+            We intentionally do not silently fall back to a default — a typo'd
+            value should fail loud at startup, not silently drop traces.
+    """
+    if protocol == OTLP_PROTOCOL_GRPC:
+        return GrpcSpanExporter(endpoint=endpoint, insecure=True)
+    if protocol == OTLP_PROTOCOL_HTTP:
+        # HttpSpanExporter uses the endpoint verbatim; the default endpoint
+        # in config_fields.py already includes the /v1/traces path.
+        return HttpSpanExporter(endpoint=endpoint)
+    supported = ", ".join(sorted(SUPPORTED_OTLP_PROTOCOLS))
+    raise ValueError(f"Unsupported OTEL_EXPORTER_OTLP_PROTOCOL={protocol!r}; expected one of: {supported}")
+
+
 def configure_tracing() -> trace.Tracer:
     """Configure OpenTelemetry tracing.
 
     Sets up:
     - Resource attributes (service name, version, environment)
-    - OTLP exporter to Tempo
+    - OTLP exporter (HTTP/protobuf by default; gRPC via OTEL_EXPORTER_OTLP_PROTOCOL=grpc)
     - Batch span processor for efficiency
 
     Returns:
         Configured tracer for manual instrumentation
     """
-    otel_enabled, otel_endpoint, service_name, service_version, environment = _get_otel_config()
+    otel_enabled, otel_endpoint, service_name, service_version, environment, protocol = _get_otel_config()
 
     if not otel_enabled:
         logger.debug("OpenTelemetry disabled (OTEL_ENABLED=false)")
@@ -122,11 +157,9 @@ def configure_tracing() -> trace.Tracer:
     # Create tracer provider
     provider = TracerProvider(resource=resource)
 
-    # Configure OTLP exporter (sends to Tempo)
-    otlp_exporter = OTLPSpanExporter(
-        endpoint=otel_endpoint,
-        insecure=True,  # No TLS for local dev
-    )
+    # Configure OTLP exporter — HTTP/protobuf works behind HTTP load balancers
+    # (ALB, nginx, Cloudflare) where gRPC fails with StatusCode.UNAVAILABLE.
+    otlp_exporter = _build_otlp_exporter(protocol, otel_endpoint)
 
     # Use batch processor for efficiency (batches spans before export)
     processor = BatchSpanProcessor(otlp_exporter)
@@ -135,7 +168,7 @@ def configure_tracing() -> trace.Tracer:
     # Set as global tracer provider
     trace.set_tracer_provider(provider)
 
-    logger.info(f"OpenTelemetry configured: {service_name} → {otel_endpoint}")
+    logger.info(f"OpenTelemetry configured: {service_name} → {otel_endpoint} ({protocol})")
 
     return trace.get_tracer(__name__)
 

--- a/tests/luthien_proxy/unit_tests/test_settings.py
+++ b/tests/luthien_proxy/unit_tests/test_settings.py
@@ -164,7 +164,7 @@ class TestOtelExporterEndpoint:
         """Test uses default when env var not set."""
         monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
         settings = Settings(_env_file=None)
-        assert settings.otel_exporter_otlp_endpoint == "http://tempo:4317"
+        assert settings.otel_exporter_otlp_endpoint == "http://tempo:4318/v1/traces"
 
 
 class TestSettingsCache:

--- a/tests/luthien_proxy/unit_tests/test_telemetry.py
+++ b/tests/luthien_proxy/unit_tests/test_telemetry.py
@@ -9,9 +9,27 @@ from unittest.mock import Mock, patch
 import pytest
 from opentelemetry import trace
 from opentelemetry.context import Context
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+    OTLPSpanExporter as GrpcSpanExporter,
+)
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter as HttpSpanExporter,
+)
 
 from luthien_proxy import telemetry
+from luthien_proxy.settings import Settings
 from luthien_proxy.telemetry import restore_context
+
+
+# Six-tuple shape of telemetry._get_otel_config():
+#   (otel_enabled, endpoint, service_name, service_version, environment, protocol)
+def _config(
+    *,
+    enabled: bool = True,
+    endpoint: str = "http://tempo:4318/v1/traces",
+    protocol: str = "http/protobuf",
+) -> tuple[bool, str, str, str, str, str]:
+    return (enabled, endpoint, "svc", "1.0", "dev", protocol)
 
 
 class TestSilenceOtelLoggers:
@@ -23,6 +41,7 @@ class TestSilenceOtelLoggers:
 
         for name in (
             "opentelemetry.exporter.otlp.proto.grpc.exporter",
+            "opentelemetry.exporter.otlp.proto.http.trace_exporter",
             "opentelemetry.sdk.trace.export",
             "grpc._channel",
             "grpc._plugin_wrapping",
@@ -43,7 +62,7 @@ class TestConfigureTracing:
     @patch("luthien_proxy.telemetry._silence_otel_loggers")
     def test_disabled_silences_loggers(self, mock_silence, mock_config):
         """When OTel is disabled, noisy loggers are silenced."""
-        mock_config.return_value = (False, "", "svc", "1.0", "dev")
+        mock_config.return_value = _config(enabled=False, endpoint="")
         telemetry.configure_tracing()
         mock_silence.assert_called_once()
 
@@ -51,18 +70,71 @@ class TestConfigureTracing:
     @patch("luthien_proxy.telemetry._silence_otel_loggers")
     def test_enabled_does_not_silence_loggers(self, mock_silence, mock_config):
         """When OTel is enabled, loggers are NOT silenced — connection errors should be visible."""
-        mock_config.return_value = (True, "http://localhost:4317", "svc", "1.0", "dev")
+        mock_config.return_value = _config()
         telemetry.configure_tracing()
         mock_silence.assert_not_called()
 
     @patch("luthien_proxy.telemetry._get_otel_config")
     def test_disabled_logs_at_debug_not_info(self, mock_config):
         """When OTel is disabled, the message should be DEBUG, not INFO."""
-        mock_config.return_value = (False, "", "svc", "1.0", "dev")
+        mock_config.return_value = _config(enabled=False, endpoint="")
         with patch.object(telemetry.logger, "debug") as mock_debug, patch.object(telemetry.logger, "info") as mock_info:
             telemetry.configure_tracing()
             mock_debug.assert_called_once()
             mock_info.assert_not_called()
+
+
+class TestBuildOtlpExporter:
+    """Test exporter dispatch on the protocol setting."""
+
+    def test_default_protocol_returns_http_exporter(self):
+        """Default protocol (http/protobuf) builds the HTTP exporter."""
+        exporter = telemetry._build_otlp_exporter("http/protobuf", "http://tempo:4318/v1/traces")
+        assert isinstance(exporter, HttpSpanExporter)
+
+    def test_grpc_protocol_returns_grpc_exporter(self):
+        """Explicit grpc protocol builds the gRPC exporter."""
+        exporter = telemetry._build_otlp_exporter("grpc", "http://tempo:4317")
+        assert isinstance(exporter, GrpcSpanExporter)
+
+    @pytest.mark.parametrize("bad_value", ["", "http", "HTTP/PROTOBUF", "tcp", "rest"])
+    def test_unknown_protocol_raises_value_error(self, bad_value):
+        """Unknown protocol values fail loud at startup — never silently fall back."""
+        with pytest.raises(ValueError, match="OTEL_EXPORTER_OTLP_PROTOCOL"):
+            telemetry._build_otlp_exporter(bad_value, "http://tempo:4318/v1/traces")
+
+    @patch("luthien_proxy.telemetry._get_otel_config")
+    def test_configure_tracing_propagates_unknown_protocol_error(self, mock_config):
+        """An invalid protocol surfaces as ValueError from configure_tracing."""
+        mock_config.return_value = _config(protocol="not-a-real-protocol")
+        with pytest.raises(ValueError):
+            telemetry.configure_tracing()
+
+
+class TestProtocolEnvVarBinding:
+    """Guard that the OTEL_EXPORTER_OTLP_PROTOCOL env var is actually wired up.
+
+    Regression guard: an earlier version of this PR named the field
+    ``otel_exporter_protocol``, which auto-derives to
+    ``OTEL_EXPORTER_PROTOCOL`` — silently breaking the documented
+    ``OTEL_EXPORTER_OTLP_PROTOCOL`` escape hatch.
+    """
+
+    def test_env_var_overrides_default(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+        settings = Settings(_env_file=None)
+        assert settings.otel_exporter_otlp_protocol == "grpc"
+
+    def test_default_is_http_protobuf(self, monkeypatch):
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_PROTOCOL", raising=False)
+        settings = Settings(_env_file=None)
+        assert settings.otel_exporter_otlp_protocol == "http/protobuf"
+
+    def test_default_endpoint_targets_http_port_with_v1_traces_path(self, monkeypatch):
+        """Default endpoint must match the default HTTP/protobuf protocol."""
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        settings = Settings(_env_file=None)
+        assert settings.otel_exporter_otlp_endpoint == "http://tempo:4318/v1/traces"
 
 
 class TestInstrumentApp:

--- a/uv.lock
+++ b/uv.lock
@@ -1046,6 +1046,7 @@ dependencies = [
     { name = "litellm", extra = ["proxy"] },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-redis" },
     { name = "opentelemetry-sdk" },
@@ -1087,6 +1088,7 @@ requires-dist = [
     { name = "litellm", extras = ["proxy"], specifier = ">=1.81.0,!=1.82.7,!=1.82.8" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.20.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.41b0" },
     { name = "opentelemetry-instrumentation-redis", specifier = ">=0.41b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
@@ -1349,6 +1351,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a2/c0/43222f5b97dc10812bc4f0abc5dc7cd0a2525a91b5151d26c9e2e958f52e/opentelemetry_exporter_otlp_proto_grpc-1.38.0.tar.gz", hash = "sha256:2473935e9eac71f401de6101d37d6f3f0f1831db92b953c7dcc912536158ebd6", size = 24676, upload-time = "2025-10-16T08:35:53.83Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/f0/bd831afbdba74ca2ce3982142a2fad707f8c487e8a3b6fef01f1d5945d1b/opentelemetry_exporter_otlp_proto_grpc-1.38.0-py3-none-any.whl", hash = "sha256:7c49fd9b4bd0dbe9ba13d91f764c2d20b0025649a6e4ac35792fb8d84d764bc7", size = 19695, upload-time = "2025-10-16T08:35:35.053Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0a/debcdfb029fbd1ccd1563f7c287b89a6f7bef3b2902ade56797bfd020854/opentelemetry_exporter_otlp_proto_http-1.38.0.tar.gz", hash = "sha256:f16bd44baf15cbe07633c5112ffc68229d0edbeac7b37610be0b2def4e21e90b", size = 17282, upload-time = "2025-10-16T08:35:54.422Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/77/154004c99fb9f291f74aa0822a2f5bbf565a72d8126b3a1b63ed8e5f83c7/opentelemetry_exporter_otlp_proto_http-1.38.0-py3-none-any.whl", hash = "sha256:84b937305edfc563f08ec69b9cb2298be8188371217e867c1854d77198d0825b", size = 19579, upload-time = "2025-10-16T08:35:36.269Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Changes the default OTLP exporter protocol from gRPC to HTTP/protobuf so traces flow through HTTP load balancers (ALB, nginx, Cloudflare) where gRPC fails with `StatusCode.UNAVAILABLE`.

This is a takeover of #562 (Sami Jawhar / @sjawhar). The original PR sat unanswered for ~3 weeks and shipped with five concrete blockers — all addressed here while preserving the original change.

Resolves #556. Closes #562.

## What changed vs #562

| Blocker in #562 | Fix in this PR |
|---|---|
| **Pydantic env-var alias bug.** Field named `otel_exporter_protocol` auto-derived to `OTEL_EXPORTER_PROTOCOL`, so the documented `OTEL_EXPORTER_OTLP_PROTOCOL` escape hatch silently never worked. | Field renamed to `otel_exporter_otlp_protocol` so auto-derivation matches the OTEL spec env var. Verified empirically. |
| **Default endpoint pointed at gRPC port.** `http://tempo:4317` with no `/v1/traces` path; `HttpSpanExporter` uses the endpoint verbatim → silent trace drop on default config. | Default endpoint changed to `http://tempo:4318/v1/traces`. |
| **Tempo only listened on gRPC.** `observability/tempo/tempo.yaml` had no HTTP receiver. | Added OTLP HTTP receiver on `0.0.0.0:4318`. `docker-compose.yaml` exposes 4318 alongside 4317. |
| **`.env.example` not regenerated** despite CLAUDE.md mandating auto-generation. | Regenerated; `OTEL_EXPORTER_OTLP_PROTOCOL` now appears. |
| **Silent fallback codified.** `test_unknown_protocol_falls_back_to_http` made silent fallback the spec. | `_build_otlp_exporter` raises `ValueError` on unknown protocols. Parametrized rejection test replaces the silent-fallback test. |

Also fixed: TLS asymmetry between exporters is now documented in the module docstring (gRPC uses `insecure=True`; HTTP follows the URL scheme).

## Behavior

| `OTEL_EXPORTER_OTLP_PROTOCOL` | Exporter | Default endpoint | Notes |
|---|---|---|---|
| `http/protobuf` (default) | `HttpSpanExporter` | `http://tempo:4318/v1/traces` | HTTP/1.1 POST; works behind any HTTP LB |
| `grpc` | `GrpcSpanExporter` | requires override to `http://tempo:4317` | Original behavior, opt-in |
| anything else | (none) | — | `ValueError` at startup — no silent fallback |

## Migration (BREAKING)

Existing deployments overriding `OTEL_EXPORTER_OTLP_ENDPOINT` to a gRPC collector must opt in to gRPC explicitly:

```bash
OTEL_EXPORTER_OTLP_PROTOCOL=grpc
OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
```

Default Docker Compose users get the HTTP/protobuf path automatically — Tempo now listens on both 4317 and 4318.

## Tests

`tests/luthien_proxy/unit_tests/test_telemetry.py`:
- HTTP/protobuf default builds `HttpSpanExporter`
- `grpc` builds `GrpcSpanExporter`
- Unknown protocol values (`""`, `"http"`, `"HTTP/PROTOBUF"`, `"tcp"`, `"rest"`) raise `ValueError`
- `OTEL_EXPORTER_OTLP_PROTOCOL` env var actually overrides the default — regression guard for the alias bug
- Default endpoint is `http://tempo:4318/v1/traces` — regression guard for the gRPC-port default

`tests/luthien_proxy/unit_tests/test_settings.py`: default-endpoint assertion updated.

## Files

```
.env.example                                       (regenerated)
changelog.d/otel-http-default.md                   (new)
dev-README.md                                      (env-var doc)
docker-compose.yaml                                (port + defaults)
observability/README.md                            (curl example)
observability/tempo/tempo.yaml                     (HTTP receiver)
pyproject.toml                                     (HTTP exporter dep)
src/luthien_proxy/config_fields.py                 (new field, endpoint default)
src/luthien_proxy/settings.py                      (regenerated)
src/luthien_proxy/telemetry.py                     (dispatch + strict validation)
tests/luthien_proxy/unit_tests/test_settings.py    (default endpoint)
tests/luthien_proxy/unit_tests/test_telemetry.py   (full rewrite)
uv.lock                                            (regenerated)
```

## Test plan

- [x] `uv run pytest tests/luthien_proxy/unit_tests --ignore=tests/luthien_proxy/unit_tests/inference` — passes
- [x] `uv run pyright` on changed files — 0 errors
- [x] `uv run ruff check && ruff format --check` — clean
- [x] Empirical: `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` overrides default
- [ ] Pre-existing flake `tests/luthien_proxy/unit_tests/inference/test_registry.py` (SQL syntax error) — unrelated, no inference code touched

---
*Posted by Claude Code (claude-opus-4-7)*