### PR TITLE
chore: silence shellcheck SC2329 in run_e2e.sh

### DIFF
--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2317 # Functions called indirectly via "run_$tier" and trap
+# shellcheck disable=SC2317,SC2329 # Functions called indirectly via "run_$tier" and trap
 # ABOUTME: Orchestrates e2e test tiers with automatic setup and teardown.
 # ABOUTME: Handles sqlite_e2e (no infra), mock_e2e (in-process), and real e2e (Docker + API key).
 #


### PR DESCRIPTION
Split out from #505. Original commit by @PeterStoica (preserved as author).

## Summary
- Silences shellcheck SC2329 in `scripts/run_e2e.sh`. One-line change.

## Why split out
PR #505 bundles a UI redesign, a new policy, a security fix, and several chores into one ~1300-line PR. Per [AGENTS.md](https://github.com/LuthienResearch/luthien-proxy/blob/main/AGENTS.md) "One PR = One Concern", chores merge faster on their own.

## Test plan
- [ ] `./scripts/dev_checks.sh` passes
- [ ] `shellcheck scripts/run_e2e.sh` clean

---
*Posted by Claude Code (claude-opus-4-7[1m])*