### PR TITLE
fix(security): strip auth-mode/credential signals from /health

### DIFF
--- a/changelog.d/health-strip-billing-leak.md
+++ b/changelog.d/health-strip-billing-leak.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**Stop leaking auth-mode and credential activity from `/health`**: The unauthenticated `/health` endpoint previously returned `auth_mode`, `last_credential_type`, and `last_credential_at`, which a probe attacker could use to fingerprint the gateway's auth configuration and recent credential activity. Those fields now live on a new authenticated endpoint, `GET /api/admin/billing-status`, and the admin UI's nav badge fetches from there. `/health` is now `{status, version}` only.

--- a/scripts/launch_claude_code.sh
+++ b/scripts/launch_claude_code.sh
@@ -77,6 +77,11 @@ if [[ -n "${admin_key}" ]]; then
     CONFIG_RESPONSE=$(curl -sf -H "Authorization: Bearer ${admin_key}" \
         "http://localhost:${GATEWAY_PORT_VAR}/api/admin/auth/config")
     AUTH_MODE=$(echo "$CONFIG_RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('auth_mode',''))" 2>/dev/null)
+else
+    echo -e "${YELLOW}⚠ ADMIN_API_KEY not set in .env — cannot detect gateway auth mode.${NC}"
+    echo -e "${YELLOW}  Defaulting to client_key behavior (USE_OAUTH=false). If your gateway"
+    echo -e "  is in passthrough or both mode, set ADMIN_API_KEY in .env so the launcher"
+    echo -e "  can configure Claude Code correctly.${NC}"
 fi
 
 if [[ "${AUTH_MODE}" == "passthrough" ]]; then

--- a/scripts/launch_claude_code.sh
+++ b/scripts/launch_claude_code.sh
@@ -72,6 +72,10 @@ GATEWAY_URL="http://localhost:${GATEWAY_PORT_VAR}/"
 # (auth_mode used to be on /health, but was moved to keep /health from leaking
 # auth configuration to unauthenticated probes.)
 admin_key=$(grep -E '^ADMIN_API_KEY=' .env 2>/dev/null | cut -d '=' -f2-)
+# Strip surrounding quotes so values like ADMIN_API_KEY="abc" don't end up
+# in the Authorization header as `Bearer "abc"` (which the gateway rejects).
+admin_key="${admin_key%\"}"; admin_key="${admin_key#\"}"
+admin_key="${admin_key%\'}"; admin_key="${admin_key#\'}"
 AUTH_MODE=""
 if [[ -n "${admin_key}" ]]; then
     # Don't let `set -e` kill the script if the gateway rejects the key

--- a/scripts/launch_claude_code.sh
+++ b/scripts/launch_claude_code.sh
@@ -66,11 +66,18 @@ echo -e "${GREEN}✅ gateway is running on port ${GATEWAY_PORT_VAR}${NC}"
 CLIENT_KEY="${CLIENT_API_KEY:-sk-luthien-dev-key}"
 GATEWAY_URL="http://localhost:${GATEWAY_PORT_VAR}/"
 
-# Detect auth mode from /health endpoint:
+# Detect auth mode from the admin-only /api/admin/auth/config endpoint:
 #   client_key — server always uses its own Anthropic API key; requests are billed to it.
 #   anything else — OAuth passthrough (Claude Pro/Max subscribers, no per-token charges).
-HEALTH_RESPONSE=$(curl -sf "http://localhost:${GATEWAY_PORT_VAR}/health")
-AUTH_MODE=$(echo "$HEALTH_RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('auth_mode',''))" 2>/dev/null)
+# (auth_mode used to be on /health, but was moved to keep /health from leaking
+# auth configuration to unauthenticated probes.)
+admin_key=$(grep -E '^ADMIN_API_KEY=' .env 2>/dev/null | cut -d '=' -f2-)
+AUTH_MODE=""
+if [[ -n "${admin_key}" ]]; then
+    CONFIG_RESPONSE=$(curl -sf -H "Authorization: Bearer ${admin_key}" \
+        "http://localhost:${GATEWAY_PORT_VAR}/api/admin/auth/config")
+    AUTH_MODE=$(echo "$CONFIG_RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('auth_mode',''))" 2>/dev/null)
+fi
 
 if [[ "${AUTH_MODE}" == "passthrough" ]]; then
     AUTH_MODE_LABEL="Claude Max / OAuth passthrough"
