### PR TITLE
fix(history): match real judge event names in SQL filter and labels

### DIFF
--- a/src/luthien_proxy/history/service.py
+++ b/src/luthien_proxy/history/service.py
@@ -40,7 +40,10 @@ class StoredEvent(TypedDict):
 
 logger = logging.getLogger(__name__)
 
-# User-friendly descriptions for common policy event types
+# User-friendly descriptions for common policy event types.
+# Note: every current emitter writes a non-empty `summary` into the event
+# payload, and `_get_event_summary` returns that summary before consulting
+# this dict. So this is fallback for events stored without a summary.
 _EVENT_TYPE_DESCRIPTIONS: dict[str, str] = {
     # Judge policy events
     "policy.judge.tool_call_allowed": "Tool call approved",
@@ -384,7 +387,7 @@ async def _fetch_session_list_pg(limit: int, db_pool: DatabasePool, offset: int 
                     COUNT(DISTINCT call_id) as turn_count,
                     COUNT(*) FILTER (
                         WHERE event_type LIKE 'policy.%'
-                        AND event_type NOT LIKE 'policy.judge.evaluation%'
+                        AND event_type NOT LIKE 'policy.%judge.evaluation%'
                     ) as policy_interventions
                 FROM conversation_events
                 WHERE session_id IS NOT NULL
@@ -482,7 +485,7 @@ async def _fetch_session_list_sqlite(limit: int, db_pool: DatabasePool, offset: 
                 COUNT(DISTINCT call_id) as turn_count,
                 SUM(CASE
                     WHEN event_type LIKE 'policy.%'
-                    AND event_type NOT LIKE 'policy.judge.evaluation%'
+                    AND event_type NOT LIKE 'policy.%judge.evaluation%'
                     THEN 1 ELSE 0
                 END) as policy_interventions
             FROM conversation_events

--- a/tests/luthien_proxy/unit_tests/history/test_service_sqlite.py
+++ b/tests/luthien_proxy/unit_tests/history/test_service_sqlite.py
@@ -173,7 +173,10 @@ async def populated_with_interventions_pool(sqlite_pool: DatabasePool) -> Databa
             """,
             "event-6",
             "call-3",
-            "policy.judge.tool_call_blocked",
+            # Real production name (post-#169). Paired with the
+            # evaluation_started row below; both must use the same prefix
+            # so the fixture represents a real session, not a chimera.
+            "policy.anthropic_judge.tool_call_blocked",
             json.dumps({"summary": "Dangerous operation blocked"}),
             "session-2",
             "2025-01-16T14:00:00",
@@ -187,7 +190,8 @@ async def populated_with_interventions_pool(sqlite_pool: DatabasePool) -> Databa
             """,
             "event-7",
             "call-3",
-            "policy.judge.evaluation_started",
+            # Real production name (post-#169 `prefix="anthropic_"`).
+            "policy.anthropic_judge.evaluation_started",
             json.dumps({}),
             "session-2",
             "2025-01-16T14:00:01",
@@ -576,7 +580,7 @@ class TestFetchSessionListSqlite:
 
             # Add multiple policy events (not evaluation)
             policy_events = [
-                "policy.judge.tool_call_blocked",
+                "policy.anthropic_judge.tool_call_blocked",
                 "policy.all_caps.content_transformed",
                 "policy.simple_policy.content_complete_warning",
             ]
@@ -605,7 +609,7 @@ class TestFetchSessionListSqlite:
                 """,
                 "event-policy-eval",
                 "call-policy",
-                "policy.judge.evaluation_started",
+                "policy.anthropic_judge.evaluation_started",
                 json.dumps({}),
                 "session-policy",
                 "2025-01-17T10:00:04",
@@ -616,6 +620,74 @@ class TestFetchSessionListSqlite:
 
         # Should count 3 policy events, not the evaluation event
         assert session.policy_interventions == 3
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "judge_prefix",
+        ["", "anthropic_"],
+        ids=["legacy", "anthropic_judge"],
+    )
+    async def test_evaluation_events_excluded_for_all_judge_prefixes(
+        self, sqlite_pool: DatabasePool, judge_prefix: str
+    ):
+        """Regression test: filter must match the emitter contract, not a literal.
+
+        PR #169 introduced `prefix="anthropic_"` at the judge emission helpers
+        in policies/tool_call_judge_policy.py, so events arrive as
+        `policy.{prefix}judge.evaluation_*`. The original filter literal
+        `policy.judge.evaluation%` no longer matched and judge lifecycle
+        events were counted as policy interventions.
+
+        Both prefixes must be excluded from the intervention count:
+          - "" (legacy unprefixed events still in stored history)
+          - "anthropic_" (current production)
+        """
+        session_id = f"session-{judge_prefix or 'legacy'}"
+        call_id = f"call-{judge_prefix or 'legacy'}"
+        async with sqlite_pool.connection() as conn:
+            await conn.execute(
+                """
+                INSERT INTO conversation_calls
+                (call_id, model_name, provider, status, session_id, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                call_id,
+                "gpt-4",
+                "openai",
+                "completed",
+                session_id,
+                "2025-01-17T10:00:00",
+            )
+
+            # One real intervention + two evaluation lifecycle events.
+            # Only the intervention should count.
+            events = [
+                (f"policy.{judge_prefix}judge.tool_call_blocked", 1),
+                (f"policy.{judge_prefix}judge.evaluation_started", 0),
+                (f"policy.{judge_prefix}judge.evaluation_complete", 0),
+            ]
+            for idx, (event_type, _expected) in enumerate(events):
+                await conn.execute(
+                    """
+                    INSERT INTO conversation_events
+                    (id, call_id, event_type, payload, session_id, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    f"{session_id}-event-{idx}",
+                    call_id,
+                    event_type,
+                    json.dumps({}),
+                    session_id,
+                    f"2025-01-17T10:00:0{idx + 1}",
+                )
+
+        result = await fetch_session_list(limit=10, db_pool=sqlite_pool)
+        session = next(s for s in result.sessions if s.session_id == session_id)
+        assert session.policy_interventions == 1, (
+            f"prefix={judge_prefix!r}: expected 1 (only tool_call_blocked), "
+            f"got {session.policy_interventions} — filter likely failed to "
+            f"exclude evaluation_started/evaluation_complete"
+        )
 
     @pytest.mark.asyncio
     async def test_limit_enforced(self, sqlite_pool: DatabasePool):


### PR DESCRIPTION
## Summary

`_fetch_session_list_*` filter strings reference a stale literal `policy.judge.evaluation%`. PR #169 changed judge event names to `policy.{prefix}judge.evaluation_*` (`prefix="anthropic_"`, `tool_call_judge_policy.py:483, 502, 523`), so the exclusion no longer fires and judge lifecycle events (`evaluation_started`, `evaluation_complete`) are counted as policy interventions in the dashboard's `policy_interventions` column.

## Fix

- Broaden filter to `NOT LIKE 'policy.%judge.evaluation%'` (matches legacy unprefixed and the `anthropic_` prefix in production today).
- Update SQLite test fixtures from legacy unprefixed names to the `anthropic_` names production actually emits.
- Add a parametrized regression test covering legacy and `anthropic_` prefixes; binds the test to the emitter contract (`f"policy.{prefix}judge.evaluation_*"`) rather than a frozen literal.

## Production impact (unverified)

Dashboard `policy_interventions` counts have been inflated by judge lifecycle events emitted under the `anthropic_` prefix since #169 merged on 2026-02-04. I have not queried a production DB to quantify the inflation or confirm the dashboard is in active use; this PR fixes the query going forward and does not backfill or correct any downstream consumer that may have cached stale counts.

## Test plan

- [x] `uv run pytest tests/luthien_proxy/unit_tests/history/` — 100 passed
- [x] `uv run pytest -q` (full suite) — 2387 passed
- [x] Reverted SQL filter locally; new parametrized test fails on `[anthropic_judge]` row (`expected 1, got 3`); `[legacy]` row passes (old filter does match unprefixed). Restored fix; both rows pass.
- [x] `uv run ruff format` / `ruff check` clean on changed files
- [x] `uv run pyright src/` — 0 errors (test files are out of pyright scope by `pyproject.toml`)

## Notes

- Display labels (`_EVENT_TYPE_DESCRIPTIONS`) are not affected — every judge emitter writes a `summary` field into the payload, and `_get_event_summary` returns the payload summary before consulting the dict. The dict is fallback for events without a summary; not a load-bearing path for judge events.
- PR #694 introduces `policy.intervention.*` taxonomy that will replace the `LIKE`-based heuristic. This fix is interim.

---
*Posted by Claude Code (claude-opus-4-7[1m])*