### PR TITLE
feat(upstream-headers): inject configurable headers on outbound LLM requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,3 +146,12 @@
 
 # Sentry server identifier
 # SENTRY_SERVER_NAME=
+
+
+# === NON-REGISTRY ================================================
+# Env vars read directly via os.environ. Not in the config registry
+# because their shape (JSON, etc.) doesn't fit scalar typing.
+
+# JSON object mapping header name → template string. Templates support ${session_id}, ${request_path}, and ${env.VARNAME}. Headers expand per-request and are merged into outbound LLM requests. Misconfiguration fails the gateway at startup. See pipeline/upstream_headers.py.
+# Example: UPSTREAM_HEADERS={"Helicone-Auth":"Bearer ${env.HELICONE_API_KEY}","Helicone-Session-Id":"${session_id}"}
+# UPSTREAM_HEADERS=

--- a/changelog.d/upstream-headers.md
+++ b/changelog.d/upstream-headers.md
@@ -1,0 +1,6 @@
+---
+category: Features
+pr: 549
+---
+
+**Configurable upstream header injection**: New `UPSTREAM_HEADERS` environment variable (JSON) lets you inject custom headers into upstream API requests with per-request template expansion (`${session_id}`, `${request_path}`, `${env.VARNAME}`). Primary use case: chaining Luthien in front of Helicone or other LLM observability proxies that require session tracking and analytics headers.

--- a/changelog.d/upstream-headers.md
+++ b/changelog.d/upstream-headers.md
@@ -1,6 +1,6 @@
 ---
 category: Features
-pr: 549
+pr: 716
 ---
 
-**Configurable upstream header injection**: New `UPSTREAM_HEADERS` environment variable (JSON) lets you inject custom headers into upstream API requests with per-request template expansion (`${session_id}`, `${request_path}`, `${env.VARNAME}`). Primary use case: chaining Luthien in front of Helicone or other LLM observability proxies that require session tracking and analytics headers.
+**Configurable upstream header injection**: New `UPSTREAM_HEADERS` environment variable (JSON) lets the operator inject custom headers into upstream LLM API requests with per-request template expansion (`${session_id}`, `${request_path}`, `${env.VARNAME}`). Primary use case: chaining Luthien in front of Helicone or other LLM observability proxies that require session tracking and analytics headers. Misconfiguration (invalid JSON, malformed RFC 7230 header names, hop-by-hop headers, non-string values) fails the gateway at startup rather than silently disabling the integration. Replaces the previously rejected PR #549; original commits authored by sjawhar are preserved.

--- a/dev/context/decisions.md
+++ b/dev/context/decisions.md
@@ -330,4 +330,21 @@ orchestrator.process_streaming_response(stream, obs_ctx, policy_ctx)
 
 ---
 
