### PR TITLE
feat(health): add /ready readiness probe with bounded DB ping

### DIFF
--- a/changelog.d/ready-endpoint-tight.md
+++ b/changelog.d/ready-endpoint-tight.md
@@ -1,0 +1,8 @@
+---
+category: Features
+---
+
+**Add /ready readiness probe**: New `GET /ready` endpoint returns 503 when the database is unreachable, times out, or dependencies are not initialized; 200 with `{"status": "ready"}` otherwise. Intended for ECS/k8s readiness probes so traffic is drained when the gateway cannot serve post-startup.
+  - DB probe is bounded by `READY_DB_PROBE_TIMEOUT_SECONDS` (2s) via `asyncio.wait_for` so a slow database does not tarpit probe workers.
+  - Error reasons are sanitized — no raw exception text or connection details are leaked to unauthenticated callers.
+  - `/ready` is included in the no-cache middleware allowlist so CDNs cannot serve a stale cached response.

--- a/dev-README.md
+++ b/dev-README.md
@@ -107,7 +107,7 @@ The gateway is a single FastAPI application:
 
 - `POST /v1/messages` - Anthropic Messages API (streaming and non-streaming)
 - `GET /health` - Liveness check (always 200 if the process is responsive)
-- `GET /ready` - Readiness probe (503 when DB is unreachable / probe times out)
+- `GET /ready` - Readiness probe (503 when DB is unreachable, probe times out, or dependencies are not initialized)
 
 **UI Endpoints:**
 

--- a/dev-README.md
+++ b/dev-README.md
@@ -106,7 +106,8 @@ The gateway is a single FastAPI application:
 **API Endpoints:**
 
 - `POST /v1/messages` - Anthropic Messages API (streaming and non-streaming)
-- `GET /health` - Health check
+- `GET /health` - Liveness check (always 200 if the process is responsive)
+- `GET /ready` - Readiness probe (503 when DB is unreachable / probe times out)
 
 **UI Endpoints:**
 

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -414,12 +414,12 @@ def create_app(
                 content={"status": "not_ready", "reason": "dependencies not initialized"},
             )
 
+        async def _probe() -> None:
+            async with deps.db_pool.connection() as conn:
+                await conn.fetchval("SELECT 1")
+
         try:
