### PR TITLE
fix(tests): unblock dev_checks pytest phase

### DIFF
--- a/changelog.d/fix-pytest-hang-and-fts-migration.md
+++ b/changelog.d/fix-pytest-hang-and-fts-migration.md
@@ -1,0 +1,7 @@
+---
+category: Fixes
+---
+
+**dev_checks: unit tests no longer hang or error**:
+  - `tests/luthien_proxy/unit_tests/inference/test_registry.py` fixture used a naive `sql.split(";")` to apply migrations, which shredded trigger bodies in `014_add_session_search_fts.sql` and failed with `near "the": syntax error`. Now reuses `_apply_sqlite_migrations()` (same runner used in production), which understands `BEGIN…END` blocks via `executescript()`.
+  - `tests/luthien_cli/test_claude.py::test_claude_fails_when_not_installed` was not patching `ensure_gateway_up`, so it polled the real gateway health endpoint until pytest's timeout — making the unit-test phase appear to hang. Now patched consistently with the other tests in the file.

--- a/tests/luthien_cli/test_claude.py
+++ b/tests/luthien_cli/test_claude.py
@@ -68,6 +68,7 @@ def test_claude_fails_when_not_installed(tmp_path):
     config_path.write_text('[gateway]\nurl = "http://localhost:8000"\n')
     with (
         patch("luthien_cli.commands.claude.DEFAULT_CONFIG_PATH", config_path),
+        patch("luthien_cli.commands.claude.ensure_gateway_up"),
         patch("luthien_cli.commands.claude.shutil.which", return_value=None),
     ):
         result = runner.invoke(cli, ["claude"])

--- a/tests/luthien_proxy/unit_tests/inference/test_registry.py
+++ b/tests/luthien_proxy/unit_tests/inference/test_registry.py
@@ -37,6 +37,7 @@ from luthien_proxy.inference.registry import (
     _build_direct_api,
 )
 from luthien_proxy.utils.db import DatabasePool
+from luthien_proxy.utils.migration_check import _apply_sqlite_migrations
 
 
 class _StubProvider(InferenceProvider):
@@ -73,17 +74,7 @@ async def sqlite_pool() -> DatabasePool:
     """Real in-memory SQLite with every migration applied."""
     pool = DatabasePool("sqlite://:memory:")
     migrations_dir = Path(__file__).resolve().parents[4] / "migrations" / "sqlite"
-
-    async with pool.connection() as conn:
-        for migration_file in sorted(migrations_dir.glob("*.sql")):
-            sql = migration_file.read_text()
-            for statement in sql.split(";"):
-                statement = statement.strip()
-                if statement and not all(
-                    line.strip().startswith("--") or not line.strip() for line in statement.split("\n")
-                ):
-                    await conn.execute(statement)
-
+    await _apply_sqlite_migrations(pool, migrations_dir=migrations_dir)
     yield pool
     await pool.close()
 


### PR DESCRIPTION
## Summary

Two failures in the unit-test phase of `scripts/dev_checks.sh` — one error-cascade across an entire test file, plus one test that hung indefinitely.

## What was broken

1. **`tests/luthien_proxy/unit_tests/inference/test_registry.py`** — every test in the file errored at fixture setup. The `sqlite_pool` fixture applied migrations by splitting SQL on `;` and executing each chunk. That shreds the `BEGIN … END` trigger bodies in `migrations/sqlite/014_add_session_search_fts.sql`, producing `sqlite3.OperationalError: near "the": syntax error`. Fix: call `_apply_sqlite_migrations()` — the production runner — which uses `executescript()` and understands trigger blocks.

2. **`tests/luthien_cli/test_claude.py::test_claude_fails_when_not_installed`** — didn't patch `ensure_gateway_up`, so it hit the real `wait_for_healthy()` polling loop on `http://localhost:8000/health`. The test phase appeared to hang. Fix: patch `ensure_gateway_up`, consistent with every other test in that file.

## Test plan

- [x] `uv run -m pytest tests/luthien_proxy/unit_tests/inference/test_registry.py` — 21 passed
- [x] `uv run -m pytest tests/luthien_cli/test_claude.py` — 6 passed
- [x] Full suite (`uv run -m pytest`) — 2340 passed, 364 deselected, 24s
- [x] `./scripts/dev_checks.sh` — all gating phases pass

---
*Posted by Claude Code (claude-opus-4-7[1m])*