@@ -95,7 +102,6 @@ echo ""
 if new_mode=$(check_auth_mode_interactive "$AUTH_MODE"); then
     update_auth_mode_env "$new_mode"
 
-    admin_key=$(grep -E '^ADMIN_API_KEY=' .env 2>/dev/null | cut -d '=' -f2-)
     update_auth_mode_api "$new_mode" "http://localhost:${GATEWAY_PORT_VAR}" "$admin_key"
 
     AUTH_MODE="$new_mode"

--- a/scripts/launch_claude_code.sh
+++ b/scripts/launch_claude_code.sh
@@ -74,9 +74,19 @@ GATEWAY_URL="http://localhost:${GATEWAY_PORT_VAR}/"
 admin_key=$(grep -E '^ADMIN_API_KEY=' .env 2>/dev/null | cut -d '=' -f2-)
 AUTH_MODE=""
 if [[ -n "${admin_key}" ]]; then
+    # Don't let `set -e` kill the script if the gateway rejects the key
+    # (stale .env, key rotated, etc.) — degrade to a warning instead.
     CONFIG_RESPONSE=$(curl -sf -H "Authorization: Bearer ${admin_key}" \
-        "http://localhost:${GATEWAY_PORT_VAR}/api/admin/auth/config")
-    AUTH_MODE=$(echo "$CONFIG_RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('auth_mode',''))" 2>/dev/null)
+        "http://localhost:${GATEWAY_PORT_VAR}/api/admin/auth/config" || true)
+    if [[ -n "${CONFIG_RESPONSE}" ]]; then
+        AUTH_MODE=$(echo "$CONFIG_RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('auth_mode',''))" 2>/dev/null || echo "")
+    fi
+    if [[ -z "${AUTH_MODE}" ]]; then
+        echo -e "${YELLOW}⚠ Could not detect gateway auth_mode (admin key may be stale or rejected).${NC}"
+        echo -e "${YELLOW}  Defaulting to client_key behavior (USE_OAUTH=false). If your gateway"
+        echo -e "  is in passthrough or both mode, verify ADMIN_API_KEY in .env matches the"
+        echo -e "  running gateway so the launcher can configure Claude Code correctly.${NC}"
+    fi
 else
     echo -e "${YELLOW}⚠ ADMIN_API_KEY not set in .env — cannot detect gateway auth mode.${NC}"
     echo -e "${YELLOW}  Defaulting to client_key behavior (USE_OAUTH=false). If your gateway"

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import httpx
 import litellm
