### PR TITLE
feat(history): friendly summaries for string_replacement events

### DIFF
--- a/changelog.d/string-replacement-event-descriptions.md
+++ b/changelog.d/string-replacement-event-descriptions.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**Friendly summaries for string replacement events**: The dashboard activity stream now renders human-readable text for `policy.string_replacement.request_modified` and `policy.string_replacement.response_modified` events instead of the raw event-type string.

--- a/src/luthien_proxy/history/service.py
+++ b/src/luthien_proxy/history/service.py
@@ -60,6 +60,9 @@ _EVENT_TYPE_DESCRIPTIONS: dict[str, str] = {
     # Simple policy events
     "policy.simple_policy.content_complete_warning": "Content warning",
     "policy.simple_policy.tool_call_complete_warning": "Tool call warning",
+    # String replacement policy events
+    "policy.string_replacement.request_modified": "Request modified by string replacement",
+    "policy.string_replacement.response_modified": "Response modified by string replacement",
 }
 
 

--- a/tests/luthien_proxy/unit_tests/history/test_service.py
+++ b/tests/luthien_proxy/unit_tests/history/test_service.py
@@ -22,6 +22,7 @@ from luthien_proxy.history.service import (
     _build_turn,
     _extract_preview_message,
     _extract_tool_calls,
+    _get_event_summary,
     _parse_request_messages,
     _parse_response_messages,
     _safe_parse_json,
@@ -31,6 +32,44 @@ from luthien_proxy.history.service import (
     fetch_session_detail,
     fetch_session_list,
 )
+
+
+class TestGetEventSummary:
+    """Test friendly-text fallback for known policy event types."""
+
+    @pytest.mark.parametrize(
+        "event_type,expected",
+        [
+            (
+                "policy.string_replacement.request_modified",
+                "Request modified by string replacement",
+            ),
+            (
+                "policy.string_replacement.response_modified",
+                "Response modified by string replacement",
+            ),
+            ("policy.judge.tool_call_blocked", "Tool call blocked"),
+        ],
+    )
+    def test_falls_back_to_event_type_description(self, event_type, expected):
+        """When payload has no `summary`, use the dict-based description."""
+        assert _get_event_summary(event_type, None) == expected
+        assert _get_event_summary(event_type, {}) == expected
+        assert _get_event_summary(event_type, {"summary": ""}) == expected
+
+    def test_payload_summary_takes_precedence(self):
+        """A non-empty payload `summary` wins over the fallback dict."""
+        assert (
+            _get_event_summary(
+                "policy.string_replacement.response_modified",
+                {"summary": "Replaced 'foo' with 'bar'"},
+            )
+            == "Replaced 'foo' with 'bar'"
+        )
+
+    def test_unknown_event_type_returns_raw(self):
+        """Unknown event types fall through to the raw event_type string."""
+        assert _get_event_summary("policy.unknown.event", None) == "policy.unknown.event"
 
 
 class TestExtractTextContent:


### PR DESCRIPTION
## Summary

PRs #693 and #700 added two events to the activity stream:

- `policy.string_replacement.request_modified`
- `policy.string_replacement.response_modified`

Neither emitter sets a payload `summary`, and neither was registered in `_EVENT_TYPE_DESCRIPTIONS` in `src/luthien_proxy/history/service.py`. The dashboard's per-turn annotation column was rendering the raw event_type string.

## Fix

Two dict entries plus unit tests covering the `_get_event_summary` fallback path. No behavioral change to event emission — this is the friendly-text fallback only.

This is intentionally not the broader event-taxonomy work (deferred to https://trello.com/c/KXw3asQ5).

## Test plan

- [x] `uv run pytest tests/luthien_proxy/unit_tests/history/` passes (105 tests)