-            pool = await deps.db_pool.get_pool()
-            await asyncio.wait_for(
-                pool.fetchval("SELECT 1"),
-                timeout=READY_DB_PROBE_TIMEOUT_SECONDS,
-            )
+            await asyncio.wait_for(_probe(), timeout=READY_DB_PROBE_TIMEOUT_SECONDS)
         except asyncio.TimeoutError:
             logger.warning("Readiness probe timed out after %.1fs", READY_DB_PROBE_TIMEOUT_SECONDS)
             return JSONResponse(

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import enum
 import logging
 import os
@@ -75,6 +76,10 @@ instrument_redis()
 init_sentry()
 
 logger = logging.getLogger(__name__)
+
+# Bounded DB probe for /ready. Short enough that a slow DB does not tarpit
+# probe workers; long enough to absorb routine acquire/network jitter.
+READY_DB_PROBE_TIMEOUT_SECONDS = 2.0
 
 _HTTP_STATUS_TO_ANTHROPIC_ERROR_TYPE = {
     400: "invalid_request_error",
@@ -340,7 +345,7 @@ def create_app(
     class StaticCacheMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request: Request, call_next):
             response = await call_next(request)
-            if request.url.path.startswith("/api/") or request.url.path == "/health":
+            if request.url.path.startswith("/api/") or request.url.path in ("/health", "/ready"):
                 # Prevent CDN/edge caching of API and health responses (Railway, Cloudflare, etc.)
                 response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
             elif request.url.path.startswith("/static/"):
@@ -390,6 +395,45 @@ def create_app(
             "last_credential_type": last_credential_type,
             "last_credential_at": last_credential_at,
         }
+
+    @app.get("/ready")
+    async def ready(request: Request):
+        """Readiness probe: 503 when the gateway cannot serve traffic.
+
+        Returns 200 when the DB pool answers a bounded `SELECT 1` within
+        READY_DB_PROBE_TIMEOUT_SECONDS. Returns 503 with a generic reason when
+        the probe fails, times out, or dependencies are not initialized.
+
+        Use this for ECS/k8s readiness probes so traffic is drained when
+        the DB becomes unreachable post-startup. Use /health for liveness.
+        """
+        deps = getattr(request.app.state, "dependencies", None)
+        if deps is None or deps.db_pool is None:
+            return JSONResponse(
+                status_code=503,
+                content={"status": "not_ready", "reason": "dependencies not initialized"},
+            )
+
+        try:
+            pool = await deps.db_pool.get_pool()
+            await asyncio.wait_for(
+                pool.fetchval("SELECT 1"),
+                timeout=READY_DB_PROBE_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("Readiness probe timed out after %.1fs", READY_DB_PROBE_TIMEOUT_SECONDS)
+            return JSONResponse(
+                status_code=503,
+                content={"status": "not_ready", "reason": "database probe timed out"},
+            )
+        except Exception as exc:
+            logger.warning("Readiness probe DB error: %s", type(exc).__name__)
+            return JSONResponse(
+                status_code=503,
+                content={"status": "not_ready", "reason": "database unreachable"},
+            )
+
+        return {"status": "ready"}
 
     # Format HTTPExceptions and validation errors as Anthropic errors on /v1/messages paths
     app.add_exception_handler(FastAPIHTTPException, http_exception_handler)

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -466,14 +466,21 @@ class TestCreateApp:
             response = client.get("/health")
             assert response.json()["auth_mode"] == "passthrough"
 
-    def test_ready_endpoint_returns_200_when_db_responsive(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """/ready returns 200 when DB ping succeeds within timeout."""
-        mock_pool = mock_db_pool.get_pool.return_value
-        mock_pool.fetchval = AsyncMock(return_value=1)
+    def test_ready_endpoint_returns_200_with_real_sqlite_pool(self, policy_config_file, mock_redis_client):
+        """/ready returns 200 against a real SqlitePool — exercises the actual DB API.
+
+        Uses an in-memory SqliteDatabasePool so the probe goes through the real
+        `connection().fetchval` path. A mock-only test would not catch the case
+        where the production code calls a method that does not exist on
+        SqlitePool.
+        """
+        from luthien_proxy.utils import db as db_module
+
+        real_pool = db_module.DatabasePool("sqlite://:memory:")
         app = create_app(
             api_key="test-key",
             admin_key=None,
-            db_pool=mock_db_pool,
+            db_pool=real_pool,
             redis_client=mock_redis_client,
             startup_policy_path=policy_config_file,
         )
@@ -485,9 +492,19 @@ class TestCreateApp:
             assert response.headers["cache-control"] == "no-store, no-cache, must-revalidate"
 
     def test_ready_endpoint_returns_503_when_db_unreachable(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """/ready returns 503 with sanitized reason when DB ping raises."""
-        mock_pool = mock_db_pool.get_pool.return_value
-        mock_pool.fetchval = AsyncMock(side_effect=ConnectionRefusedError("conn refused: 10.0.0.1:5432"))
+        """/ready returns 503 with sanitized reason when the connection raises.
+
+        No raw exception text or connection details may leak to unauthenticated
+        callers.
+        """
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def failing_connection():
+            raise ConnectionRefusedError("conn refused: db.internal.example.com:5432")
+            yield  # unreachable, required by @asynccontextmanager
+
+        mock_db_pool.connection = failing_connection
         app = create_app(
             api_key="test-key",
             admin_key=None,
@@ -502,27 +519,28 @@ class TestCreateApp:
             body = response.json()
             assert body["status"] == "not_ready"
             assert body["reason"] == "database unreachable"
-            # No raw exception text leaked to unauthenticated callers
-            assert "10.0.0.1" not in response.text
+            assert "db.internal.example.com" not in response.text
 
     def test_ready_endpoint_returns_503_when_db_probe_times_out(
         self, policy_config_file, mock_db_pool, mock_redis_client, monkeypatch
     ):
-        """/ready returns 503 when DB ping exceeds the bounded timeout.
+        """/ready returns 503 when the probe exceeds the bounded timeout.
 
-        A slow DB must not tarpit probe workers — the probe is bounded by
-        READY_DB_PROBE_TIMEOUT_SECONDS via asyncio.wait_for.
+        A slow DB must not tarpit probe workers — the entire probe (pool
+        acquisition + query) is bounded by asyncio.wait_for.
         """
-        # Tighten the probe timeout for the test so it returns quickly.
+        from contextlib import asynccontextmanager
+
         from luthien_proxy import main as main_module
 
         monkeypatch.setattr(main_module, "READY_DB_PROBE_TIMEOUT_SECONDS", 0.05)
 
-        async def hang(*args, **kwargs):
-            await asyncio.sleep(5.0)
+        @asynccontextmanager
+        async def hanging_connection():
+            await asyncio.sleep(1.0)
+            yield  # unreachable under the patched timeout
 
-        mock_pool = mock_db_pool.get_pool.return_value
-        mock_pool.fetchval = hang
+        mock_db_pool.connection = hanging_connection
         app = create_app(
             api_key="test-key",
             admin_key=None,
@@ -537,6 +555,26 @@ class TestCreateApp:
             body = response.json()
             assert body["status"] == "not_ready"
             assert body["reason"] == "database probe timed out"
+
+    def test_ready_endpoint_returns_503_when_dependencies_not_initialized(
+        self, policy_config_file, mock_db_pool, mock_redis_client
+    ):
+        """/ready returns 503 when app.state.dependencies is missing post-startup."""
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            app.state.dependencies = None  # type: ignore[attr-defined]
+            response = client.get("/ready")
+            assert response.status_code == 503
+            body = response.json()
+            assert body["status"] == "not_ready"
+            assert body["reason"] == "dependencies not initialized"
 
     def test_create_app_root_endpoint(self, policy_config_file, mock_db_pool, mock_redis_client):
         """Test root endpoint returns HTML landing page."""

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -3,6 +3,7 @@
 
 """Tests for V2 main FastAPI application."""
 
+import asyncio
 import os
 import tempfile
 from pathlib import Path
@@ -464,6 +465,78 @@ class TestCreateApp:
         with TestClient(app) as client:
             response = client.get("/health")
             assert response.json()["auth_mode"] == "passthrough"
+
+    def test_ready_endpoint_returns_200_when_db_responsive(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """/ready returns 200 when DB ping succeeds within timeout."""
+        mock_pool = mock_db_pool.get_pool.return_value
+        mock_pool.fetchval = AsyncMock(return_value=1)
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            response = client.get("/ready")
+            assert response.status_code == 200
+            assert response.json() == {"status": "ready"}
+            assert response.headers["cache-control"] == "no-store, no-cache, must-revalidate"
+
+    def test_ready_endpoint_returns_503_when_db_unreachable(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """/ready returns 503 with sanitized reason when DB ping raises."""
+        mock_pool = mock_db_pool.get_pool.return_value
+        mock_pool.fetchval = AsyncMock(side_effect=ConnectionRefusedError("conn refused: 10.0.0.1:5432"))
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            response = client.get("/ready")
+            assert response.status_code == 503
+            body = response.json()
+            assert body["status"] == "not_ready"
+            assert body["reason"] == "database unreachable"
+            # No raw exception text leaked to unauthenticated callers
+            assert "10.0.0.1" not in response.text
+
+    def test_ready_endpoint_returns_503_when_db_probe_times_out(
+        self, policy_config_file, mock_db_pool, mock_redis_client, monkeypatch
+    ):
+        """/ready returns 503 when DB ping exceeds the bounded timeout.
+
+        A slow DB must not tarpit probe workers — the probe is bounded by
+        READY_DB_PROBE_TIMEOUT_SECONDS via asyncio.wait_for.
+        """
+        # Tighten the probe timeout for the test so it returns quickly.
+        from luthien_proxy import main as main_module
+
+        monkeypatch.setattr(main_module, "READY_DB_PROBE_TIMEOUT_SECONDS", 0.05)
+
+        async def hang(*args, **kwargs):
+            await asyncio.sleep(5.0)
+
+        mock_pool = mock_db_pool.get_pool.return_value
+        mock_pool.fetchval = hang
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            response = client.get("/ready")
+            assert response.status_code == 503
+            body = response.json()
+            assert body["status"] == "not_ready"
+            assert body["reason"] == "database probe timed out"
 
     def test_create_app_root_endpoint(self, policy_config_file, mock_db_pool, mock_redis_client):
         """Test root endpoint returns HTML landing page."""


### PR DESCRIPTION
## Summary

Tighter, narrowly-scoped alternative to #570. Adds `GET /ready` that returns 503 when the gateway cannot serve traffic post-startup, with the bugs we found in #570 fixed and the dead/decorative parts dropped.

## Endpoint behavior

- **200 `{"status": "ready"}`** when the DB pool answers `SELECT 1` within `READY_DB_PROBE_TIMEOUT_SECONDS` (2.0s).
- **503 `{"status": "not_ready", "reason": "..."}`** when:
  - DB ping raises (`reason: "database unreachable"`)
  - DB ping times out (`reason: "database probe timed out"`)
  - dependencies are not initialized (`reason: "dependencies not initialized"`)

`/health` is **unchanged** — this PR does not touch the existing liveness contract.

## What this fixes vs. #570

| Issue in #570 | Fixed here |
|---|---|
| No timeout on `SELECT 1` — slow DB tarpits probe workers, risks cascade failure | `asyncio.wait_for(..., timeout=2.0)` around the ping |
| `/ready` not in the no-cache middleware allowlist (CDN can cache `ready`) | Added `/ready` alongside `/health` and `/api/*` |
| Raw exception text leaked to unauthenticated callers (`database_error: str(exc)`) | Reasons are generic strings; `type(exc).__name__` only goes to the log |
| "Policy not loaded" check is dead code (`current_policy` raises before `is None` can be checked; lifespan raises if init fails) | Dropped — readiness is about post-startup serving capacity, and the only thing that can break post-startup is the DB |
| `/health` body changes (`status: degraded` in a 200) — invisible to ALB/k8s probes | Not done — `/health` left alone |
| Startup-race framing (Uvicorn doesn't bind socket until lifespan completes, so the claimed race doesn't exist on the gateway side) | Reframed: `/ready` is for **post-startup DB drain**, not startup race |

## Tests

Three new tests in `tests/luthien_proxy/unit_tests/test_main.py`:

- `test_ready_endpoint_returns_200_when_db_responsive` — happy path + asserts no-cache header
- `test_ready_endpoint_returns_503_when_db_unreachable` — DB raises, asserts no exception text leaks
- `test_ready_endpoint_returns_503_when_db_probe_times_out` — slow DB, bounded by `asyncio.wait_for`

## Operational notes

- Pulling an instance from rotation on a slow DB is still a tradeoff (cascade-failure risk under DB-wide degradation). The 2s timeout is short enough to drain a genuinely-down instance and long enough to absorb routine acquire/network jitter. Consider tuning per deployment if this becomes a problem.
- Error details (exception type) are logged at `WARNING` level — operators can correlate from logs without exposing them to callers.

## Files

- `src/luthien_proxy/main.py` — `/ready` handler, `READY_DB_PROBE_TIMEOUT_SECONDS` constant, `/ready` added to no-cache middleware
- `tests/luthien_proxy/unit_tests/test_main.py` — three tests
- `dev-README.md` — endpoint table updated
- `changelog.d/ready-endpoint-tight.md` — fragment

---
*Posted by Claude Code (claude-opus-4-7[1m])*