+## Upstream Header Injection Trust Model (2026-05-07)
+
+**Decision**: `UPSTREAM_HEADERS` (PR #716) treats the operator and clients as trusted. The feature does not defend against:
+- Hostile operators — they own the env, they can already do anything.
+- Hostile clients — CRLF in `session_id` is malformed input, not an attack.
+- "Exfiltration" of the operator's own secrets to a destination they configured.
+
+**What is in scope**: input hygiene (CRLF/NUL stripping, RFC 7230 token validation, hop-by-hop blocklist). Failures fail loud at startup; misconfiguration cannot silently disable the integration.
+
+**Explicitly rejected** (from PR #595's stack):
+- **Sensitive-env-var blocklist** (`*KEY`, `*SECRET`, etc.). Paternalistic and breaks the canonical `HELICONE_API_KEY` use case.
+- **`Authorization` / `X-Api-Key` blocklist**. Operator may legitimately want to override these on the way upstream (e.g., a proxy that uses standard `Authorization` instead of `Helicone-Auth`).
+
+**Canonical reference**: `src/luthien_proxy/pipeline/upstream_headers.py` module docstring. Re-derive from there if the trust boundaries shift.
+
+---
+
 (Add new decisions as they're made with timestamps: YYYY-MM-DD)

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -16,6 +16,21 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from luthien_proxy.config_fields import CONFIG_CATEGORIES, CONFIG_FIELDS
 
+# Non-registry env vars: features that read os.environ directly because their
+# value shape (e.g. JSON blob) doesn't fit the scalar config registry. Listed
+# here so they remain discoverable in .env.example without the registry's type
+# system and dashboard plumbing.
+EXTRA_ENV_VARS: tuple[tuple[str, str, str], ...] = (
+    (
+        "UPSTREAM_HEADERS",
+        "JSON object mapping header name → template string. Templates support "
+        "${session_id}, ${request_path}, and ${env.VARNAME}. Headers expand "
+        "per-request and are merged into outbound LLM requests. Misconfiguration "
+        "fails the gateway at startup. See pipeline/upstream_headers.py.",
+        '{"Helicone-Auth":"Bearer ${env.HELICONE_API_KEY}","Helicone-Session-Id":"${session_id}"}',
+    ),
+)
+
 
 def _format_default(value: object) -> str:
     """Render a default value as it should appear after ``VAR=`` in .env.
@@ -81,6 +96,19 @@ def build_env_example_text() -> str:
                 lines.append(f"# {meta.env_var}=")
             else:
                 lines.append(f"# {meta.env_var}={_format_default(meta.default)}")
+            lines.append("")
+
+    if EXTRA_ENV_VARS:
+        lines.append("")
+        bar = "=" * (60 - len("non-registry"))
+        lines.append(f"# === NON-REGISTRY {bar}")
+        lines.append("# Env vars read directly via os.environ. Not in the config registry")
+        lines.append("# because their shape (JSON, etc.) doesn't fit scalar typing.")
+        lines.append("")
+        for env_var, description, example in EXTRA_ENV_VARS:
+            lines.append(f"# {description}")
+            lines.append(f"# Example: {env_var}={example}")
+            lines.append(f"# {env_var}=")
             lines.append("")
 
     return "\n".join(lines)

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -41,6 +41,7 @@ from luthien_proxy.observability.event_publisher import (
 )
 from luthien_proxy.observability.redis_event_publisher import RedisEventPublisher
 from luthien_proxy.observability.sentry import init_sentry
+from luthien_proxy.pipeline.upstream_headers import validate_upstream_headers_at_startup
 from luthien_proxy.policy_manager import PolicyManager
 from luthien_proxy.request_log import router as request_log_router
 from luthien_proxy.session import login_page_router
@@ -189,10 +190,8 @@ def create_app(
         await _config_registry.initialize()
         logger.info("Config registry initialized")
 
-        # Validate UPSTREAM_HEADERS at startup so misconfiguration fails fast
-        # rather than silently disabling the integration on first request.
-        from luthien_proxy.pipeline.upstream_headers import validate_upstream_headers_at_startup
-
+        # Fail fast on UPSTREAM_HEADERS misconfiguration rather than silently
+        # disabling the integration on first request.
         validate_upstream_headers_at_startup()
 
         # Configure litellm globally (moved from policy file to prevent import side effects)

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -189,6 +189,12 @@ def create_app(
         await _config_registry.initialize()
         logger.info("Config registry initialized")
 
+        # Validate UPSTREAM_HEADERS at startup so misconfiguration fails fast
+        # rather than silently disabling the integration on first request.
+        from luthien_proxy.pipeline.upstream_headers import validate_upstream_headers_at_startup
+
+        validate_upstream_headers_at_startup()
+
         # Configure litellm globally (moved from policy file to prevent import side effects)
         litellm.drop_params = True
         logger.info("Configured litellm: drop_params=True")

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -411,9 +411,12 @@ async def process_anthropic_request(
             request_path=raw_http_request.path,
         )
         if upstream:
+            # Remove any upstream headers that collide with reserved client headers
+            # (case-insensitive, since HTTP headers are case-insensitive).
             if forwarded_headers:
-                upstream.update(forwarded_headers)  # anthropic-beta takes precedence
-            forwarded_headers = upstream
+                reserved = {k.lower() for k in forwarded_headers}
+                upstream = {k: v for k, v in upstream.items() if k.lower() not in reserved}
+            forwarded_headers = {**(upstream or {}), **(forwarded_headers or {})}
 
         # Create policy cache factory if database is available. The cap is
         # configured once here so every policy's cache honors the same limit;

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -53,6 +53,7 @@ from luthien_proxy.pipeline.session import (
     extract_session_id_from_anthropic_body,
     extract_session_id_from_headers,
 )
+from luthien_proxy.pipeline.upstream_headers import expand_upstream_headers
 from luthien_proxy.pipeline.stream_protocol_validator import validate_anthropic_event_ordering
 from luthien_proxy.policy_core.anthropic_execution_interface import (
     AnthropicExecutionInterface,
@@ -402,6 +403,17 @@ async def process_anthropic_request(
         forwarded_headers: dict[str, str] | None = None
         if beta := raw_http_request.headers.get("anthropic-beta"):
             forwarded_headers = {"anthropic-beta": beta}
+
+        # Expand configurable upstream headers (e.g. Helicone session/auth headers).
+        # Templates in UPSTREAM_HEADERS env var are expanded with per-request context.
+        upstream = expand_upstream_headers(
+            session_id=session_id,
+            request_path=raw_http_request.path,
+        )
+        if upstream:
+            if forwarded_headers:
+                upstream.update(forwarded_headers)  # anthropic-beta takes precedence
+            forwarded_headers = upstream
 
         # Create policy cache factory if database is available. The cap is
         # configured once here so every policy's cache honors the same limit;

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -53,7 +53,7 @@ from luthien_proxy.pipeline.session import (
     extract_session_id_from_anthropic_body,
     extract_session_id_from_headers,
 )
-from luthien_proxy.pipeline.upstream_headers import expand_upstream_headers
+from luthien_proxy.pipeline.upstream_headers import expand_upstream_headers, merge_forwarded_headers
 from luthien_proxy.pipeline.stream_protocol_validator import validate_anthropic_event_ordering
 from luthien_proxy.policy_core.anthropic_execution_interface import (
     AnthropicExecutionInterface,
@@ -406,17 +406,13 @@ async def process_anthropic_request(
 
         # Expand configurable upstream headers (e.g. Helicone session/auth headers).
         # Templates in UPSTREAM_HEADERS env var are expanded with per-request context.
-        upstream = expand_upstream_headers(
-            session_id=session_id,
-            request_path=raw_http_request.path,
+        forwarded_headers = merge_forwarded_headers(
+            base=forwarded_headers,
+            upstream=expand_upstream_headers(
+                session_id=session_id,
+                request_path=raw_http_request.path,
+            ),
         )
-        if upstream:
-            # Remove any upstream headers that collide with reserved client headers
-            # (case-insensitive, since HTTP headers are case-insensitive).
-            if forwarded_headers:
-                reserved = {k.lower() for k in forwarded_headers}
-                upstream = {k: v for k, v in upstream.items() if k.lower() not in reserved}
-            forwarded_headers = {**(upstream or {}), **(forwarded_headers or {})}
 
         # Create policy cache factory if database is available. The cap is
         # configured once here so every policy's cache honors the same limit;

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -53,8 +53,8 @@ from luthien_proxy.pipeline.session import (
     extract_session_id_from_anthropic_body,
     extract_session_id_from_headers,
 )
-from luthien_proxy.pipeline.upstream_headers import expand_upstream_headers, merge_forwarded_headers
 from luthien_proxy.pipeline.stream_protocol_validator import validate_anthropic_event_ordering
+from luthien_proxy.pipeline.upstream_headers import expand_upstream_headers, merge_forwarded_headers
 from luthien_proxy.policy_core.anthropic_execution_interface import (
     AnthropicExecutionInterface,
     AnthropicPolicyEmission,

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -1,0 +1,94 @@
+"""Configurable upstream header injection.
+
+Reads header templates from the UPSTREAM_HEADERS environment variable (JSON)
+and expands per-request context variables before forwarding to the backend.
+
+Supported template variables:
+    ${session_id}    — Claude Code session UUID (from metadata.user_id)
+    ${request_path}  — HTTP request path (e.g. /v1/messages)
+    ${env.VARNAME}   — Any environment variable
+
+Example:
+    UPSTREAM_HEADERS='{"Helicone-Auth":"Bearer ${env.HELICONE_API_KEY}","Helicone-Session-Id":"${session_id}"}'
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from functools import lru_cache
+
+logger = logging.getLogger(__name__)
+
+_TEMPLATE_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+@lru_cache(maxsize=1)
+def _load_header_templates() -> dict[str, str]:
+    """Parse UPSTREAM_HEADERS env var once at first use.
+
+    Returns empty dict if unset or malformed (fail-open).
+    """
+    raw = os.environ.get("UPSTREAM_HEADERS", "")
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            logger.warning("UPSTREAM_HEADERS must be a JSON object, got %s", type(parsed).__name__)
+            return {}
+        # Validate all values are strings
+        result = {}
+        for k, v in parsed.items():
+            if not isinstance(k, str) or not isinstance(v, str):
+                logger.warning("UPSTREAM_HEADERS: skipping non-string entry %r: %r", k, v)
+                continue
+            result[k] = v
+        if result:
+            logger.info("Loaded %d upstream header template(s)", len(result))
+        return result
+    except json.JSONDecodeError as e:
+        logger.warning("UPSTREAM_HEADERS: invalid JSON: %s", e)
+        return {}
+
+
+def _expand_template(template: str, session_id: str | None, request_path: str) -> str:
+    """Expand a single template string with context variables."""
+
+    def _replace(match: re.Match[str]) -> str:
+        var = match.group(1)
+        if var == "session_id":
+            return session_id or ""
+        if var == "request_path":
+            return request_path
+        if var.startswith("env."):
+            env_name = var[4:]
+            return os.environ.get(env_name, "")
+        logger.debug("Unknown template variable: ${%s}", var)
+        return match.group(0)  # Leave unknown variables unexpanded
+
+    return _TEMPLATE_PATTERN.sub(_replace, template)
+
+
+def expand_upstream_headers(
+    session_id: str | None,
+    request_path: str,
+) -> dict[str, str] | None:
+    """Expand upstream header templates for a single request.
+
+    Returns None if no upstream headers are configured (avoids unnecessary dict
+    allocation on the hot path).
+    """
+    templates = _load_header_templates()
+    if not templates:
+        return None
+
+    headers = {}
+    for name, template in templates.items():
+        value = _expand_template(template, session_id, request_path)
+        # Skip headers that expand to empty (e.g. session_id not available)
+        if value:
+            headers[name] = value
+    return headers or None

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -3,13 +3,40 @@
 Reads header templates from the UPSTREAM_HEADERS environment variable (JSON)
 and expands per-request context variables before forwarding to the backend.
 
-Supported template variables:
+Supported template variables::
+
     ${session_id}    — Claude Code session UUID (from metadata.user_id)
     ${request_path}  — HTTP request path (e.g. /v1/messages)
     ${env.VARNAME}   — Any environment variable
 
-Example:
+Example::
+
     UPSTREAM_HEADERS='{"Helicone-Auth":"Bearer ${env.HELICONE_API_KEY}","Helicone-Session-Id":"${session_id}"}'
+
+Design notes:
+
+    **Config system bypass (intentional):** This feature reads from the
+    ``UPSTREAM_HEADERS`` env var directly via ``os.environ`` rather than going
+    through the ``config_fields.py`` / ``settings.py`` config system. The config
+    system is designed for scalar values (str, int, bool) with per-field env
+    vars. A JSON blob of arbitrary header templates doesn't fit that model
+    cleanly. If this feature is later promoted to a first-class config field,
+    the ``lru_cache`` on ``_load_header_templates()`` will need to be replaced
+    with a config-registry-aware loader.
+
+    **Restart required:** The ``lru_cache`` means UPSTREAM_HEADERS is read on
+    the first request and cached for the process lifetime. Changes require a
+    gateway restart.
+
+Security:
+
+    **Env var expansion surface:** The ``${env.VARNAME}`` syntax expands any
+    environment variable into an outbound header value. This means anyone who
+    can set the ``UPSTREAM_HEADERS`` value can route any env var (including
+    ``ANTHROPIC_API_KEY``, ``ADMIN_API_KEY``, etc.) into upstream request
+    headers. This is acceptable when the upstream is trusted (e.g., Helicone,
+    Anthropic API) because server-side access is already required to set the
+    env var. Do NOT use this feature to forward headers to untrusted upstreams.
 """
 
 from __future__ import annotations

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -11,7 +11,7 @@ Supported template variables::
 
 Example::
 
-    UPSTREAM_HEADERS='{"Helicone-Auth":"Bearer ${env.HELICONE_API_KEY}","Helicone-Session-Id":"${session_id}"}'
+    UPSTREAM_HEADERS = '{"Helicone-Auth":"Bearer ${env.HELICONE_API_KEY}","Helicone-Session-Id":"${session_id}"}'
 
 Design notes:
 
@@ -96,7 +96,8 @@ def _expand_template(template: str, session_id: str | None, request_path: str) -
         logger.debug("Unknown template variable: ${%s}", var)
         return match.group(0)  # Leave unknown variables unexpanded
 
-    return _TEMPLATE_PATTERN.sub(_replace, template)
+    result = _TEMPLATE_PATTERN.sub(_replace, template)
+    return result.replace("\r", "").replace("\n", "")
 
 
 def expand_upstream_headers(

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -49,9 +49,8 @@ Config system bypass (intentional):
     This feature reads ``UPSTREAM_HEADERS`` directly via ``os.environ``
     rather than going through ``config_fields.py``. The config registry is
     typed for scalars; a JSON blob of arbitrary header templates does not
-    fit that model. The ``upstream_headers_enabled`` flag in
-    ``config_fields.py`` exists so the feature is discoverable on the
-    ``/config`` dashboard.
+    fit that model. Operability comes from the startup audit log
+    enumerating which env vars the templates reference.
 """
 
 from __future__ import annotations
@@ -95,9 +94,7 @@ def _validate_and_filter(parsed: dict[str, object]) -> dict[str, str]:
         if not isinstance(v, str):
             raise ValueError(f"UPSTREAM_HEADERS: value for {k!r} must be a string, got {type(v).__name__}")
         if not _HEADER_NAME_PATTERN.match(k):
-            raise ValueError(
-                f"UPSTREAM_HEADERS: header name {k!r} is not a valid RFC 7230 token"
-            )
+            raise ValueError(f"UPSTREAM_HEADERS: header name {k!r} is not a valid RFC 7230 token")
         if k.lower() in _RESERVED_HEADERS:
             logger.warning(
                 "UPSTREAM_HEADERS: dropping hop-by-hop/framing header %r (overriding it would break HTTP transport)",
@@ -142,9 +139,7 @@ def _load_header_templates() -> dict[str, str]:
         return {}
     parsed = json.loads(raw)  # raises JSONDecodeError on invalid JSON
     if not isinstance(parsed, dict):
-        raise ValueError(
-            f"UPSTREAM_HEADERS must be a JSON object, got {type(parsed).__name__}"
-        )
+        raise ValueError(f"UPSTREAM_HEADERS must be a JSON object, got {type(parsed).__name__}")
     result = _validate_and_filter(parsed)
     if result:
         logger.info("Loaded %d upstream header template(s)", len(result))

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -258,8 +258,9 @@ def merge_forwarded_headers(
     """
     if not upstream:
         return base or None
-    if base:
-        reserved = {k.lower() for k in base}
-        upstream = {k: v for k, v in upstream.items() if k.lower() not in reserved}
-    merged: dict[str, str] = {**upstream, **base} if base else dict(upstream)
+    if not base:
+        return upstream
+    reserved = {k.lower() for k in base}
+    upstream = {k: v for k, v in upstream.items() if k.lower() not in reserved}
+    merged: dict[str, str] = {**upstream, **base}
     return merged or None

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -97,7 +97,7 @@ def _expand_template(template: str, session_id: str | None, request_path: str) -
         return match.group(0)  # Leave unknown variables unexpanded
 
     result = _TEMPLATE_PATTERN.sub(_replace, template)
-    return result.replace("\r", "").replace("\n", "")
+    return result.replace("\r", "").replace("\n", "").replace("\x00", "")
 
 
 def expand_upstream_headers(

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -249,6 +249,12 @@ def merge_forwarded_headers(
     dict entries and produce duplicate header lines on the wire.
 
     Returns ``None`` if both inputs are empty.
+
+    .. note::
+       When one input is empty, the *other input is returned by reference*
+       (no copy) to avoid an allocation on the request hot path. Callers
+       must treat the return value as read-only — mutating it would
+       silently mutate the original ``base`` or ``upstream`` dict.
     """
     if not upstream:
         return base or None

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -100,7 +100,14 @@ _KNOWN_VARS = frozenset({"session_id", "request_path"})
 
 
 def _validate_and_filter(parsed: dict[str, object]) -> dict[str, str]:
-    """Validate parsed JSON object and drop reserved headers. Raises on bad input."""
+    """Validate parsed JSON object and drop reserved headers. Raises on bad input.
+
+    Validation order is fail-loud-first: type errors → RFC 7230 token →
+    template-var refs → hop-by-hop drop → case-insensitive duplicate. A
+    hop-by-hop entry with a malformed name (e.g. ``"Connection ": "close"``)
+    raises rather than being silently dropped — operator gets the louder
+    error first.
+    """
     result: dict[str, str] = {}
     seen_lower: dict[str, str] = {}
     for k, v in parsed.items():
@@ -225,6 +232,12 @@ def expand_upstream_headers(
     Returns ``None`` when no headers are configured (avoids unnecessary dict
     allocation on the hot path) or when every configured header expands to
     the empty string.
+
+    Note: the empty-skip catches templates that expand to ``""`` entirely.
+    A *partially* empty expansion like ``"Bearer ${env.MISSING}"`` produces
+    the literal string ``"Bearer "`` and ships as a malformed header — the
+    upstream will 401, and the startup audit log warns operators about
+    unset/empty referenced env vars to catch the typo class at boot.
     """
     templates = _load_header_templates()
     if not templates:

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -30,11 +30,11 @@ Validation:
       time. Misconfiguration fails the gateway at startup, not at first
       request.
     * Header names must match the RFC 7230 token spec.
-    * Hop-by-hop / framing headers (``Connection``, ``Content-Length``,
-      ``Keep-Alive``, ``Proxy-Authenticate``, ``Proxy-Authorization``,
-      ``Proxy-Connection``, ``TE``, ``Trailer``, ``Trailers``,
-      ``Transfer-Encoding``, ``Upgrade``) are dropped with a warning —
-      overriding them breaks HTTP transport.
+    * Hop-by-hop / framing / transport-owned headers (``Connection``,
+      ``Content-Length``, ``Host``, ``Keep-Alive``, ``Proxy-Authenticate``,
+      ``Proxy-Authorization``, ``Proxy-Connection``, ``TE``, ``Trailer``,
+      ``Trailers``, ``Transfer-Encoding``, ``Upgrade``) are dropped with a
+      warning — overriding them breaks HTTP transport or vhost routing.
     * Unknown template variables (``${foo}`` that isn't ``session_id``,
       ``request_path``, or ``env.X``) are logged at load time, not on every
       request.
@@ -83,6 +83,7 @@ _HOP_BY_HOP_HEADERS = frozenset(
     {
         "connection",
         "content-length",
+        "host",
         "keep-alive",
         "proxy-authenticate",
         "proxy-authorization",
@@ -248,18 +249,12 @@ def merge_forwarded_headers(
     config and ``anthropic-beta`` from the SDK would ship as two distinct
     dict entries and produce duplicate header lines on the wire.
 
-    Returns ``None`` if both inputs are empty.
-
-    .. note::
-       When one input is empty, the *other input is returned by reference*
-       (no copy) to avoid an allocation on the request hot path. Callers
-       must treat the return value as read-only — mutating it would
-       silently mutate the original ``base`` or ``upstream`` dict.
+    Always returns a fresh dict (or ``None``); callers may mutate freely.
     """
     if not upstream:
-        return base or None
+        return dict(base) if base else None
     if not base:
-        return upstream
+        return dict(upstream)
     base_keys_lower = {k.lower() for k in base}
     upstream = {k: v for k, v in upstream.items() if k.lower() not in base_keys_lower}
     return {**upstream, **base}

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -101,6 +101,7 @@ _KNOWN_VARS = frozenset({"session_id", "request_path"})
 def _validate_and_filter(parsed: dict[str, object]) -> dict[str, str]:
     """Validate parsed JSON object and drop reserved headers. Raises on bad input."""
     result: dict[str, str] = {}
+    seen_lower: dict[str, str] = {}
     for k, v in parsed.items():
         if not isinstance(k, str):
             raise ValueError(f"UPSTREAM_HEADERS: header name must be a string, got {type(k).__name__}: {k!r}")
@@ -117,12 +118,16 @@ def _validate_and_filter(parsed: dict[str, object]) -> dict[str, str]:
                         f"UPSTREAM_HEADERS: invalid env var reference ${{env.{env_name}}} in {k!r} — "
                         "must be a non-empty identifier (letters, digits, underscore; no leading digit)"
                     )
-        if k.lower() in _RESERVED_HEADERS:
+        lower = k.lower()
+        if lower in _RESERVED_HEADERS:
             logger.warning(
                 "UPSTREAM_HEADERS: dropping hop-by-hop/framing header %r (overriding it would break HTTP transport)",
                 k,
             )
             continue
+        if lower in seen_lower:
+            raise ValueError(f"UPSTREAM_HEADERS: duplicate header (case-insensitive): {seen_lower[lower]!r} and {k!r}")
+        seen_lower[lower] = k
         result[k] = v
     return result
 

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -71,6 +71,11 @@ _TEMPLATE_PATTERN = re.compile(r"\$\{([^}]+)\}")
 # RFC 7230 token: 1*tchar where tchar = ALPHA / DIGIT / "!#$%&'*+-.^_`|~"
 _HEADER_NAME_PATTERN = re.compile(r"^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$")
 
+# POSIX-ish env var name: leading letter/underscore, then alnum/underscore.
+# Stricter than the shell allows in practice but catches the typo class
+# (`${env.}` empty, `${env.NAME WITH SPACES}`, `${env.NAME-WITH-DASH}`).
+_ENV_VAR_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
 # Hop-by-hop / framing headers per RFC 7230 §6.1, plus framing headers and the
 # common-but-non-standard Proxy-Connection. Overriding these breaks HTTP
 # transport. Lower-case for case-insensitive comparison.
@@ -103,6 +108,15 @@ def _validate_and_filter(parsed: dict[str, object]) -> dict[str, str]:
             raise ValueError(f"UPSTREAM_HEADERS: value for {k!r} must be a string, got {type(v).__name__}")
         if not _HEADER_NAME_PATTERN.match(k):
             raise ValueError(f"UPSTREAM_HEADERS: header name {k!r} is not a valid RFC 7230 token")
+        for match in _TEMPLATE_PATTERN.finditer(v):
+            var = match.group(1)
+            if var.startswith("env."):
+                env_name = var[4:]
+                if not _ENV_VAR_NAME_PATTERN.match(env_name):
+                    raise ValueError(
+                        f"UPSTREAM_HEADERS: invalid env var reference ${{env.{env_name}}} in {k!r} — "
+                        "must be a non-empty identifier (letters, digits, underscore; no leading digit)"
+                    )
         if k.lower() in _RESERVED_HEADERS:
             logger.warning(
                 "UPSTREAM_HEADERS: dropping hop-by-hop/framing header %r (overriding it would break HTTP transport)",

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -1,42 +1,57 @@
 """Configurable upstream header injection.
 
-Reads header templates from the UPSTREAM_HEADERS environment variable (JSON)
-and expands per-request context variables before forwarding to the backend.
+Reads header templates from the ``UPSTREAM_HEADERS`` environment variable (a
+JSON object: ``{header_name: template_string}``) and expands per-request
+context variables before forwarding to the backend.
 
 Supported template variables::
 
     ${session_id}    — Claude Code session UUID (from metadata.user_id)
     ${request_path}  — HTTP request path (e.g. /v1/messages)
-    ${env.VARNAME}   — Any environment variable
+    ${env.VARNAME}   — Any process environment variable
 
 Example::
 
     UPSTREAM_HEADERS = '{"Helicone-Auth":"Bearer ${env.HELICONE_API_KEY}","Helicone-Session-Id":"${session_id}"}'
 
-Design notes:
+Trust model:
 
-    **Config system bypass (intentional):** This feature reads from the
-    ``UPSTREAM_HEADERS`` env var directly via ``os.environ`` rather than going
-    through the ``config_fields.py`` / ``settings.py`` config system. The config
-    system is designed for scalar values (str, int, bool) with per-field env
-    vars. A JSON blob of arbitrary header templates doesn't fit that model
-    cleanly. If this feature is later promoted to a first-class config field,
-    the ``lru_cache`` on ``_load_header_templates()`` will need to be replaced
-    with a config-registry-aware loader.
+    The operator who runs the gateway sets ``UPSTREAM_HEADERS`` and the
+    referenced env vars, and chooses the trusted upstream. The feature does
+    not defend against hostile operators (they own the env), hostile clients
+    (CRLF in ``session_id`` is malformed input, not an attack), or
+    "exfiltration" of the operator's own secrets to a destination they
+    configured. CRLF/NUL stripping and RFC 7230 token validation are input
+    hygiene — they keep failures legible, not safer.
 
-    **Restart required:** The ``lru_cache`` means UPSTREAM_HEADERS is read on
-    the first request and cached for the process lifetime. Changes require a
-    gateway restart.
+Validation:
 
-Security:
+    * Invalid JSON, a non-object root, or non-string entries raise at load
+      time. Misconfiguration fails the gateway at startup, not at first
+      request.
+    * Header names must match the RFC 7230 token spec.
+    * Hop-by-hop / framing headers (``Connection``, ``Transfer-Encoding``,
+      ``Content-Length``, ``Keep-Alive``, ``Trailer``, ``Trailers``,
+      ``Proxy-Connection``) are dropped with a warning — overriding them
+      breaks HTTP transport.
+    * Unknown template variables (``${foo}`` that isn't ``session_id``,
+      ``request_path``, or ``env.X``) are logged at load time, not on every
+      request.
 
-    **Env var expansion surface:** The ``${env.VARNAME}`` syntax expands any
-    environment variable into an outbound header value. This means anyone who
-    can set the ``UPSTREAM_HEADERS`` value can route any env var (including
-    ``ANTHROPIC_API_KEY``, ``ADMIN_API_KEY``, etc.) into upstream request
-    headers. This is acceptable when the upstream is trusted (e.g., Helicone,
-    Anthropic API) because server-side access is already required to set the
-    env var. Do NOT use this feature to forward headers to untrusted upstreams.
+Restart required:
+
+    Templates are parsed once and cached for the process lifetime. Changes
+    to ``UPSTREAM_HEADERS`` or any referenced env var require a gateway
+    restart.
+
+Config system bypass (intentional):
+
+    This feature reads ``UPSTREAM_HEADERS`` directly via ``os.environ``
+    rather than going through ``config_fields.py``. The config registry is
+    typed for scalars; a JSON blob of arbitrary header templates does not
+    fit that model. The ``upstream_headers_enabled`` flag in
+    ``config_fields.py`` exists so the feature is discoverable on the
+    ``/config`` dashboard.
 """
 
 from __future__ import annotations
@@ -51,34 +66,100 @@ logger = logging.getLogger(__name__)
 
 _TEMPLATE_PATTERN = re.compile(r"\$\{([^}]+)\}")
 
+# RFC 7230 token: 1*tchar where tchar = ALPHA / DIGIT / "!#$%&'*+-.^_`|~"
+_HEADER_NAME_PATTERN = re.compile(r"^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$")
+
+# Hop-by-hop / framing headers. Overriding these breaks HTTP transport.
+# Lower-case for case-insensitive comparison.
+_RESERVED_HEADERS = frozenset(
+    {
+        "connection",
+        "content-length",
+        "keep-alive",
+        "proxy-connection",
+        "trailer",
+        "trailers",
+        "transfer-encoding",
+    }
+)
+
+_KNOWN_VARS = frozenset({"session_id", "request_path"})
+
+
+def _validate_and_filter(parsed: dict[str, object]) -> dict[str, str]:
+    """Validate parsed JSON object and drop reserved headers. Raises on bad input."""
+    result: dict[str, str] = {}
+    for k, v in parsed.items():
+        if not isinstance(k, str):
+            raise ValueError(f"UPSTREAM_HEADERS: header name must be a string, got {type(k).__name__}: {k!r}")
+        if not isinstance(v, str):
+            raise ValueError(f"UPSTREAM_HEADERS: value for {k!r} must be a string, got {type(v).__name__}")
+        if not _HEADER_NAME_PATTERN.match(k):
+            raise ValueError(
+                f"UPSTREAM_HEADERS: header name {k!r} is not a valid RFC 7230 token"
+            )
+        if k.lower() in _RESERVED_HEADERS:
+            logger.warning(
+                "UPSTREAM_HEADERS: dropping hop-by-hop/framing header %r (overriding it would break HTTP transport)",
+                k,
+            )
+            continue
+        result[k] = v
+    return result
+
+
+def _audit_template_vars(templates: dict[str, str]) -> None:
+    """Log which env vars and template variables are referenced (operator audit)."""
+    env_refs: set[str] = set()
+    unknown: set[str] = set()
+    for value in templates.values():
+        for match in _TEMPLATE_PATTERN.finditer(value):
+            var = match.group(1)
+            if var.startswith("env."):
+                env_refs.add(var[4:])
+            elif var not in _KNOWN_VARS:
+                unknown.add(var)
+    if env_refs:
+        logger.info(
+            "UPSTREAM_HEADERS: referencing env vars: %s",
+            ", ".join(sorted(env_refs)),
+        )
+    if unknown:
+        logger.warning(
+            "UPSTREAM_HEADERS: unknown template variable(s): %s — will be left unexpanded",
+            ", ".join(sorted(f"${{{v}}}" for v in unknown)),
+        )
+
 
 @lru_cache(maxsize=1)
 def _load_header_templates() -> dict[str, str]:
-    """Parse UPSTREAM_HEADERS env var once at first use.
+    """Parse and validate UPSTREAM_HEADERS once. Raises on misconfiguration.
 
-    Returns empty dict if unset or malformed (fail-open).
+    Returns empty dict if the env var is unset or empty (the only fail-open path).
     """
     raw = os.environ.get("UPSTREAM_HEADERS", "")
     if not raw:
         return {}
-    try:
-        parsed = json.loads(raw)
-        if not isinstance(parsed, dict):
-            logger.warning("UPSTREAM_HEADERS must be a JSON object, got %s", type(parsed).__name__)
-            return {}
-        # Validate all values are strings
-        result = {}
-        for k, v in parsed.items():
-            if not isinstance(k, str) or not isinstance(v, str):
-                logger.warning("UPSTREAM_HEADERS: skipping non-string entry %r: %r", k, v)
-                continue
-            result[k] = v
-        if result:
-            logger.info("Loaded %d upstream header template(s)", len(result))
-        return result
-    except json.JSONDecodeError as e:
-        logger.warning("UPSTREAM_HEADERS: invalid JSON: %s", e)
-        return {}
+    parsed = json.loads(raw)  # raises JSONDecodeError on invalid JSON
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            f"UPSTREAM_HEADERS must be a JSON object, got {type(parsed).__name__}"
+        )
+    result = _validate_and_filter(parsed)
+    if result:
+        logger.info("Loaded %d upstream header template(s)", len(result))
+    _audit_template_vars(result)
+    return result
+
+
+def validate_upstream_headers_at_startup() -> None:
+    """Force-load templates so misconfiguration fails the gateway at startup.
+
+    Call from the app lifespan. Any ``json.JSONDecodeError`` or ``ValueError``
+    raised here will propagate and prevent the gateway from coming up with a
+    silently-disabled integration.
+    """
+    _load_header_templates()
 
 
 def _expand_template(template: str, session_id: str | None, request_path: str) -> str:
@@ -93,10 +174,10 @@ def _expand_template(template: str, session_id: str | None, request_path: str) -
         if var.startswith("env."):
             env_name = var[4:]
             return os.environ.get(env_name, "")
-        logger.debug("Unknown template variable: ${%s}", var)
-        return match.group(0)  # Leave unknown variables unexpanded
+        return match.group(0)  # Leave unknown variables unexpanded; warned at load time.
 
     result = _TEMPLATE_PATTERN.sub(_replace, template)
+    # Strip CRLF + NUL: keep failures legible at the HTTP layer.
     return result.replace("\r", "").replace("\n", "").replace("\x00", "")
 
 
@@ -106,17 +187,17 @@ def expand_upstream_headers(
 ) -> dict[str, str] | None:
     """Expand upstream header templates for a single request.
 
-    Returns None if no upstream headers are configured (avoids unnecessary dict
-    allocation on the hot path).
+    Returns ``None`` when no headers are configured (avoids unnecessary dict
+    allocation on the hot path) or when every configured header expands to
+    the empty string.
     """
     templates = _load_header_templates()
     if not templates:
         return None
 
-    headers = {}
+    headers: dict[str, str] = {}
     for name, template in templates.items():
         value = _expand_template(template, session_id, request_path)
-        # Skip headers that expand to empty (e.g. session_id not available)
         if value:
             headers[name] = value
     return headers or None

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -30,19 +30,22 @@ Validation:
       time. Misconfiguration fails the gateway at startup, not at first
       request.
     * Header names must match the RFC 7230 token spec.
-    * Hop-by-hop / framing headers (``Connection``, ``Transfer-Encoding``,
-      ``Content-Length``, ``Keep-Alive``, ``Trailer``, ``Trailers``,
-      ``Proxy-Connection``) are dropped with a warning — overriding them
-      breaks HTTP transport.
+    * Hop-by-hop / framing headers (``Connection``, ``Content-Length``,
+      ``Keep-Alive``, ``Proxy-Authenticate``, ``Proxy-Authorization``,
+      ``Proxy-Connection``, ``TE``, ``Trailer``, ``Trailers``,
+      ``Transfer-Encoding``, ``Upgrade``) are dropped with a warning —
+      overriding them breaks HTTP transport.
     * Unknown template variables (``${foo}`` that isn't ``session_id``,
       ``request_path``, or ``env.X``) are logged at load time, not on every
       request.
 
 Restart required:
 
-    Templates are parsed once and cached for the process lifetime. Changes
-    to ``UPSTREAM_HEADERS`` or any referenced env var require a gateway
-    restart.
+    Template structure is parsed once and cached for the process lifetime,
+    so changes to ``UPSTREAM_HEADERS`` itself require a gateway restart.
+    Referenced env vars (``${env.X}``) are read per request — mutating them
+    in the running process takes effect on the next request, but this is
+    not a recommended workflow.
 
 Config system bypass (intentional):
 
@@ -68,17 +71,22 @@ _TEMPLATE_PATTERN = re.compile(r"\$\{([^}]+)\}")
 # RFC 7230 token: 1*tchar where tchar = ALPHA / DIGIT / "!#$%&'*+-.^_`|~"
 _HEADER_NAME_PATTERN = re.compile(r"^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$")
 
-# Hop-by-hop / framing headers. Overriding these breaks HTTP transport.
-# Lower-case for case-insensitive comparison.
+# Hop-by-hop / framing headers per RFC 7230 §6.1, plus framing headers and the
+# common-but-non-standard Proxy-Connection. Overriding these breaks HTTP
+# transport. Lower-case for case-insensitive comparison.
 _RESERVED_HEADERS = frozenset(
     {
         "connection",
         "content-length",
         "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
         "proxy-connection",
+        "te",
         "trailer",
         "trailers",
         "transfer-encoding",
+        "upgrade",
     }
 )
 
@@ -106,7 +114,13 @@ def _validate_and_filter(parsed: dict[str, object]) -> dict[str, str]:
 
 
 def _audit_template_vars(templates: dict[str, str]) -> None:
-    """Log which env vars and template variables are referenced (operator audit)."""
+    """Log referenced env vars / template variables and flag the ones unset.
+
+    The unset-at-startup warning catches the typo class where ``Helicone-Auth``
+    expands to ``""`` (silently dropped) or ``"Bearer "`` (upstream rejects)
+    because ``${env.HELICONE_API_KEY}`` is misspelled. Surfacing it at
+    startup beats correlating with downstream 401s after the fact.
+    """
     env_refs: set[str] = set()
     unknown: set[str] = set()
     for value in templates.values():
@@ -121,6 +135,12 @@ def _audit_template_vars(templates: dict[str, str]) -> None:
             "UPSTREAM_HEADERS: referencing env vars: %s",
             ", ".join(sorted(env_refs)),
         )
+        unset = {v for v in env_refs if not os.environ.get(v)}
+        if unset:
+            logger.warning(
+                "UPSTREAM_HEADERS: referenced env var(s) are unset and will expand to empty: %s",
+                ", ".join(sorted(unset)),
+            )
     if unknown:
         logger.warning(
             "UPSTREAM_HEADERS: unknown template variable(s): %s — will be left unexpanded",

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -201,3 +201,25 @@ def expand_upstream_headers(
         if value:
             headers[name] = value
     return headers or None
+
+
+def merge_forwarded_headers(
+    base: dict[str, str] | None,
+    upstream: dict[str, str] | None,
+) -> dict[str, str] | None:
+    """Merge ``upstream`` into ``base`` with ``base`` winning on collision.
+
+    HTTP header names are case-insensitive, so the collision check is
+    case-insensitive too — without it, ``Anthropic-Beta`` from the upstream
+    config and ``anthropic-beta`` from the SDK would ship as two distinct
+    dict entries and produce duplicate header lines on the wire.
+
+    Returns ``None`` if both inputs are empty.
+    """
+    if not upstream:
+        return base or None
+    if base:
+        reserved = {k.lower() for k in base}
+        upstream = {k: v for k, v in upstream.items() if k.lower() not in reserved}
+    merged: dict[str, str] = {**upstream, **base} if base else dict(upstream)
+    return merged or None

--- a/src/luthien_proxy/pipeline/upstream_headers.py
+++ b/src/luthien_proxy/pipeline/upstream_headers.py
@@ -79,7 +79,7 @@ _ENV_VAR_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 # Hop-by-hop / framing headers per RFC 7230 §6.1, plus framing headers and the
 # common-but-non-standard Proxy-Connection. Overriding these breaks HTTP
 # transport. Lower-case for case-insensitive comparison.
-_RESERVED_HEADERS = frozenset(
+_HOP_BY_HOP_HEADERS = frozenset(
     {
         "connection",
         "content-length",
@@ -119,7 +119,7 @@ def _validate_and_filter(parsed: dict[str, object]) -> dict[str, str]:
                         "must be a non-empty identifier (letters, digits, underscore; no leading digit)"
                     )
         lower = k.lower()
-        if lower in _RESERVED_HEADERS:
+        if lower in _HOP_BY_HOP_HEADERS:
             logger.warning(
                 "UPSTREAM_HEADERS: dropping hop-by-hop/framing header %r (overriding it would break HTTP transport)",
                 k,
@@ -154,11 +154,11 @@ def _audit_template_vars(templates: dict[str, str]) -> None:
             "UPSTREAM_HEADERS: referencing env vars: %s",
             ", ".join(sorted(env_refs)),
         )
-        unset = {v for v in env_refs if not os.environ.get(v)}
-        if unset:
+        unset_or_empty = {v for v in env_refs if not os.environ.get(v)}
+        if unset_or_empty:
             logger.warning(
-                "UPSTREAM_HEADERS: referenced env var(s) are unset and will expand to empty: %s",
-                ", ".join(sorted(unset)),
+                "UPSTREAM_HEADERS: referenced env var(s) are unset or empty and will expand to empty: %s",
+                ", ".join(sorted(unset_or_empty)),
             )
     if unknown:
         logger.warning(
@@ -260,7 +260,6 @@ def merge_forwarded_headers(
         return base or None
     if not base:
         return upstream
-    reserved = {k.lower() for k in base}
-    upstream = {k: v for k, v in upstream.items() if k.lower() not in reserved}
-    merged: dict[str, str] = {**upstream, **base}
-    return merged or None
+    base_keys_lower = {k.lower() for k in base}
+    upstream = {k: v for k, v in upstream.items() if k.lower() not in base_keys_lower}
+    return {**upstream, **base}

--- a/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
@@ -1,0 +1,168 @@
+"""Tests for upstream header injection."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from luthien_proxy.pipeline.upstream_headers import (
+    _expand_template,
+    _load_header_templates,
+    expand_upstream_headers,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Clear the lru_cache between tests."""
+    _load_header_templates.cache_clear()
+    yield
+    _load_header_templates.cache_clear()
+
+
+class TestLoadHeaderTemplates:
+    """Tests for parsing UPSTREAM_HEADERS env var."""
+
+    def test_returns_empty_when_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("UPSTREAM_HEADERS", raising=False)
+        assert _load_header_templates() == {}
+
+    def test_returns_empty_for_empty_string(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", "")
+        assert _load_header_templates() == {}
+
+    def test_parses_valid_json(self, monkeypatch: pytest.MonkeyPatch):
+        headers = {"Helicone-Auth": "Bearer key123", "X-Custom": "value"}
+        monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps(headers))
+        assert _load_header_templates() == headers
+
+    def test_returns_empty_for_invalid_json(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", "not json")
+        assert _load_header_templates() == {}
+
+    def test_returns_empty_for_non_object_json(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", '["not", "an", "object"]')
+        assert _load_header_templates() == {}
+
+    def test_skips_non_string_values(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", '{"good": "value", "bad": 123}')
+        result = _load_header_templates()
+        assert result == {"good": "value"}
+        assert "bad" not in result
+
+
+class TestExpandTemplate:
+    """Tests for template variable expansion."""
+
+    def test_expands_session_id(self):
+        assert _expand_template("sess-${session_id}", "abc-123", "/v1/messages") == "sess-abc-123"
+
+    def test_expands_none_session_id_to_empty(self):
+        assert _expand_template("${session_id}", None, "/v1/messages") == ""
+
+    def test_expands_request_path(self):
+        assert _expand_template("${request_path}", None, "/v1/messages") == "/v1/messages"
+
+    def test_expands_env_var(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MY_SECRET", "s3cret")
+        assert _expand_template("Bearer ${env.MY_SECRET}", None, "/") == "Bearer s3cret"
+
+    def test_missing_env_var_expands_to_empty(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
+        assert _expand_template("${env.NONEXISTENT_VAR}", None, "/") == ""
+
+    def test_unknown_variable_left_unexpanded(self):
+        assert _expand_template("${unknown_var}", None, "/") == "${unknown_var}"
+
+    def test_multiple_variables_in_one_template(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("USER", "sami")
+        result = _expand_template("${env.USER}:${session_id}", "sess-1", "/v1/messages")
+        assert result == "sami:sess-1"
+
+    def test_no_variables_returns_literal(self):
+        assert _expand_template("plain value", None, "/") == "plain value"
+
+
+class TestExpandUpstreamHeaders:
+    """Tests for the full expansion pipeline."""
+
+    def test_returns_none_when_no_config(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("UPSTREAM_HEADERS", raising=False)
+        assert expand_upstream_headers("sess-1", "/v1/messages") is None
+
+    def test_expands_all_headers(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("HELICONE_API_KEY", "sk-hel-test")
+        monkeypatch.setenv(
+            "UPSTREAM_HEADERS",
+            json.dumps(
+                {
+                    "Helicone-Auth": "Bearer ${env.HELICONE_API_KEY}",
+                    "Helicone-Session-Id": "${session_id}",
+                    "Helicone-Session-Path": "${request_path}",
+                }
+            ),
+        )
+        result = expand_upstream_headers("abc-123-uuid", "/v1/messages")
+        assert result is not None
+        assert result["Helicone-Auth"] == "Bearer sk-hel-test"
+        assert result["Helicone-Session-Id"] == "abc-123-uuid"
+        assert result["Helicone-Session-Path"] == "/v1/messages"
+
+    def test_skips_headers_that_expand_to_empty(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(
+            "UPSTREAM_HEADERS",
+            json.dumps(
+                {
+                    "Helicone-Session-Id": "${session_id}",
+                    "Helicone-Auth": "Bearer static-key",
+                }
+            ),
+        )
+        # session_id is None → Helicone-Session-Id expands to "" → skipped
+        result = expand_upstream_headers(None, "/v1/messages")
+        assert result is not None
+        assert "Helicone-Session-Id" not in result
+        assert result["Helicone-Auth"] == "Bearer static-key"
+
+    def test_returns_none_when_all_expand_to_empty(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(
+            "UPSTREAM_HEADERS",
+            json.dumps({"Helicone-Session-Id": "${session_id}"}),
+        )
+        assert expand_upstream_headers(None, "/v1/messages") is None
+
+    def test_helicone_full_config(self, monkeypatch: pytest.MonkeyPatch):
+        """Integration-style test matching the real Helicone use case."""
+        monkeypatch.setenv("HELICONE_API_KEY", "sk-helicone-prod")
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_prod_key")
+        monkeypatch.setenv("USER", "sami@trajectory.dev")
+        monkeypatch.setenv(
+            "UPSTREAM_HEADERS",
+            json.dumps(
+                {
+                    "Helicone-Auth": "Bearer ${env.HELICONE_API_KEY}",
+                    "Helicone-Session-Id": "${session_id}",
+                    "Helicone-Session-Name": "Claude Code",
+                    "Helicone-Session-Path": "${request_path}",
+                    "Helicone-User-Id": "${env.USER}",
+                    "Helicone-Posthog-Key": "${env.POSTHOG_API_KEY}",
+                    "Helicone-Posthog-Host": "https://us.i.posthog.com",
+                    "Helicone-Property-SessionId": "${session_id}",
+                    "Helicone-Property-UserId": "${env.USER}",
+                }
+            ),
+        )
+        result = expand_upstream_headers("9f3a-b2c1-session-uuid", "/v1/messages")
+        assert result is not None
+        assert result == {
+            "Helicone-Auth": "Bearer sk-helicone-prod",
+            "Helicone-Session-Id": "9f3a-b2c1-session-uuid",
+            "Helicone-Session-Name": "Claude Code",
+            "Helicone-Session-Path": "/v1/messages",
+            "Helicone-User-Id": "sami@trajectory.dev",
+            "Helicone-Posthog-Key": "phc_prod_key",
+            "Helicone-Posthog-Host": "https://us.i.posthog.com",
+            "Helicone-Property-SessionId": "9f3a-b2c1-session-uuid",
+            "Helicone-Property-UserId": "sami@trajectory.dev",
+        }

--- a/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
@@ -83,6 +83,19 @@ class TestExpandTemplate:
     def test_no_variables_returns_literal(self):
         assert _expand_template("plain value", None, "/") == "plain value"
 
+    def test_strips_crlf_from_literal_value(self):
+        assert _expand_template("value\r\nX-Injected: evil", None, "/") == "valueX-Injected: evil"
+
+    def test_strips_crlf_from_env_var_expansion(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("EVIL_VAR", "legit\r\nX-Injected: evil")
+        assert _expand_template("${env.EVIL_VAR}", None, "/") == "legitX-Injected: evil"
+
+    def test_strips_lf_only(self):
+        assert _expand_template("value\ninjected", None, "/") == "valueinjected"
+
+    def test_strips_cr_only(self):
+        assert _expand_template("value\rinjected", None, "/") == "valueinjected"
+
 
 class TestExpandUpstreamHeaders:
     """Tests for the full expansion pipeline."""

--- a/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
@@ -118,6 +118,12 @@ class TestLoadHeaderTemplates:
         monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps({"Authorization": "Bearer override"}))
         assert _load_header_templates() == {"Authorization": "Bearer override"}
 
+    def test_raises_on_intra_config_case_insensitive_duplicate(self, monkeypatch: pytest.MonkeyPatch):
+        # Two casings of the same logical header would otherwise ship as two header lines.
+        monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps({"Helicone-Auth": "a", "HELICONE-AUTH": "b"}))
+        with pytest.raises(ValueError, match="duplicate header"):
+            _load_header_templates()
+
     def test_audit_log_lists_referenced_env_vars(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ):

--- a/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
@@ -118,9 +118,7 @@ class TestLoadHeaderTemplates:
             _load_header_templates()
         assert "not_a_real_var" in caplog.text
 
-    def test_known_vars_do_not_warn(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ):
+    def test_known_vars_do_not_warn(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
         monkeypatch.setenv(
             "UPSTREAM_HEADERS",
             json.dumps({"X-Sess": "${session_id}", "X-Path": "${request_path}"}),
@@ -250,6 +248,7 @@ class TestExpandUpstreamHeaders:
             json.dumps({"Helicone-Session-Id": "${session_id}"}),
         )
         assert expand_upstream_headers(None, "/v1/messages") is None
+
 
 class TestMergeForwardedHeaders:
     """Tests for the merge logic used at the integration site in anthropic_processor."""

--- a/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
@@ -71,9 +71,13 @@ class TestLoadHeaderTemplates:
                     "Transfer-Encoding": "chunked",
                     "Content-Length": "0",
                     "Keep-Alive": "timeout=5",
+                    "Proxy-Authenticate": "Basic",
+                    "Proxy-Authorization": "Basic abc",
+                    "Proxy-Connection": "close",
+                    "TE": "trailers",
                     "Trailer": "Expires",
                     "Trailers": "Expires",
-                    "Proxy-Connection": "close",
+                    "Upgrade": "h2c",
                     "X-Custom": "kept",
                 }
             ),
@@ -83,6 +87,8 @@ class TestLoadHeaderTemplates:
         assert result == {"X-Custom": "kept"}
         assert "Connection" in caplog.text
         assert "Transfer-Encoding" in caplog.text
+        assert "Upgrade" in caplog.text
+        assert "Proxy-Authorization" in caplog.text
 
     def test_reserved_check_is_case_insensitive(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps({"CONTENT-LENGTH": "0", "X-Custom": "kept"}))
@@ -96,6 +102,8 @@ class TestLoadHeaderTemplates:
     def test_audit_log_lists_referenced_env_vars(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ):
+        monkeypatch.setenv("HELICONE_API_KEY", "x")
+        monkeypatch.setenv("USER", "y")
         monkeypatch.setenv(
             "UPSTREAM_HEADERS",
             json.dumps(
@@ -109,6 +117,33 @@ class TestLoadHeaderTemplates:
             _load_header_templates()
         assert "HELICONE_API_KEY" in caplog.text
         assert "USER" in caplog.text
+
+    def test_warns_on_unset_referenced_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.delenv("HELICONE_API_KEY", raising=False)
+        monkeypatch.delenv("MISSING_THING", raising=False)
+        monkeypatch.setenv("USER", "present")
+        monkeypatch.setenv(
+            "UPSTREAM_HEADERS",
+            json.dumps(
+                {
+                    "Helicone-Auth": "Bearer ${env.HELICONE_API_KEY}",
+                    "Helicone-User": "${env.USER}",
+                    "X-Other": "${env.MISSING_THING}",
+                }
+            ),
+        )
+        with caplog.at_level(logging.WARNING, logger="luthien_proxy.pipeline.upstream_headers"):
+            _load_header_templates()
+        assert "unset" in caplog.text.lower()
+        assert "HELICONE_API_KEY" in caplog.text
+        assert "MISSING_THING" in caplog.text
+        # USER is set, must not appear in the unset warning line.
+        # (It will appear in the "referencing" info line, which is fine.)
+        warning_lines = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("HELICONE_API_KEY" in r.getMessage() for r in warning_lines)
+        assert not any("USER" in r.getMessage() and "unset" in r.getMessage() for r in warning_lines)
 
     def test_unknown_template_var_warns_at_load_time(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture

--- a/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
@@ -60,6 +60,25 @@ class TestLoadHeaderTemplates:
         with pytest.raises(ValueError, match="not a valid RFC 7230 token"):
             _load_header_templates()
 
+    @pytest.mark.parametrize(
+        "bad_ref",
+        [
+            "${env.}",  # empty
+            "${env.WITH SPACE}",  # space
+            "${env.WITH-DASH}",  # dash
+            "${env.1LEADING_DIGIT}",
+        ],
+    )
+    def test_raises_on_invalid_env_var_reference(self, monkeypatch: pytest.MonkeyPatch, bad_ref: str):
+        monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps({"X-Custom": f"prefix {bad_ref} suffix"}))
+        with pytest.raises(ValueError, match="invalid env var reference"):
+            _load_header_templates()
+
+    def test_accepts_valid_env_var_references(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps({"X-A": "${env.FOO}", "X-B": "${env._UNDER}"}))
+        # Does not raise.
+        _load_header_templates()
+
     def test_drops_hop_by_hop_headers_with_warning(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ):

--- a/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import pytest
 
@@ -10,6 +11,7 @@ from luthien_proxy.pipeline.upstream_headers import (
     _expand_template,
     _load_header_templates,
     expand_upstream_headers,
+    validate_upstream_headers_at_startup,
 )
 
 
@@ -37,19 +39,116 @@ class TestLoadHeaderTemplates:
         monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps(headers))
         assert _load_header_templates() == headers
 
-    def test_returns_empty_for_invalid_json(self, monkeypatch: pytest.MonkeyPatch):
+    def test_raises_on_invalid_json(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("UPSTREAM_HEADERS", "not json")
-        assert _load_header_templates() == {}
+        with pytest.raises(json.JSONDecodeError):
+            _load_header_templates()
 
-    def test_returns_empty_for_non_object_json(self, monkeypatch: pytest.MonkeyPatch):
+    def test_raises_on_non_object_root(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("UPSTREAM_HEADERS", '["not", "an", "object"]')
-        assert _load_header_templates() == {}
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            _load_header_templates()
 
-    def test_skips_non_string_values(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv("UPSTREAM_HEADERS", '{"good": "value", "bad": 123}')
-        result = _load_header_templates()
-        assert result == {"good": "value"}
-        assert "bad" not in result
+    def test_raises_on_non_string_value(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", '{"good": 123}')
+        with pytest.raises(ValueError, match="must be a string"):
+            _load_header_templates()
+
+    def test_raises_on_invalid_header_name(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", '{"bad name with spaces": "value"}')
+        with pytest.raises(ValueError, match="not a valid RFC 7230 token"):
+            _load_header_templates()
+
+    def test_drops_hop_by_hop_headers_with_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv(
+            "UPSTREAM_HEADERS",
+            json.dumps(
+                {
+                    "Connection": "close",
+                    "Transfer-Encoding": "chunked",
+                    "Content-Length": "0",
+                    "Keep-Alive": "timeout=5",
+                    "Trailer": "Expires",
+                    "Trailers": "Expires",
+                    "Proxy-Connection": "close",
+                    "X-Custom": "kept",
+                }
+            ),
+        )
+        with caplog.at_level(logging.WARNING, logger="luthien_proxy.pipeline.upstream_headers"):
+            result = _load_header_templates()
+        assert result == {"X-Custom": "kept"}
+        assert "Connection" in caplog.text
+        assert "Transfer-Encoding" in caplog.text
+
+    def test_reserved_check_is_case_insensitive(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps({"CONTENT-LENGTH": "0", "X-Custom": "kept"}))
+        assert _load_header_templates() == {"X-Custom": "kept"}
+
+    def test_authorization_header_is_allowed(self, monkeypatch: pytest.MonkeyPatch):
+        # Operator may legitimately want to override Authorization on the way upstream.
+        monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps({"Authorization": "Bearer override"}))
+        assert _load_header_templates() == {"Authorization": "Bearer override"}
+
+    def test_audit_log_lists_referenced_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv(
+            "UPSTREAM_HEADERS",
+            json.dumps(
+                {
+                    "Helicone-Auth": "Bearer ${env.HELICONE_API_KEY}",
+                    "Helicone-User": "${env.USER}",
+                }
+            ),
+        )
+        with caplog.at_level(logging.INFO, logger="luthien_proxy.pipeline.upstream_headers"):
+            _load_header_templates()
+        assert "HELICONE_API_KEY" in caplog.text
+        assert "USER" in caplog.text
+
+    def test_unknown_template_var_warns_at_load_time(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps({"X-Custom": "${not_a_real_var}"}))
+        with caplog.at_level(logging.WARNING, logger="luthien_proxy.pipeline.upstream_headers"):
+            _load_header_templates()
+        assert "not_a_real_var" in caplog.text
+
+    def test_known_vars_do_not_warn(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        monkeypatch.setenv(
+            "UPSTREAM_HEADERS",
+            json.dumps({"X-Sess": "${session_id}", "X-Path": "${request_path}"}),
+        )
+        with caplog.at_level(logging.WARNING, logger="luthien_proxy.pipeline.upstream_headers"):
+            _load_header_templates()
+        assert "unknown template variable" not in caplog.text
+
+
+class TestValidateAtStartup:
+    """Tests for the startup validator."""
+
+    def test_passes_when_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("UPSTREAM_HEADERS", raising=False)
+        validate_upstream_headers_at_startup()  # does not raise
+
+    def test_passes_for_valid_config(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps({"X-Custom": "value"}))
+        validate_upstream_headers_at_startup()  # does not raise
+
+    def test_raises_for_invalid_json(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", "not json")
+        with pytest.raises(json.JSONDecodeError):
+            validate_upstream_headers_at_startup()
+
+    def test_raises_for_invalid_header_name(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps({"bad name": "value"}))
+        with pytest.raises(ValueError):
+            validate_upstream_headers_at_startup()
 
 
 class TestExpandTemplate:
@@ -90,11 +189,17 @@ class TestExpandTemplate:
         monkeypatch.setenv("EVIL_VAR", "legit\r\nX-Injected: evil")
         assert _expand_template("${env.EVIL_VAR}", None, "/") == "legitX-Injected: evil"
 
+    def test_strips_crlf_from_session_id(self):
+        assert _expand_template("${session_id}", "good\r\nX-Injected: evil", "/") == "goodX-Injected: evil"
+
     def test_strips_lf_only(self):
         assert _expand_template("value\ninjected", None, "/") == "valueinjected"
 
     def test_strips_cr_only(self):
         assert _expand_template("value\rinjected", None, "/") == "valueinjected"
+
+    def test_strips_nul_byte(self):
+        assert _expand_template("value\x00injected", None, "/") == "valueinjected"
 
 
 class TestExpandUpstreamHeaders:

--- a/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
@@ -11,6 +11,7 @@ from luthien_proxy.pipeline.upstream_headers import (
     _expand_template,
     _load_header_templates,
     expand_upstream_headers,
+    merge_forwarded_headers,
     validate_upstream_headers_at_startup,
 )
 
@@ -249,6 +250,48 @@ class TestExpandUpstreamHeaders:
             json.dumps({"Helicone-Session-Id": "${session_id}"}),
         )
         assert expand_upstream_headers(None, "/v1/messages") is None
+
+class TestMergeForwardedHeaders:
+    """Tests for the merge logic used at the integration site in anthropic_processor."""
+
+    def test_returns_base_when_upstream_is_none(self):
+        base = {"anthropic-beta": "x"}
+        assert merge_forwarded_headers(base=base, upstream=None) is base
+
+    def test_returns_base_when_upstream_is_empty(self):
+        base = {"anthropic-beta": "x"}
+        assert merge_forwarded_headers(base=base, upstream={}) is base
+
+    def test_returns_upstream_when_base_is_none(self):
+        upstream = {"Helicone-Auth": "Bearer x"}
+        assert merge_forwarded_headers(base=None, upstream=upstream) == upstream
+
+    def test_returns_none_when_both_empty(self):
+        assert merge_forwarded_headers(base=None, upstream=None) is None
+        assert merge_forwarded_headers(base={}, upstream={}) is None
+
+    def test_base_wins_on_case_insensitive_collision(self):
+        # SDK adds anthropic-beta; upstream config (mistakenly) tries to override with Anthropic-Beta.
+        base = {"anthropic-beta": "sdk-value"}
+        upstream = {"Anthropic-Beta": "config-value", "Helicone-Auth": "Bearer x"}
+        merged = merge_forwarded_headers(base=base, upstream=upstream)
+        assert merged == {"anthropic-beta": "sdk-value", "Helicone-Auth": "Bearer x"}
+        # Ensure no duplicate logical header on the wire.
+        assert "Anthropic-Beta" not in merged
+
+    def test_non_colliding_headers_pass_through(self):
+        base = {"anthropic-beta": "x"}
+        upstream = {"Helicone-Auth": "Bearer y", "Helicone-Session-Id": "s"}
+        merged = merge_forwarded_headers(base=base, upstream=upstream)
+        assert merged == {
+            "anthropic-beta": "x",
+            "Helicone-Auth": "Bearer y",
+            "Helicone-Session-Id": "s",
+        }
+
+
+class TestHeliconeFullConfig:
+    """Integration-style test for the original sjawhar Helicone scenario."""
 
     def test_helicone_full_config(self, monkeypatch: pytest.MonkeyPatch):
         """Integration-style test matching the real Helicone use case."""

--- a/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
@@ -323,7 +323,12 @@ class TestMergeForwardedHeaders:
 
     def test_returns_upstream_when_base_is_none(self):
         upstream = {"Helicone-Auth": "Bearer x"}
-        assert merge_forwarded_headers(base=None, upstream=upstream) == upstream
+        # Aliased by reference per merge_forwarded_headers' contract.
+        assert merge_forwarded_headers(base=None, upstream=upstream) is upstream
+
+    def test_returns_upstream_when_base_is_empty(self):
+        upstream = {"Helicone-Auth": "Bearer x"}
+        assert merge_forwarded_headers(base={}, upstream=upstream) is upstream
 
     def test_returns_none_when_both_empty(self):
         assert merge_forwarded_headers(base=None, upstream=None) is None

--- a/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py
@@ -90,6 +90,7 @@ class TestLoadHeaderTemplates:
                     "Transfer-Encoding": "chunked",
                     "Content-Length": "0",
                     "Keep-Alive": "timeout=5",
+                    "Host": "evil.example.com",
                     "Proxy-Authenticate": "Basic",
                     "Proxy-Authorization": "Basic abc",
                     "Proxy-Connection": "close",
@@ -108,6 +109,7 @@ class TestLoadHeaderTemplates:
         assert "Transfer-Encoding" in caplog.text
         assert "Upgrade" in caplog.text
         assert "Proxy-Authorization" in caplog.text
+        assert "Host" in caplog.text
 
     def test_reserved_check_is_case_insensitive(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("UPSTREAM_HEADERS", json.dumps({"CONTENT-LENGTH": "0", "X-Custom": "kept"}))
@@ -313,22 +315,29 @@ class TestExpandUpstreamHeaders:
 class TestMergeForwardedHeaders:
     """Tests for the merge logic used at the integration site in anthropic_processor."""
 
-    def test_returns_base_when_upstream_is_none(self):
+    def test_returns_fresh_copy_of_base_when_upstream_is_none(self):
         base = {"anthropic-beta": "x"}
-        assert merge_forwarded_headers(base=base, upstream=None) is base
+        result = merge_forwarded_headers(base=base, upstream=None)
+        assert result == base
+        assert result is not base  # Fresh copy — caller may mutate freely.
 
-    def test_returns_base_when_upstream_is_empty(self):
+    def test_returns_fresh_copy_of_base_when_upstream_is_empty(self):
         base = {"anthropic-beta": "x"}
-        assert merge_forwarded_headers(base=base, upstream={}) is base
+        result = merge_forwarded_headers(base=base, upstream={})
+        assert result == base
+        assert result is not base
 
-    def test_returns_upstream_when_base_is_none(self):
+    def test_returns_fresh_copy_of_upstream_when_base_is_none(self):
         upstream = {"Helicone-Auth": "Bearer x"}
-        # Aliased by reference per merge_forwarded_headers' contract.
-        assert merge_forwarded_headers(base=None, upstream=upstream) is upstream
+        result = merge_forwarded_headers(base=None, upstream=upstream)
+        assert result == upstream
+        assert result is not upstream
 
-    def test_returns_upstream_when_base_is_empty(self):
+    def test_returns_fresh_copy_of_upstream_when_base_is_empty(self):
         upstream = {"Helicone-Auth": "Bearer x"}
-        assert merge_forwarded_headers(base={}, upstream=upstream) is upstream
+        result = merge_forwarded_headers(base={}, upstream=upstream)
+        assert result == upstream
+        assert result is not upstream
 
     def test_returns_none_when_both_empty(self):
         assert merge_forwarded_headers(base=None, upstream=None) is None

--- a/tests/luthien_proxy/unit_tests/policies/test_string_replacement_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_string_replacement_policy.py
@@ -1485,9 +1485,7 @@ class TestRequestSideFiltering:
     @pytest.mark.asyncio
     async def test_empty_replacements_is_identity_passthrough(self):
         """apply_to='request' with empty replacements returns the original request."""
-        policy = StringReplacementPolicy(
-            config=StringReplacementConfig(replacements=[], apply_to="request")
-        )
+        policy = StringReplacementPolicy(config=StringReplacementConfig(replacements=[], apply_to="request"))
         ctx, _ = _ctx_with_recorder()
         request = _request_with_messages([{"role": "user", "content": "anything goes"}])
 


### PR DESCRIPTION
## Summary

Rebuild of [#549](https://github.com/LuthienResearch/luthien-proxy/pull/549) (sjawhar) as part of the effort to break the rejected mega-PR [#595](https://github.com/LuthienResearch/luthien-proxy/pull/595) into reviewable chunks. Adds configurable upstream header injection so the gateway can chain in front of services like Helicone that require custom session/auth headers.

Original commits authored by sjawhar are preserved via cherry-pick. The CRLF/NUL stripping commits authored by paolo are also preserved. Other follow-ups are hand-ported as a single new commit because they collide with a refactor in #595 that is not being carried over.

## What it does

Operator sets `UPSTREAM_HEADERS` to a JSON object mapping header name → template string:

```bash
export UPSTREAM_HEADERS='{
  "Helicone-Auth": "Bearer ${env.HELICONE_API_KEY}",
  "Helicone-Session-Id": "${session_id}",
  "Helicone-Session-Path": "${request_path}"
}'
```

Templates expand per-request with `${session_id}`, `${request_path}`, and `${env.VARNAME}`. The expanded headers are merged onto outbound `/v1/messages` requests, with SDK-controlled headers (e.g. `anthropic-beta`) winning on case-insensitive collision.

## Trust model

The operator sets `UPSTREAM_HEADERS`, owns the env vars it references, and chooses the trusted upstream. This PR explicitly does **not** defend against:

- **Hostile clients.** CRLF in `session_id` is malformed input, not an attack.
- **Hostile operators.** They own the env; they can already do anything.
- **"Exfiltration" of the operator's own secrets** to an upstream they configured.

CRLF/NUL stripping and RFC 7230 token validation are input hygiene — they keep failures legible (clean errors at the HTTP layer instead of opaque h11 crashes), not safer.

## Validation behavior

At gateway startup, `UPSTREAM_HEADERS` is parsed, validated, and any misconfiguration **fails the gateway** rather than silently disabling the integration:

- Invalid JSON → `JSONDecodeError`
- Non-object root → `ValueError`
- Non-string entries → `ValueError`
- Header names not matching RFC 7230 token spec → `ValueError`
- Hop-by-hop / framing headers (`Connection`, `Content-Length`, `Host`, `Keep-Alive`, `Proxy-Authenticate`, `Proxy-Authorization`, `Proxy-Connection`, `TE`, `Trailer`, `Trailers`, `Transfer-Encoding`, `Upgrade`) → dropped at load time with a warning, since overriding them breaks HTTP transport
- Unknown template variables → warned at load time, left unexpanded at runtime

At load time the module also emits a single audit log line enumerating which env vars the templates reference, so operators can sanity-check at boot without grepping config.

Per-request expansion strips CRLF + NUL from the result.

## Deliberately not in this PR

- **OTel `traceparent` propagation** (sjawhar's commit `9415ca1` from #549). Unrelated feature — distributed-tracing, separate threat surface, no tests as written. Should be its own PR. Repo's One PR = One Concern rule (CLAUDE.md) calls out exactly this kind of bundling.
- **Sensitive-env-var blocklist** (#595's `d106b62` / `844b94f` / `cd1255d`). Paternalistic and breaks the canonical `HELICONE_API_KEY` use case (`*KEY` suffix matches it). Replaced with an audit log enumerating referenced env vars; the operator who set the env owns the trust decision. See [discussion](https://github.com/LuthienResearch/luthien-proxy/pull/716#issuecomment-placeholder) for trust-model rationale.
- **`Authorization` / `X-Api-Key` blocklist.** Operator may legitimately want to override these on the way upstream. Hop-by-hop/framing headers only.
- **`upstream_headers_enabled` config-fields entry.** Would be either cosmetic (dashboard-only) or non-trivial (gating logic in two call sites + settings dep in the upstream_headers module). The startup audit log covers the "is this gateway injecting headers?" operability question without the complexity.

## Refactor

The case-insensitive collision logic in `process_anthropic_request` is extracted to `merge_forwarded_headers()` in `upstream_headers.py` so it has direct unit tests. The integration site goes from ~10 lines of inline merging to a single helper call.

## Test plan

- [x] `tests/luthien_proxy/unit_tests/pipeline/test_upstream_headers.py` — 42 unit tests covering: parse + validation (JSON/object/RFC 7230/values/case insensitivity), hop-by-hop blocking, audit logging, unknown-var warnings, startup validator, template expansion (CRLF/NUL/CR-only/LF-only stripping, env var/missing var/session_id/request_path), full Helicone scenario, `merge_forwarded_headers` collision + identity passthrough cases.
- [x] `uv run ruff format` ✓
- [x] `uv run ruff check` ✓
- [x] `uv run pyright` (0 errors, 0 warnings) ✓
- [x] `uv run -m pytest --no-cov` (2469 passed) ✓
- [ ] Manual smoke against a real Helicone instance — sjawhar verified on the original PR; not re-tested here.

## Commit attribution

```
Jai Dhyani  chore: integrate hand-port — startup wiring, changelog, formatter pass
Jai Dhyani  refactor: extract merge_forwarded_headers + integration tests
Jai Dhyani  fix(upstream-headers): validate at startup, block hop-by-hop, drop fail-open
Paolo Calvi fix(upstream-headers): strip NUL bytes alongside CRLF in header values
Paolo Calvi fix(security): strip CRLF from upstream header template expansion
Sami Jawhar fix: case-insensitive collision check for reserved upstream headers
Sami Jawhar review: add changelog fragment, document config bypass and security surface
Sami Jawhar feat: configurable upstream header injection via UPSTREAM_HEADERS env var
```