-from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi import APIRouter, Depends, HTTPException, Path, Request
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from luthien_proxy.admin.policy_discovery import discover_policies, validate_policy_config
@@ -20,6 +20,7 @@ from luthien_proxy.credential_manager import AuthConfig, AuthMode, CredentialMan
 from luthien_proxy.credentials import Credential, CredentialError, CredentialType
 from luthien_proxy.dependencies import (
     get_db_pool,
+    get_dependencies,
     get_policy_manager,
     require_config_registry,
     require_credential_manager,
@@ -130,6 +131,20 @@ class AuthConfigResponse(BaseModel):
     invalid_cache_ttl_seconds: int
     updated_at: str | None = None
     updated_by: str | None = None
+
+
+class BillingStatusResponse(BaseModel):
+    """Response with billing-mode signals for the admin UI badge.
+
+    These fields previously rode along on the unauthenticated /health
+    response, which leaked auth-mode and recent-activity fingerprinting
+    information. The admin UI now fetches this from an authenticated
+    endpoint instead.
+    """
+
+    auth_mode: str | None
+    last_credential_type: str | None
+    last_credential_at: float | None
 
 
 class AuthConfigUpdateRequest(BaseModel):
@@ -425,6 +440,29 @@ async def get_auth_config(
 ):
     """Get current authentication configuration."""
     return _config_to_response(credential_manager.config)
+
+
+@router.get("/billing-status", response_model=BillingStatusResponse)
+async def get_billing_status(
+    request: Request,
+    _: str = Depends(verify_admin_token),
+):
+    """Return billing-mode signals (auth_mode, last credential type/timestamp).
+
+    Used by the admin UI nav bar to render the API-key-billing warning badge.
+    Behind admin auth so the values are not exposed to unauthenticated probes
+    (a probe attacker could otherwise fingerprint the gateway's auth mode and
+    recent activity via /health).
+    """
+    deps = get_dependencies(request)
+    auth_mode = deps.credential_manager.config.auth_mode.value if deps.credential_manager else None
+    last_type = deps.last_credential_info.get("type") if deps.last_credential_info else None
+    last_at = deps.last_credential_info.get("timestamp") if deps.last_credential_info else None
+    return BillingStatusResponse(
+        auth_mode=auth_mode,
+        last_credential_type=last_type,
+        last_credential_at=last_at,
+    )
 
 
 @router.post("/auth/config", response_model=AuthConfigResponse)

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import httpx
 import litellm
-from fastapi import APIRouter, Depends, HTTPException, Path, Request
+from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from luthien_proxy.admin.policy_discovery import discover_policies, validate_policy_config
@@ -19,6 +19,7 @@ from luthien_proxy.config_registry import ConfigOverriddenError, ConfigRegistry
 from luthien_proxy.credential_manager import AuthConfig, AuthMode, CredentialManager
 from luthien_proxy.credentials import Credential, CredentialError, CredentialType
 from luthien_proxy.dependencies import (
+    Dependencies,
     get_db_pool,
     get_dependencies,
     get_policy_manager,
@@ -444,8 +445,8 @@ async def get_auth_config(
 
 @router.get("/billing-status", response_model=BillingStatusResponse)
 async def get_billing_status(
-    request: Request,
     _: str = Depends(verify_admin_token),
+    deps: Dependencies = Depends(get_dependencies),
 ):
     """Return billing-mode signals (auth_mode, last credential type/timestamp).
 
@@ -454,7 +455,6 @@ async def get_billing_status(
     (a probe attacker could otherwise fingerprint the gateway's auth mode and
     recent activity via /health).
     """
-    deps = get_dependencies(request)
     auth_mode = deps.credential_manager.config.auth_mode.value if deps.credential_manager else None
     last_type = deps.last_credential_info.get("type") if deps.last_credential_info else None
     last_at = deps.last_credential_info.get("timestamp") if deps.last_credential_info else None

--- a/src/luthien_proxy/gateway_routes.py
+++ b/src/luthien_proxy/gateway_routes.py
@@ -126,7 +126,7 @@ async def resolve_anthropic_client(
     base_url = base_client._base_url if base_client else None
 
     async def _record_credential_type(cred_type: str) -> None:
-        """Best-effort write of observed credential type for /health visibility."""
+        """Best-effort write of observed credential type for /api/admin/billing-status visibility."""
         if auth_mode == AuthMode.CLIENT_KEY:
             return
         deps = getattr(request.app.state, "dependencies", None)

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -372,28 +372,16 @@ def create_app(
     # Simple utility endpoints
     @app.get("/health")
     async def health(request: Request):
-        """Health check endpoint.
+        """Liveness probe endpoint.
 
-        Returns gateway status, auth mode, and last observed credential type so
-        operators and the UI can surface billing mode warnings accurately.
+        Always returns HTTP 200 if the process is responsive. Kept minimal:
+        a probe attacker shouldn't be able to fingerprint the gateway's auth
+        mode or recent credential activity from this endpoint. The admin UI
+        gets billing-mode signals from /api/admin/billing-status instead.
         """
-        deps = getattr(request.app.state, "dependencies", None)
-        auth_mode = None
-        if deps and deps.credential_manager:
-            auth_mode = deps.credential_manager.config.auth_mode.value
-
-        last_credential_type = None
-        last_credential_at = None
-        if deps and deps.last_credential_info:
-            last_credential_type = deps.last_credential_info.get("type")
-            last_credential_at = deps.last_credential_info.get("timestamp")
-
         return {
             "status": "healthy",
             "version": PROXY_DISPLAY_VERSION,
-            "auth_mode": auth_mode,
-            "last_credential_type": last_credential_type,
-            "last_credential_at": last_credential_at,
         }
 
     @app.get("/ready")

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -371,7 +371,7 @@ def create_app(
 
     # Simple utility endpoints
     @app.get("/health")
-    async def health(request: Request):
+    async def health():
         """Liveness probe endpoint.
 
         Always returns HTTP 200 if the process is responsive. Kept minimal:

--- a/src/luthien_proxy/static/nav.js
+++ b/src/luthien_proxy/static/nav.js
@@ -195,16 +195,26 @@ document.addEventListener('alpine:init', () => {
             document.addEventListener('click', closeTooltip);
             window.addEventListener('resize', positionTooltip);
 
-            const healthData = await updateBadge();
+            await updateBadge();
             const intervalId = setInterval(updateBadge, 30000);
 
-            // Render version footer from the health data we already fetched
+            // Version comes from the public /health endpoint; billing signals
+            // come from the admin-gated /api/admin/billing-status above.
+            // Two fetches keep each endpoint single-purpose.
             let footer = null;
-            if (healthData && healthData.version) {
-                footer = document.createElement('footer');
-                footer.className = 'luthien-footer';
-                footer.textContent = 'luthien-proxy @ ' + healthData.version;
-                document.body.appendChild(footer);
+            try {
+                const healthResponse = await fetch('/health');
+                if (healthResponse.ok) {
+                    const healthData = await healthResponse.json();
+                    if (healthData && healthData.version) {
+                        footer = document.createElement('footer');
+                        footer.className = 'luthien-footer';
+                        footer.textContent = 'luthien-proxy @ ' + healthData.version;
+                        document.body.appendChild(footer);
+                    }
+                }
+            } catch (e) {
+                // Footer is non-critical; leave it absent on fetch error.
             }
 
             this.$cleanup(() => {

--- a/src/luthien_proxy/static/nav.js
+++ b/src/luthien_proxy/static/nav.js
@@ -47,7 +47,14 @@ document.addEventListener('alpine:init', () => {
             const updateBadge = async () => {
                 let data;
                 try {
-                    data = await fetch('/health').then(r => r.json());
+                    // Authenticated endpoint — uses the admin session cookie
+                    // set by /auth/login. Returns 403 when unauthenticated;
+                    // we then leave the badge unset.
+                    const response = await fetch('/api/admin/billing-status', {
+                        credentials: 'same-origin',
+                    });
+                    if (!response.ok) return;
+                    data = await response.json();
                     let badgeType = null; // 'warning' or 'ok'
                     let badgeLabel = null;
                     let tooltipText = null;

--- a/src/luthien_proxy/static/nav.js
+++ b/src/luthien_proxy/static/nav.js
@@ -44,7 +44,12 @@ document.addEventListener('alpine:init', () => {
                 }
             };
 
+            // Page-lifetime flag: stop polling once we know we're not
+            // authenticated (e.g. anonymous visitors loading the public
+            // landing page). Avoids 30s 403 noise in access logs.
+            let billingStatusUnauthorized = false;
             const updateBadge = async () => {
+                if (billingStatusUnauthorized) return;
                 let data;
                 try {
                     // Authenticated endpoint — uses the admin session cookie
@@ -53,6 +58,10 @@ document.addEventListener('alpine:init', () => {
                     const response = await fetch('/api/admin/billing-status', {
                         credentials: 'same-origin',
                     });
+                    if (response.status === 403) {
+                        billingStatusUnauthorized = true;
+                        return;
+                    }
                     if (!response.ok) return;
                     data = await response.json();
                     let badgeType = null; // 'warning' or 'ok'
@@ -121,7 +130,9 @@ document.addEventListener('alpine:init', () => {
                         }
                     }
                 } catch (_) {
-                    // Health check failure is not fatal — nav still works without the badge.
+                    // Billing-status fetch failure is not fatal — nav still
+                    // works without the badge. The 403 path (unauthenticated)
+                    // is handled by the !response.ok early-return above.
                 }
                 return data;
             };
@@ -195,16 +206,19 @@ document.addEventListener('alpine:init', () => {
             document.addEventListener('click', closeTooltip);
             window.addEventListener('resize', positionTooltip);
 
-            await updateBadge();
+            // Version comes from the public /health endpoint; billing signals
+            // come from the admin-gated /api/admin/billing-status. Two fetches
+            // keep each endpoint single-purpose; we issue them in parallel so
+            // the page renders in a single round-trip.
+            const [, healthResponse] = await Promise.all([
+                updateBadge(),
+                fetch('/health').catch(() => null),
+            ]);
             const intervalId = setInterval(updateBadge, 30000);
 
-            // Version comes from the public /health endpoint; billing signals
-            // come from the admin-gated /api/admin/billing-status above.
-            // Two fetches keep each endpoint single-purpose.
             let footer = null;
             try {
-                const healthResponse = await fetch('/health');
-                if (healthResponse.ok) {
+                if (healthResponse && healthResponse.ok) {
                     const healthData = await healthResponse.json();
                     if (healthData && healthData.version) {
                         footer = document.createElement('footer');
@@ -214,7 +228,7 @@ document.addEventListener('alpine:init', () => {
                     }
                 }
             } catch (e) {
-                // Footer is non-critical; leave it absent on fetch error.
+                // Footer is non-critical; leave it absent on fetch/parse error.
             }
 
             this.$cleanup(() => {

--- a/src/luthien_proxy/static/nav.js
+++ b/src/luthien_proxy/static/nav.js
@@ -45,9 +45,10 @@ document.addEventListener('alpine:init', () => {
             };
 
             // Page-lifetime flag: stop polling once we know billing-status
-            // can't work for this session (anonymous visitor → 403, or
-            // ADMIN_API_KEY unset on the server → 500). Both are deterministic
-            // for the lifetime of the page, so polling further is just noise.
+            // can't work for this session. Only 403 is treated as terminal
+            // here — that's the deterministic anonymous-visitor case. 5xx
+            // codes are left as "skip this tick"; an upstream proxy/CDN
+            // could legitimately return them transiently.
             let billingStatusUnavailable = false;
             let billingPollIntervalId = null;
             const stopBillingPoll = () => {
@@ -62,14 +63,13 @@ document.addEventListener('alpine:init', () => {
                 let data;
                 try {
                     // Authenticated endpoint — uses the admin session cookie
-                    // set by /auth/login. 403 means unauthenticated; 500 means
-                    // ADMIN_API_KEY isn't configured server-side (see
-                    // verify_admin_token). Both are page-lifetime conditions,
-                    // so latch and stop polling.
+                    // set by /auth/login.
                     const response = await fetch('/api/admin/billing-status', {
                         credentials: 'same-origin',
                     });
-                    if (response.status === 403 || response.status === 500) {
+                    if (response.status === 403) {
+                        // Anonymous visitor — page-lifetime condition. Stop
+                        // polling so we don't generate 30s log noise.
                         stopBillingPoll();
                         return;
                     }
@@ -141,9 +141,10 @@ document.addEventListener('alpine:init', () => {
                         }
                     }
                 } catch (_) {
-                    // Billing-status fetch failure is not fatal — nav still
-                    // works without the badge. The 403 path (unauthenticated)
-                    // is handled by the !response.ok early-return above.
+                    // Network/parse failure is not fatal — nav still works
+                    // without the badge. The 403 (anonymous-visitor) path is
+                    // handled by the explicit status check above, which both
+                    // returns and stops the poll.
                 }
                 return data;
             };

--- a/src/luthien_proxy/static/nav.js
+++ b/src/luthien_proxy/static/nav.js
@@ -44,22 +44,33 @@ document.addEventListener('alpine:init', () => {
                 }
             };
 
-            // Page-lifetime flag: stop polling once we know we're not
-            // authenticated (e.g. anonymous visitors loading the public
-            // landing page). Avoids 30s 403 noise in access logs.
-            let billingStatusUnauthorized = false;
+            // Page-lifetime flag: stop polling once we know billing-status
+            // can't work for this session (anonymous visitor → 403, or
+            // ADMIN_API_KEY unset on the server → 500). Both are deterministic
+            // for the lifetime of the page, so polling further is just noise.
+            let billingStatusUnavailable = false;
+            let billingPollIntervalId = null;
+            const stopBillingPoll = () => {
+                billingStatusUnavailable = true;
+                if (billingPollIntervalId !== null) {
+                    clearInterval(billingPollIntervalId);
+                    billingPollIntervalId = null;
+                }
+            };
             const updateBadge = async () => {
-                if (billingStatusUnauthorized) return;
+                if (billingStatusUnavailable) return;
                 let data;
                 try {
                     // Authenticated endpoint — uses the admin session cookie
-                    // set by /auth/login. Returns 403 when unauthenticated;
-                    // we then leave the badge unset.
+                    // set by /auth/login. 403 means unauthenticated; 500 means
+                    // ADMIN_API_KEY isn't configured server-side (see
+                    // verify_admin_token). Both are page-lifetime conditions,
+                    // so latch and stop polling.
                     const response = await fetch('/api/admin/billing-status', {
                         credentials: 'same-origin',
                     });
-                    if (response.status === 403) {
-                        billingStatusUnauthorized = true;
+                    if (response.status === 403 || response.status === 500) {
+                        stopBillingPoll();
                         return;
                     }
                     if (!response.ok) return;
@@ -214,7 +225,10 @@ document.addEventListener('alpine:init', () => {
                 updateBadge(),
                 fetch('/health').catch(() => null),
             ]);
-            const intervalId = setInterval(updateBadge, 30000);
+            // Only start the periodic poll if the first call didn't latch.
+            if (!billingStatusUnavailable) {
+                billingPollIntervalId = setInterval(updateBadge, 30000);
+            }
 
             let footer = null;
             try {
@@ -232,7 +246,7 @@ document.addEventListener('alpine:init', () => {
             }
 
             this.$cleanup(() => {
-                clearInterval(intervalId);
+                if (billingPollIntervalId !== null) clearInterval(billingPollIntervalId);
                 if (activeTooltip) activeTooltip.remove();
                 if (footer) footer.remove();
                 document.removeEventListener('click', closeTooltip);

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -544,6 +544,25 @@ class TestCreateApp:
             assert response.status_code == 200
             assert response.json()["auth_mode"] is None
 
+    def test_billing_status_response_is_not_cacheable(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Billing status must not be cached — it can change at any time."""
+        mock_redis_client.get = AsyncMock(return_value=None)
+        app = create_app(
+            api_key="test-key",
+            admin_key="test-admin-key",
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/admin/billing-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            )
+            assert response.status_code == 200
+            assert response.headers["cache-control"] == "no-store, no-cache, must-revalidate"
+
     def test_ready_endpoint_returns_200_with_real_sqlite_pool(self, policy_config_file, mock_redis_client):
         """/ready returns 200 against a real SqlitePool — exercises the actual DB API.
 

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -545,7 +545,13 @@ class TestCreateApp:
             assert response.json()["auth_mode"] is None
 
     def test_billing_status_response_is_not_cacheable(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """Billing status must not be cached — it can change at any time."""
+        """Billing status must not be cached — it can change at any time.
+
+        The Cache-Control header comes from StaticCacheMiddleware's /api/*
+        allowlist, not from the route itself. This test guards against a
+        future refactor that moves the route off /api/* without re-adding
+        the cache-control intent (or that drops the middleware allowlist).
+        """
         mock_redis_client.get = AsyncMock(return_value=None)
         app = create_app(
             api_key="test-key",

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -497,6 +497,53 @@ class TestCreateApp:
             )
             assert response.json()["auth_mode"] == "passthrough"
 
+    def test_billing_status_carries_last_credential_info_when_set(
+        self, policy_config_file, mock_db_pool, mock_redis_client
+    ):
+        """Billing status surfaces last_credential_type/at when populated."""
+        mock_redis_client.get = AsyncMock(return_value=None)
+        app = create_app(
+            api_key="test-key",
+            admin_key="test-admin-key",
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            app.state.dependencies.last_credential_info = {  # type: ignore[attr-defined]
+                "type": "user_api_key",
+                "timestamp": 1700000000.5,
+            }
+            response = client.get(
+                "/api/admin/billing-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            )
+            assert response.status_code == 200
+            body = response.json()
+            assert body["last_credential_type"] == "user_api_key"
+            assert body["last_credential_at"] == 1700000000.5
+
+    def test_billing_status_handles_no_credential_manager(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Billing status returns auth_mode=None when credential_manager is unset."""
+        mock_redis_client.get = AsyncMock(return_value=None)
+        app = create_app(
+            api_key="test-key",
+            admin_key="test-admin-key",
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            app.state.dependencies.credential_manager = None  # type: ignore[attr-defined]
+            response = client.get(
+                "/api/admin/billing-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            )
+            assert response.status_code == 200
+            assert response.json()["auth_mode"] is None
+
     def test_ready_endpoint_returns_200_with_real_sqlite_pool(self, policy_config_file, mock_redis_client):
         """/ready returns 200 against a real SqlitePool — exercises the actual DB API.
 

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -398,7 +398,13 @@ class TestCreateApp:
         assert "/v1/messages" in routes or any("/v1/messages" in str(r) for r in routes if r)
 
     def test_create_app_health_endpoint(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """Test health endpoint returns correct response shape."""
+        """Test health endpoint returns the minimal liveness shape only.
+
+        /health is unauthenticated, so it must not leak auth_mode or recent
+        credential activity (those would let a probe attacker fingerprint
+        the gateway). Billing-mode signals live on
+        /api/admin/billing-status instead.
+        """
         mock_redis_client.get = AsyncMock(return_value=None)
         app = create_app(
             api_key="test-key",
@@ -412,18 +418,33 @@ class TestCreateApp:
             response = client.get("/health")
             assert response.status_code == 200
             data = response.json()
-            assert data["status"] == "healthy"
+            assert data == {"status": "healthy", "version": data["version"]}
             assert data["version"] and data["version"] != "unknown"
-            assert data["auth_mode"] in ("client_key", "both", "passthrough", None)
-            assert "last_credential_type" in data
-            assert "last_credential_at" in data
+            assert "auth_mode" not in data
+            assert "last_credential_type" not in data
+            assert "last_credential_at" not in data
 
-    def test_create_app_health_endpoint_client_key_mode(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """Health endpoint reports auth_mode=client_key when configured."""
+    def test_billing_status_returns_403_without_auth(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Billing status is gated by admin auth — unauthenticated callers get 403."""
         mock_redis_client.get = AsyncMock(return_value=None)
         app = create_app(
             api_key="test-key",
-            admin_key=None,
+            admin_key="test-admin-key",
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            response = client.get("/api/admin/billing-status")
+            assert response.status_code == 403
+
+    def test_billing_status_reports_auth_mode_client_key(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Billing status reports auth_mode=client_key when configured."""
+        mock_redis_client.get = AsyncMock(return_value=None)
+        app = create_app(
+            api_key="test-key",
+            admin_key="test-admin-key",
             db_pool=mock_db_pool,
             redis_client=mock_redis_client,
             startup_policy_path=policy_config_file,
@@ -431,15 +452,19 @@ class TestCreateApp:
         )
 
         with TestClient(app) as client:
-            response = client.get("/health")
+            response = client.get(
+                "/api/admin/billing-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            )
+            assert response.status_code == 200
             assert response.json()["auth_mode"] == "client_key"
 
-    def test_create_app_health_endpoint_both_mode(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """Health endpoint reports auth_mode=both when configured."""
+    def test_billing_status_reports_auth_mode_both(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Billing status reports auth_mode=both when configured."""
         mock_redis_client.get = AsyncMock(return_value=None)
         app = create_app(
             api_key="test-key",
-            admin_key=None,
+            admin_key="test-admin-key",
             db_pool=mock_db_pool,
             redis_client=mock_redis_client,
             startup_policy_path=policy_config_file,
@@ -447,15 +472,18 @@ class TestCreateApp:
         )
 
         with TestClient(app) as client:
-            response = client.get("/health")
+            response = client.get(
+                "/api/admin/billing-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            )
             assert response.json()["auth_mode"] == "both"
 
-    def test_create_app_health_endpoint_passthrough_mode(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """Health endpoint reports auth_mode=passthrough when configured."""
+    def test_billing_status_reports_auth_mode_passthrough(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Billing status reports auth_mode=passthrough when configured."""
         mock_redis_client.get = AsyncMock(return_value=None)
         app = create_app(
             api_key="test-key",
-            admin_key=None,
+            admin_key="test-admin-key",
             db_pool=mock_db_pool,
             redis_client=mock_redis_client,
             startup_policy_path=policy_config_file,
@@ -463,7 +491,10 @@ class TestCreateApp:
         )
 
         with TestClient(app) as client:
-            response = client.get("/health")
+            response = client.get(
+                "/api/admin/billing-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            )
             assert response.json()["auth_mode"] == "passthrough"
 
     def test_ready_endpoint_returns_200_with_real_sqlite_pool(self, policy_config_file, mock_redis_client):


### PR DESCRIPTION
## Summary

The unauthenticated `/health` endpoint returned `auth_mode`, `last_credential_type`, and `last_credential_at` — values a probe attacker could use to fingerprint the gateway's auth configuration and recent credential activity. This PR moves those fields to a new authenticated endpoint and trims `/health` to its minimal liveness shape.

This is the security concern PR #570 tried to address (commit `a0f1571c`). When #570 was reverted in favor of the merged #690, that fix was dropped from the trajectory branch since it had become a no-op there. This PR reinstates the intent cleanly, without depending on any of #570's other changes.

## Changes

- **`/health` now returns `{status, version}` only.** No more auth-mode or credential leakage.
- **New endpoint `GET /api/admin/billing-status`** returns `{auth_mode, last_credential_type, last_credential_at}`, gated by `verify_admin_token` (session cookie / Bearer / x-api-key / localhost bypass).
- **`nav.js` (admin UI nav-bar billing badge)** now fetches from `/api/admin/billing-status` with `credentials: 'same-origin'` so the session cookie carries the auth. On 403 the badge is silently left unset (consistent with previous behavior when admin auth wasn't available).
- **Tests:** the four `/health` auth-mode tests are migrated to test the new endpoint; a new test asserts `/api/admin/billing-status` returns 403 without admin auth.

## Why a separate endpoint instead of just removing the fields

`nav.js` uses `auth_mode` and `last_credential_type` to render the API-key-billing warning badge in the admin UI nav bar. Removing them outright would silently break that warning. Moving them behind admin auth keeps the UI feature working for authenticated operators while closing the unauthenticated leak.

## Touch points

- `src/luthien_proxy/main.py` — `/health` body trimmed
- `src/luthien_proxy/admin/routes.py` — new `BillingStatusResponse` model + `/billing-status` route
- `src/luthien_proxy/static/nav.js` — fetch URL + auth-aware error handling
- `tests/luthien_proxy/unit_tests/test_main.py` — tests migrated
- `changelog.d/health-strip-billing-leak.md` — fragment

## Verified

- `pytest tests/luthien_proxy/unit_tests/test_main.py` — 45 pass.
- `pytest tests/luthien_proxy/unit_tests/admin/ tests/luthien_cli/test_gateway_client.py` — 67 pass.
- `ruff check`, `pyright` clean on changed files.

## Out of scope

- Adding rate limiting / general hardening to admin endpoints — separate concern.
- Changing other unauthenticated endpoints' response shapes — only `/health` is in scope here.

---
*Posted by Claude Code (claude-opus-4-7[1m])*