### PR TITLE
chore: set objective to fix safety judgment unavailable API 400 (issue #708)

### DIFF
--- a/changelog.d/fix-issue-708-safety-judgment-400.md
+++ b/changelog.d/fix-issue-708-safety-judgment-400.md
@@ -1,0 +1,6 @@
+---
+category: Fixes
+pr: 719
+---
+
+**Fix safety-judge stream corruption**: `SimpleLLMPolicy` and `ToolCallJudgePolicy` no longer emit streaming events that violate the Anthropic block-index/stop-reason invariants when the judge blocks, replaces, or fails on a tool call. This prevented sessions from continuing after a judge failure on single or parallel tool_use responses (issue #708).

--- a/dev/context/gotchas.md
+++ b/dev/context/gotchas.md
@@ -357,7 +357,7 @@ Three invariants the Anthropic API enforces on streaming responses:
 3. **No empty text blocks**: Emitting a `content_block_start` for a text block with no subsequent delta is technically valid but can confuse clients.
 
 **Which functions own each invariant**:
-- Invariant 1: `SimpleLLMPolicy._emit_anthropic_replacement_events` (tracks `current_index`), `SimpleLLMPolicy._handle_block_stop` (tracks `state.max_emitted_index`), `SimpleLLMPolicy._handle_message_delta` (uses `state.max_emitted_index + 1` for warning index)
+- Invariant 1: `SimpleLLMPolicy._emit_anthropic_replacement_events` (tracks `current_index`, updates `state.index_shift` for multi-block replacements), `SimpleLLMPolicy._handle_block_stop` (tracks `state.max_emitted_index`, applies `state.index_shift`), `SimpleLLMPolicy._handle_message_delta` (uses `state.max_emitted_index + 1` for warning index). Also `ToolCallJudgePolicy._handle_anthropic_content_block_stop` (tracks `state.emitted_tool_indices` — blocked tools reuse the original index slot without shifting).
 - Invariant 2: `SimpleLLMPolicy._handle_message_delta` (checks `emitted_blocks` for tool_use type), `ToolCallJudgePolicy._handle_anthropic_message_delta` (checks `emitted_tool_indices`)
 - Invariant 3: No dedicated owner — avoid emitting empty text blocks
 

--- a/dev/context/gotchas.md
+++ b/dev/context/gotchas.md
@@ -346,4 +346,21 @@ Policies using session-level state trackers (like `ConversationLinkPolicy`'s onc
 
 ---
 
+## 2026-05-08 — Anthropic streaming invariants (issue #708)
+
+Three invariants the Anthropic API enforces on streaming responses:
+
+1. **Monotonic block indices**: `content_block_start.index` must be strictly increasing across the stream. Emitting two starts at the same index causes a 400 on the next turn.
+
+2. **stop_reason must match content**: If `message_delta.stop_reason == "tool_use"`, at least one `tool_use` content block must have been emitted. If all tools are blocked/replaced by text, `stop_reason` must be corrected to `"end_turn"` before the event is forwarded.
+
+3. **No empty text blocks**: Emitting a `content_block_start` for a text block with no subsequent delta is technically valid but can confuse clients.
+
+**Which functions own each invariant**:
+- Invariant 1: `SimpleLLMPolicy._emit_anthropic_replacement_events` (tracks `current_index`), `SimpleLLMPolicy._handle_block_stop` (tracks `state.max_emitted_index`), `SimpleLLMPolicy._handle_message_delta` (uses `state.max_emitted_index + 1` for warning index)
+- Invariant 2: `SimpleLLMPolicy._handle_message_delta` (checks `emitted_blocks` for tool_use type), `ToolCallJudgePolicy._handle_anthropic_message_delta` (checks `emitted_tool_indices`)
+- Invariant 3: No dedicated owner — avoid emitting empty text blocks
+
+---
+
 (Add gotchas as discovered with timestamps: YYYY-MM-DD)

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -4,7 +4,8 @@
 set -uo pipefail
 
 # Only act on Python files that are staged (Added, Modified, Copied, Renamed)
-mapfile -t staged_py < <(git diff --cached --name-only --diff-filter=ACMR -- '*.py')
+staged_py=()
+while IFS= read -r line; do [[ -n "$line" ]] && staged_py+=("$line"); done < <(git diff --cached --name-only --diff-filter=ACMR -- '*.py')
 [ "${#staged_py[@]}" -eq 0 ] && exit 0
 
 echo "pre-commit: formatting ${#staged_py[@]} staged Python file(s)..."

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -4,8 +4,7 @@
 set -uo pipefail
 
 # Only act on Python files that are staged (Added, Modified, Copied, Renamed)
-staged_py=()
-while IFS= read -r line; do [[ -n "$line" ]] && staged_py+=("$line"); done < <(git diff --cached --name-only --diff-filter=ACMR -- '*.py')
+mapfile -t staged_py < <(git diff --cached --name-only --diff-filter=ACMR -- '*.py')
 [ "${#staged_py[@]}" -eq 0 ] && exit 0
 
 echo "pre-commit: formatting ${#staged_py[@]} staged Python file(s)..."

--- a/src/luthien_proxy/policies/simple_llm_policy.py
+++ b/src/luthien_proxy/policies/simple_llm_policy.py
@@ -95,6 +95,7 @@ class _SimpleLLMAnthropicState:
     emitted_blocks: list[BlockDescriptor] = field(default_factory=list)
     original_had_tool_use: bool = False
     judge_error_occurred: bool = False
+    max_emitted_index: int = -1
 
 
 class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
@@ -387,6 +388,7 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
 
             if action.action == "pass":
                 state.emitted_blocks.append(descriptor)
+                state.max_emitted_index = max(state.max_emitted_index, index)
                 events: list[MessageStreamEvent] = []
                 if pending_start is not None:
                     events.append(pending_start)
@@ -415,6 +417,7 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
 
             if action.action == "pass":
                 state.emitted_blocks.append(descriptor)
+                state.max_emitted_index = max(state.max_emitted_index, index)
                 return self._emit_anthropic_tool_events(index, buffered, event)
             elif action.action == "replace":
                 return self._emit_anthropic_replacement_events(index, action, state, event)
@@ -425,6 +428,7 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             else:
                 blocked_text = _blocked_tool_message(buffered.name)
             state.emitted_blocks.append(self._block_descriptor_from_text(blocked_text))
+            state.max_emitted_index = max(state.max_emitted_index, index)
             return self._make_anthropic_text_block_events(index, blocked_text)
 
         return [cast(MessageStreamEvent, event)]
@@ -443,7 +447,7 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
 
         # Inject judge-unavailable warning as a content block before message_delta
         if state.judge_error_occurred and self._config.on_error == "pass":
-            warning_index = len(state.emitted_blocks)
+            warning_index = state.max_emitted_index + 1
             events.extend(self._make_anthropic_warning_events(warning_index))
         elif state.judge_error_occurred and not state.emitted_blocks:
             events.extend(self._make_anthropic_text_block_events(0, JUDGE_ERROR_BLOCKED_MESSAGE))
@@ -557,6 +561,7 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
                     ]
                 )
 
+            state.max_emitted_index = max(state.max_emitted_index, current_index)
             current_index += 1
 
         return events

--- a/src/luthien_proxy/policies/simple_llm_policy.py
+++ b/src/luthien_proxy/policies/simple_llm_policy.py
@@ -189,6 +189,7 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
         descriptor: BlockDescriptor,
         emitted_blocks: list[BlockDescriptor],
         context: "PolicyContext",
+        upstream_index: int = 0,
     ) -> JudgeAction:
         """Call the judge LLM.
 
@@ -219,7 +220,7 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
                 extra={
                     "transaction_id": context.transaction_id,
                     "block_type": descriptor.type,
-                    "block_index": len(emitted_blocks),
+                    "upstream_index": upstream_index,
                 },
             )
             context.record_event(
@@ -387,11 +388,14 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             # block (start + stop with no content) produces {"type":"text","text":""}
             # in the client's conversation history, which Anthropic rejects with
             # 400 "text content blocks must be non-empty" on the next turn.
+            # Skipping the judge here is intentional: an empty block has no
+            # content to evaluate, so state.emitted_blocks and
+            # state.judge_error_occurred are deliberately left unchanged.
             if not text:
                 return []
 
             descriptor = self._block_descriptor_from_text(text)
-            action = await self._judge_block(descriptor, state.emitted_blocks, context)
+            action = await self._judge_block(descriptor, state.emitted_blocks, context, upstream_index=index)
             if action.judge_failed:
                 state.judge_error_occurred = True
 
@@ -427,7 +431,7 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
                 logger.warning(f"Malformed tool input JSON for '{buffered.name}', using raw string")
                 input_data = {"_raw": buffered.input_json}
             descriptor = self._block_descriptor_from_tool(buffered.name, input_data)
-            action = await self._judge_block(descriptor, state.emitted_blocks, context)
+            action = await self._judge_block(descriptor, state.emitted_blocks, context, upstream_index=index)
             if action.judge_failed:
                 state.judge_error_occurred = True
 
@@ -527,6 +531,10 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
         action: JudgeAction,
         state: _SimpleLLMAnthropicState,
     ) -> list[MessageStreamEvent]:
+        # If action.blocks is empty/None the loop never runs: the upstream block's
+        # index slot is silently dropped (num_emitted == 0, index_shift unchanged).
+        # This is a deliberate "0-block replace = suppress" — the validator only
+        # requires strictly monotonic index starts, so a gap is valid.
         events: list[MessageStreamEvent] = []
         current_index = emitted_index
 
@@ -579,6 +587,8 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             current_index += 1
 
         num_emitted = current_index - emitted_index
+        # Only shift when N > 1: a 1-for-1 replacement consumes the same upstream
+        # index slot it came from, so downstream indices are unaffected.
         if num_emitted > 1:
             state.index_shift += num_emitted - 1
 

--- a/src/luthien_proxy/policies/simple_llm_policy.py
+++ b/src/luthien_proxy/policies/simple_llm_policy.py
@@ -515,41 +515,50 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
         state: _SimpleLLMAnthropicState,
         stop_event: RawContentBlockStopEvent,
     ) -> list[MessageStreamEvent]:
-        """Emit replacement block events."""
+        """Emit replacement block events with monotonically increasing indices."""
         events: list[MessageStreamEvent] = []
+        current_index = index
 
         for rblock in action.blocks or ():
             state.emitted_blocks.append(self._block_descriptor_from_replacement(rblock))
+            block_stop = RawContentBlockStopEvent(type="content_block_stop", index=current_index)
 
             if rblock.type == "text":
                 text_block = TextBlock(type="text", text="")
-                start = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=text_block)
+                start = RawContentBlockStartEvent(
+                    type="content_block_start", index=current_index, content_block=text_block
+                )
                 text_delta = TextDelta.model_construct(type="text_delta", text=rblock.text or "")
                 delta = RawContentBlockDeltaEvent.model_construct(
-                    type="content_block_delta", index=index, delta=text_delta
+                    type="content_block_delta", index=current_index, delta=text_delta
                 )
                 events.extend(
                     [
                         cast(MessageStreamEvent, start),
                         cast(MessageStreamEvent, delta),
+                        cast(MessageStreamEvent, block_stop),
                     ]
                 )
 
             elif rblock.type == "tool_use":
                 tool_id = f"toolu_{uuid4().hex[:24]}"
                 tool_block = ToolUseBlock(type="tool_use", id=tool_id, name=rblock.name or "", input={})
-                start = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=tool_block)
+                start = RawContentBlockStartEvent(
+                    type="content_block_start", index=current_index, content_block=tool_block
+                )
                 json_str = json.dumps(rblock.input or {})
                 json_delta = InputJSONDelta(type="input_json_delta", partial_json=json_str)
-                delta = RawContentBlockDeltaEvent(type="content_block_delta", index=index, delta=json_delta)
+                delta = RawContentBlockDeltaEvent(type="content_block_delta", index=current_index, delta=json_delta)
                 events.extend(
                     [
                         cast(MessageStreamEvent, start),
                         cast(MessageStreamEvent, delta),
+                        cast(MessageStreamEvent, block_stop),
                     ]
                 )
 
-        events.append(cast(MessageStreamEvent, stop_event))
+            current_index += 1
+
         return events
 
     async def on_anthropic_streaming_policy_complete(self, context: "PolicyContext") -> None:

--- a/src/luthien_proxy/policies/simple_llm_policy.py
+++ b/src/luthien_proxy/policies/simple_llm_policy.py
@@ -213,7 +213,15 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             )
             return result
         except Exception as exc:
-            logger.error(f"SimpleLLM judge failed: {exc}", exc_info=True)
+            logger.error(
+                f"SimpleLLM judge failed: {exc}",
+                exc_info=True,
+                extra={
+                    "transaction_id": context.transaction_id,
+                    "block_type": descriptor.type,
+                    "block_index": len(emitted_blocks),
+                },
+            )
             context.record_event(
                 "policy.simple_llm.judge_error",
                 {

--- a/src/luthien_proxy/policies/simple_llm_policy.py
+++ b/src/luthien_proxy/policies/simple_llm_policy.py
@@ -96,6 +96,7 @@ class _SimpleLLMAnthropicState:
     original_had_tool_use: bool = False
     judge_error_occurred: bool = False
     max_emitted_index: int = -1
+    index_shift: int = 0  # cumulative offset from multi-block replacements (N blocks → shift += N-1)
 
 
 class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
@@ -386,16 +387,23 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             if action.judge_failed:
                 state.judge_error_occurred = True
 
+            emitted_index = index + state.index_shift
             if action.action == "pass":
                 state.emitted_blocks.append(descriptor)
-                state.max_emitted_index = max(state.max_emitted_index, index)
+                state.max_emitted_index = max(state.max_emitted_index, emitted_index)
                 events: list[MessageStreamEvent] = []
                 if pending_start is not None:
-                    events.append(pending_start)
-                events.extend(self._emit_anthropic_text_events(index, text, event))
+                    orig_start = cast(RawContentBlockStartEvent, pending_start)
+                    shifted_start = RawContentBlockStartEvent(
+                        type="content_block_start",
+                        index=emitted_index,
+                        content_block=orig_start.content_block,
+                    )
+                    events.append(cast(MessageStreamEvent, shifted_start))
+                events.extend(self._emit_anthropic_text_events(emitted_index, text))
                 return events
             elif action.action == "replace":
-                return self._emit_anthropic_replacement_events(index, action, state, event)
+                return self._emit_anthropic_replacement_events(emitted_index, action, state)
             # Judge blocked the text block — suppress entirely (pending_start was
             # never emitted, so there's nothing to close).
             return []
@@ -415,12 +423,13 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             if action.judge_failed:
                 state.judge_error_occurred = True
 
+            emitted_index = index + state.index_shift
             if action.action == "pass":
                 state.emitted_blocks.append(descriptor)
-                state.max_emitted_index = max(state.max_emitted_index, index)
-                return self._emit_anthropic_tool_events(index, buffered, event)
+                state.max_emitted_index = max(state.max_emitted_index, emitted_index)
+                return self._emit_anthropic_tool_events(emitted_index, buffered)
             elif action.action == "replace":
-                return self._emit_anthropic_replacement_events(index, action, state, event)
+                return self._emit_anthropic_replacement_events(emitted_index, action, state)
             # Tool start was suppressed — emit a text block so the client
             # knows the tool call was blocked and can continue the conversation.
             if action.judge_failed:
@@ -428,8 +437,8 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             else:
                 blocked_text = _blocked_tool_message(buffered.name)
             state.emitted_blocks.append(self._block_descriptor_from_text(blocked_text))
-            state.max_emitted_index = max(state.max_emitted_index, index)
-            return self._make_anthropic_text_block_events(index, blocked_text)
+            state.max_emitted_index = max(state.max_emitted_index, emitted_index)
+            return self._make_anthropic_text_block_events(emitted_index, blocked_text)
 
         return [cast(MessageStreamEvent, event)]
 
@@ -465,30 +474,22 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
         events.append(cast(MessageStreamEvent, event))
         return events
 
-    def _emit_anthropic_text_events(
-        self,
-        index: int,
-        text: str,
-        stop_event: RawContentBlockStopEvent,
-    ) -> list[MessageStreamEvent]:
-        """Emit buffered text as a single delta + stop."""
+    def _emit_anthropic_text_events(self, index: int, text: str) -> list[MessageStreamEvent]:
+        """Emit buffered text as a single delta + stop at the given index."""
         text_delta = TextDelta.model_construct(type="text_delta", text=text)
         delta_event = RawContentBlockDeltaEvent.model_construct(
             type="content_block_delta", index=index, delta=text_delta
         )
+        stop_event = RawContentBlockStopEvent(type="content_block_stop", index=index)
         return [cast(MessageStreamEvent, delta_event), cast(MessageStreamEvent, stop_event)]
 
-    def _emit_anthropic_tool_events(
-        self,
-        index: int,
-        buffered: _BufferedToolUse,
-        stop_event: RawContentBlockStopEvent,
-    ) -> list[MessageStreamEvent]:
-        """Reconstruct tool_use block events: start + json delta + stop."""
+    def _emit_anthropic_tool_events(self, index: int, buffered: _BufferedToolUse) -> list[MessageStreamEvent]:
+        """Reconstruct tool_use block events: start + json delta + stop at the given index."""
         tool_block = ToolUseBlock(type="tool_use", id=buffered.id, name=buffered.name, input={})
         start_event = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=tool_block)
         json_delta = InputJSONDelta(type="input_json_delta", partial_json=buffered.input_json or "{}")
         delta_event = RawContentBlockDeltaEvent(type="content_block_delta", index=index, delta=json_delta)
+        stop_event = RawContentBlockStopEvent(type="content_block_stop", index=index)
         return [
             cast(MessageStreamEvent, start_event),
             cast(MessageStreamEvent, delta_event),
@@ -514,17 +515,14 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
 
     def _emit_anthropic_replacement_events(
         self,
-        index: int,
+        emitted_index: int,
         action: JudgeAction,
         state: _SimpleLLMAnthropicState,
-        stop_event: RawContentBlockStopEvent,
     ) -> list[MessageStreamEvent]:
-        """Emit replacement block events with monotonically increasing indices."""
         events: list[MessageStreamEvent] = []
-        current_index = index
+        current_index = emitted_index
 
         for rblock in action.blocks or ():
-            state.emitted_blocks.append(self._block_descriptor_from_replacement(rblock))
             block_stop = RawContentBlockStopEvent(type="content_block_stop", index=current_index)
 
             if rblock.type == "text":
@@ -561,8 +559,20 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
                     ]
                 )
 
+            else:
+                logger.warning(
+                    "SimpleLLMPolicy: unknown replacement block type %r — skipping, index not consumed",
+                    rblock.type,
+                )
+                continue
+
+            state.emitted_blocks.append(self._block_descriptor_from_replacement(rblock))
             state.max_emitted_index = max(state.max_emitted_index, current_index)
             current_index += 1
+
+        num_emitted = current_index - emitted_index
+        if num_emitted > 1:
+            state.index_shift += num_emitted - 1
 
         return events
 

--- a/src/luthien_proxy/policies/tool_call_judge_policy.py
+++ b/src/luthien_proxy/policies/tool_call_judge_policy.py
@@ -35,6 +35,7 @@ from anthropic.types import (
     RawContentBlockDeltaEvent,
     RawContentBlockStartEvent,
     RawContentBlockStopEvent,
+    RawMessageDeltaEvent,
     TextBlock,
     TextDelta,
     ToolUseBlock,
@@ -86,6 +87,7 @@ class _BufferedAnthropicToolUse:
 class _ToolCallJudgeAnthropicState:
     buffered_tool_uses: dict[int, _BufferedAnthropicToolUse] = field(default_factory=dict)
     blocked_blocks: set[int] = field(default_factory=set)
+    emitted_tool_indices: set[int] = field(default_factory=set)
 
 
 class ToolCallJudgeConfig(BaseModel):
@@ -277,6 +279,9 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
         elif isinstance(event, RawContentBlockStopEvent):
             return await self._handle_anthropic_content_block_stop(event, context)
 
+        elif isinstance(event, RawMessageDeltaEvent):
+            return self._handle_anthropic_message_delta(event, context)
+
         return [event]
 
     # ========================================================================
@@ -356,6 +361,7 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
 
         # Tool call allowed - reconstruct the full event sequence from buffered data
         logger.debug(f"Tool call '{tool_call['name']}' allowed, re-emitting buffered events")
+        self._anthropic_state(context).emitted_tool_indices.add(index)
         tool_use_block = ToolUseBlock(type="tool_use", id=buffered.id, name=buffered.name, input={})
         start_event = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=tool_use_block)
         json_delta = InputJSONDelta(type="input_json_delta", partial_json=buffered.input_json or "{}")
@@ -365,6 +371,22 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
             cast(MessageStreamEvent, delta_event),
             cast(MessageStreamEvent, event),
         ]
+
+    def _handle_anthropic_message_delta(
+        self,
+        event: RawMessageDeltaEvent,
+        context: "PolicyContext",
+    ) -> list[MessageStreamEvent]:
+        state = self._anthropic_state(context)
+        has_emitted_tool = bool(state.emitted_tool_indices)
+        expected_stop = "tool_use" if has_emitted_tool else "end_turn"
+        if event.delta.stop_reason == "tool_use" and not has_emitted_tool:
+            event = RawMessageDeltaEvent.model_construct(
+                type="message_delta",
+                delta=event.delta.model_copy(update={"stop_reason": expected_stop}),
+                usage=event.usage,
+            )
+        return [cast(MessageStreamEvent, event)]
 
     def _extract_tool_call_from_anthropic_block(self, block: "AnthropicToolUseBlock") -> ToolCallDict:
         """Extract tool call dict from a tool_use content block dict."""

--- a/src/luthien_proxy/policies/tool_call_judge_policy.py
+++ b/src/luthien_proxy/policies/tool_call_judge_policy.py
@@ -378,12 +378,10 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
         context: "PolicyContext",
     ) -> list[MessageStreamEvent]:
         state = self._anthropic_state(context)
-        has_emitted_tool = bool(state.emitted_tool_indices)
-        expected_stop = "tool_use" if has_emitted_tool else "end_turn"
-        if event.delta.stop_reason == "tool_use" and not has_emitted_tool:
+        if event.delta.stop_reason == "tool_use" and not state.emitted_tool_indices:
             event = RawMessageDeltaEvent.model_construct(
                 type="message_delta",
-                delta=event.delta.model_copy(update={"stop_reason": expected_stop}),
+                delta=event.delta.model_copy(update={"stop_reason": "end_turn"}),
                 usage=event.usage,
             )
         return [cast(MessageStreamEvent, event)]

--- a/src/luthien_proxy/policies/tool_call_judge_policy.py
+++ b/src/luthien_proxy/policies/tool_call_judge_policy.py
@@ -379,6 +379,13 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
     ) -> list[MessageStreamEvent]:
         state = self._anthropic_state(context)
         if event.delta.stop_reason == "tool_use" and not state.emitted_tool_indices:
+            logger.info(
+                "Rewriting stop_reason tool_use -> end_turn (all tool calls blocked)",
+                extra={
+                    "transaction_id": context.transaction_id,
+                    "emitted_tool_indices": list(state.emitted_tool_indices),
+                },
+            )
             event = RawMessageDeltaEvent.model_construct(
                 type="message_delta",
                 delta=event.delta.model_copy(update={"stop_reason": "end_turn"}),

--- a/src/luthien_proxy/policies/tool_call_judge_policy.py
+++ b/src/luthien_proxy/policies/tool_call_judge_policy.py
@@ -381,10 +381,7 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
         if event.delta.stop_reason == "tool_use" and not state.emitted_tool_indices:
             logger.info(
                 "Rewriting stop_reason tool_use -> end_turn (all tool calls blocked)",
-                extra={
-                    "transaction_id": context.transaction_id,
-                    "emitted_tool_indices": list(state.emitted_tool_indices),
-                },
+                extra={"transaction_id": context.transaction_id},
             )
             event = RawMessageDeltaEvent.model_construct(
                 type="message_delta",

--- a/tests/luthien_proxy/e2e_tests/test_mock_simple_llm_single_tool.py
+++ b/tests/luthien_proxy/e2e_tests/test_mock_simple_llm_single_tool.py
@@ -79,3 +79,44 @@ async def test_single_tool_use_with_judge_failure_event_ordering(
     assert len(turn.tool_calls) == 1
     validate_anthropic_event_ordering(turn.raw_events).assert_valid()
     assert turn.stop_reason == "tool_use"
+
+
+@pytest.mark.asyncio
+async def test_yash_scrapling_install_scenario_session_survives(
+    mock_anthropic: MockAnthropicServer,
+    gateway_healthy,
+    gateway_url,
+    api_key,
+    admin_api_key,
+):
+    """Regression test for issue #708: Yash's 'install Scrapling' scenario.
+
+    Customer: Yash (RealPage), 2026-05-06 live trial.
+    Symptom: 'safety judgment unavailable — API 400' after judge failure on tool call.
+
+    Scenario: Claude attempts `pip install scrapling` (a Bash tool call). The judge
+    fails (unreachable URL, simulating API 400 due to concurrency issues as observed
+    in the trial). The session must survive — turn 2 (the follow-up with the tool
+    result) must succeed without a 400 error, and streaming event ordering must be
+    valid throughout.
+    """
+    mock_anthropic.enqueue(tool_response("Bash", {"command": "pip install scrapling"}))
+    mock_anthropic.enqueue(text_response("Scrapling has been set up. Ready to use."))
+
+    config = {**_UNREACHABLE_JUDGE, "on_error": "pass"}
+
+    async with policy_context(_SIMPLE_LLM_POLICY, config, gateway_url=gateway_url, admin_api_key=admin_api_key):
+        session = ClaudeCodeSimulator(gateway_url, api_key)
+        turn1 = await session.send("install Scrapling")
+
+        assert len(turn1.tool_calls) == 1, f"Expected 1 tool call, got {turn1.tool_calls}"
+        assert turn1.stop_reason == "tool_use"
+        assert "Safety judge unavailable" in turn1.text
+        validate_anthropic_event_ordering(turn1.raw_events).assert_valid()
+
+        turn2 = await session.continue_with_tool_result(
+            turn1.tool_calls[0].id,
+            "Successfully installed scrapling-0.4.0",
+        )
+
+        assert turn2.text, f"Turn 2 must return a non-empty response, got: {turn2.text!r}"

--- a/tests/luthien_proxy/e2e_tests/test_mock_simple_llm_single_tool.py
+++ b/tests/luthien_proxy/e2e_tests/test_mock_simple_llm_single_tool.py
@@ -1,0 +1,81 @@
+"""E2E tests: single tool_use with judge failure (on_error=pass).
+
+Scenario:
+  1. Backend responds with a single Bash tool_use block
+  2. Judge fails (unreachable URL) → warning injected, tool passes through (on_error=pass)
+  3. Client sends tool_result
+  4. Backend responds with text
+  5. Session must remain functional (no 400)
+
+Run:
+    ./scripts/run_e2e.sh mock
+    # or directly:
+    uv run pytest -m mock_e2e tests/luthien_proxy/e2e_tests/test_mock_simple_llm_single_tool.py -v
+"""
+
+import pytest
+from tests.luthien_proxy.e2e_tests.conftest import policy_context
+from tests.luthien_proxy.e2e_tests.mock_anthropic.responses import text_response, tool_response
+from tests.luthien_proxy.e2e_tests.mock_anthropic.server import MockAnthropicServer
+from tests.luthien_proxy.e2e_tests.mock_anthropic.simulator import ClaudeCodeSimulator
+from tests.luthien_proxy.fixtures.anthropic_stream_validator import validate_anthropic_event_ordering
+
+pytestmark = pytest.mark.mock_e2e
+
+_SIMPLE_LLM_POLICY = "luthien_proxy.policies.simple_llm_policy:SimpleLLMPolicy"
+
+_UNREACHABLE_JUDGE = {
+    "instructions": "Block all content",
+    "model": "claude-haiku-4-5",
+    "api_base": "http://127.0.0.1:19999",
+    "auth_provider": "user_credentials",
+}
+
+
+@pytest.mark.asyncio
+async def test_single_tool_use_with_judge_failure_session_survives(
+    mock_anthropic: MockAnthropicServer,
+    gateway_healthy,
+    gateway_url,
+    api_key,
+    admin_api_key,
+):
+    """Single tool + judge failure (on_error=pass): turn 2 with tool_result must succeed."""
+    mock_anthropic.enqueue(tool_response("Bash", {"command": "ls"}))
+    mock_anthropic.enqueue(text_response("ls output: file1.txt file2.txt"))
+
+    config = {**_UNREACHABLE_JUDGE, "on_error": "pass"}
+
+    async with policy_context(_SIMPLE_LLM_POLICY, config, gateway_url=gateway_url, admin_api_key=admin_api_key):
+        session = ClaudeCodeSimulator(gateway_url, api_key)
+        turn1 = await session.send("List the files")
+
+        assert len(turn1.tool_calls) == 1, f"Expected 1 tool call, got {turn1.tool_calls}"
+        assert turn1.stop_reason == "tool_use"
+        assert "Safety judge unavailable" in turn1.text
+
+        turn2 = await session.continue_with_tool_result(turn1.tool_calls[0].id, "file1.txt\nfile2.txt")
+
+        assert "file" in turn2.text.lower(), f"Expected tool result response, got: {turn2.text!r}"
+
+
+@pytest.mark.asyncio
+async def test_single_tool_use_with_judge_failure_event_ordering(
+    mock_anthropic: MockAnthropicServer,
+    gateway_healthy,
+    gateway_url,
+    api_key,
+    admin_api_key,
+):
+    """Streaming event ordering must be valid when judge fails on a single tool_use."""
+    mock_anthropic.enqueue(tool_response("Bash", {"command": "echo hello"}))
+
+    config = {**_UNREACHABLE_JUDGE, "on_error": "pass"}
+
+    async with policy_context(_SIMPLE_LLM_POLICY, config, gateway_url=gateway_url, admin_api_key=admin_api_key):
+        session = ClaudeCodeSimulator(gateway_url, api_key)
+        turn = await session.send("Echo hello")
+
+    assert len(turn.tool_calls) == 1
+    validate_anthropic_event_ordering(turn.raw_events).assert_valid()
+    assert turn.stop_reason == "tool_use"

--- a/tests/luthien_proxy/e2e_tests/test_mock_tool_call_judge_blocked.py
+++ b/tests/luthien_proxy/e2e_tests/test_mock_tool_call_judge_blocked.py
@@ -1,0 +1,63 @@
+"""E2E test: ToolCallJudgePolicy must correct stop_reason when all tools are blocked.
+
+H5 regression: when ToolCallJudgePolicy blocks all tools in a streaming response,
+the message_delta stop_reason must be corrected from 'tool_use' to 'end_turn'.
+
+Without the fix, the stream emits stop_reason='tool_use' with zero tool_use blocks,
+which causes the Anthropic API to reject the next turn with 400.
+
+Run:
+    ./scripts/run_e2e.sh mock
+    # or directly:
+    uv run pytest -m mock_e2e tests/luthien_proxy/e2e_tests/test_mock_tool_call_judge_blocked.py -v
+"""
+
+import pytest
+from tests.luthien_proxy.e2e_tests.conftest import policy_context
+from tests.luthien_proxy.e2e_tests.mock_anthropic.responses import text_response, tool_response
+from tests.luthien_proxy.e2e_tests.mock_anthropic.server import MockAnthropicServer
+from tests.luthien_proxy.e2e_tests.mock_anthropic.simulator import ClaudeCodeSimulator
+
+pytestmark = pytest.mark.mock_e2e
+
+_TOOL_JUDGE_POLICY = "luthien_proxy.policies.tool_call_judge_policy:ToolCallJudgePolicy"
+
+_BLOCKING_JUDGE_CONFIG = {
+    "auth_provider": "user_credentials",
+    "api_base": "http://127.0.0.1:19999",
+    "probability_threshold": 0.5,
+}
+
+
+@pytest.mark.asyncio
+async def test_tool_call_judge_blocks_single_tool_session_continues(
+    mock_anthropic: MockAnthropicServer,
+    gateway_healthy,
+    gateway_url,
+    api_key,
+    admin_api_key,
+):
+    """H5: ToolCallJudgePolicy blocks all tools → stop_reason corrected to 'end_turn'.
+
+    The judge is unreachable (probability=1.0 fail-secure) so all tools are blocked.
+    Turn 1 stop_reason must be 'end_turn', not 'tool_use'.
+    Turn 2 (follow-up user message) must succeed.
+    """
+    mock_anthropic.enqueue(tool_response("Bash", {"command": "ls"}))
+    mock_anthropic.enqueue(text_response("I blocked that tool call."))
+
+    async with policy_context(
+        _TOOL_JUDGE_POLICY, _BLOCKING_JUDGE_CONFIG, gateway_url=gateway_url, admin_api_key=admin_api_key
+    ):
+        session = ClaudeCodeSimulator(gateway_url, api_key)
+        turn1 = await session.send("Run ls")
+
+        assert len(turn1.tool_calls) == 0, f"Blocked tool must not appear as tool_call, got {turn1.tool_calls}"
+        assert turn1.stop_reason == "end_turn", (
+            f"Expected 'end_turn' after all tools blocked, got {turn1.stop_reason!r}; "
+            "this is the H5 bug: stop_reason='tool_use' with no tool_use blocks"
+        )
+
+        turn2 = await session.send("Never mind, just tell me what happened")
+
+        assert turn2.text, f"Turn 2 must return a response, got: {turn2.text!r}"

--- a/tests/luthien_proxy/unit_tests/policies/anthropic_event_builders.py
+++ b/tests/luthien_proxy/unit_tests/policies/anthropic_event_builders.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 from anthropic.lib.streaming import MessageStreamEvent
 from anthropic.types import (
     InputJSONDelta,
+    Message,
     RawContentBlockDeltaEvent,
     RawContentBlockStartEvent,
     RawContentBlockStopEvent,
     RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawMessageStopEvent,
     TextBlock,
     TextDelta,
     ToolUseBlock,
@@ -69,3 +72,22 @@ def message_delta(stop_reason: str = "end_turn") -> RawMessageDeltaEvent:
 def event_types(events: list[MessageStreamEvent]) -> list[str]:
     """Extract event type strings for easy assertion."""
     return [getattr(e, "type", None) for e in events]
+
+
+def full_stream(events: list) -> list:
+    """Wrap events in message_start + ... + message_stop for the stream validator."""
+    message_start = RawMessageStartEvent(
+        type="message_start",
+        message=Message.model_construct(
+            type="message",
+            id="test",
+            role="assistant",
+            content=[],
+            model="claude-haiku",
+            stop_reason=None,
+            stop_sequence=None,
+            usage=Usage(input_tokens=1, output_tokens=1),
+        ),
+    )
+    message_stop = RawMessageStopEvent(type="message_stop")
+    return [message_start, *events, message_stop]

--- a/tests/luthien_proxy/unit_tests/policies/test_simple_llm_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_simple_llm_policy.py
@@ -13,13 +13,18 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from anthropic.lib.streaming import MessageStreamEvent
 from anthropic.types import (
+    Message,
     RawContentBlockDeltaEvent,
     RawContentBlockStartEvent,
     RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawMessageStopEvent,
     TextBlock,
     TextDelta,
     ToolUseBlock,
+    Usage,
 )
+from tests.luthien_proxy.fixtures.anthropic_stream_validator import validate_anthropic_event_ordering
 from tests.luthien_proxy.unit_tests.policies.anthropic_event_builders import (
     block_stop,
     event_types,
@@ -58,6 +63,25 @@ def _make_policy(on_error: str = "block") -> SimpleLLMPolicy:
 
 def _make_context() -> PolicyContext:
     return PolicyContext.for_testing(transaction_id="test-txn")
+
+
+def _full_stream(events: list) -> list:
+    """Wrap events in message_start + ... + message_stop for the stream validator."""
+    message_start = RawMessageStartEvent(
+        type="message_start",
+        message=Message.model_construct(
+            type="message",
+            id="test",
+            role="assistant",
+            content=[],
+            model="claude-haiku",
+            stop_reason=None,
+            stop_sequence=None,
+            usage=Usage(input_tokens=1, output_tokens=1),
+        ),
+    )
+    message_stop = RawMessageStopEvent(type="message_stop")
+    return [message_start, *events, message_stop]
 
 
 # ============================================================================
@@ -569,3 +593,153 @@ class TestJudgeErrorEmptyResponseInjection:
             e for e in msg_events if isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, TextDelta)
         ]
         assert any(JUDGE_ERROR_BLOCKED_MESSAGE in d.delta.text for d in error_deltas)
+
+
+# ============================================================================
+# H2: multi-block replacement indices
+# ============================================================================
+
+
+class TestMultiBlockReplacementIndices:
+    @pytest.mark.asyncio
+    async def test_replacement_with_multiple_blocks_uses_monotonic_indices(self):
+        """H2 regression: two replacement blocks must use indices [0, 1], not [0, 0]."""
+        policy = _make_policy()
+        ctx = _make_context()
+
+        blocks = (
+            ReplacementBlock(type="text", text="A"),
+            ReplacementBlock(type="text", text="B"),
+        )
+        with patch.object(policy, "_judge_block", new_callable=AsyncMock) as mock_judge:
+            mock_judge.return_value = JudgeAction(action="replace", blocks=blocks)
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"command":"ls"}', 0)), ctx)
+            stop_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+            msg_events = await policy.on_anthropic_stream_event(
+                cast(MessageStreamEvent, message_delta("tool_use")), ctx
+            )
+
+        all_events = stop_events + msg_events
+        start_indices = [e.index for e in all_events if isinstance(e, RawContentBlockStartEvent)]
+
+        assert len(start_indices) == 2, f"Expected 2 replacement blocks, got {len(start_indices)}"
+        assert start_indices[0] < start_indices[1], (
+            f"Replacement block indices must be monotonically increasing, got {start_indices}"
+        )
+
+        validate_anthropic_event_ordering(_full_stream(all_events)).assert_valid()
+
+
+# ============================================================================
+# H1: empty preamble + blocked tool index
+# ============================================================================
+
+
+class TestEmptyPreambleBlockedTool:
+    @pytest.mark.asyncio
+    async def test_empty_preamble_then_blocked_tool_does_not_reuse_index(self):
+        """H1 regression: blocked tool at idx 1 (preamble at idx 0 suppressed) emits correct stream."""
+        policy = _make_policy(on_error="block")
+        ctx = _make_context()
+
+        with patch.object(policy, "_judge_block", new_callable=AsyncMock) as mock_judge:
+            mock_judge.return_value = JudgeAction(action="block")
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, text_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, text_delta("", 0)), ctx)
+            preamble_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+            assert preamble_events == [], "Empty preamble must be fully suppressed"
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(1)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta("{}", 1)), ctx)
+            tool_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(1)), ctx)
+
+            msg_events = await policy.on_anthropic_stream_event(
+                cast(MessageStreamEvent, message_delta("tool_use")), ctx
+            )
+
+        assert event_types(tool_events) == ["content_block_start", "content_block_delta", "content_block_stop"]
+        start = tool_events[0]
+        assert isinstance(start, RawContentBlockStartEvent)
+        assert start.index == 1, f"Blocked text must be at idx 1, got {start.index}"
+
+        delta_ev = next(e for e in msg_events if isinstance(e, RawMessageDeltaEvent))
+        assert delta_ev.delta.stop_reason == "end_turn"
+
+        all_events = tool_events + msg_events
+        validate_anthropic_event_ordering(_full_stream(all_events)).assert_valid()
+
+
+# ============================================================================
+# H3: warning index with single tool + judge failure
+# ============================================================================
+
+
+class TestWarningIndexNoCollision:
+    @pytest.mark.asyncio
+    async def test_single_tool_judge_failure_warning_index_no_collision(self):
+        """H3 regression: no preamble, tool at idx 0, judge fails (on_error=pass).
+        Warning must be at idx 1, not idx 0 (collision with emitted tool).
+        """
+        policy = _make_policy(on_error="pass")
+        ctx = _make_context()
+
+        with patch.object(policy, "_judge_block", new_callable=AsyncMock) as mock_judge:
+            mock_judge.return_value = JudgeAction(action="pass", judge_failed=True)
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"command":"ls"}', 0)), ctx)
+            tool_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+            msg_events = await policy.on_anthropic_stream_event(
+                cast(MessageStreamEvent, message_delta("tool_use")), ctx
+            )
+
+        all_events = tool_events + msg_events
+        start_indices = [e.index for e in all_events if isinstance(e, RawContentBlockStartEvent)]
+
+        assert start_indices == [0, 1], f"Expected tool@0 and warning@1, got {start_indices}"
+
+        delta_ev = next(e for e in msg_events if isinstance(e, RawMessageDeltaEvent))
+        assert delta_ev.delta.stop_reason == "tool_use"
+
+        validate_anthropic_event_ordering(_full_stream(all_events)).assert_valid()
+
+
+# ============================================================================
+# H6: block mode + judge failure on tool emits judge-failed text
+# ============================================================================
+
+
+class TestBlockModeJudgeFailureTool:
+    @pytest.mark.asyncio
+    async def test_block_mode_judge_failure_on_tool_emits_judge_failed_text(self):
+        """H6 regression: on_error='block' + judge failure → judge-failed blocked message, no warning."""
+        policy = _make_policy(on_error="block")
+        ctx = _make_context()
+
+        with patch.object(policy, "_judge_block", new_callable=AsyncMock) as mock_judge:
+            mock_judge.return_value = JudgeAction(action="block", judge_failed=True)
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"command":"ls"}', 0)), ctx)
+            tool_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+            msg_events = await policy.on_anthropic_stream_event(
+                cast(MessageStreamEvent, message_delta("tool_use")), ctx
+            )
+
+        assert event_types(tool_events) == ["content_block_start", "content_block_delta", "content_block_stop"]
+        delta = next(e for e in tool_events if isinstance(e, RawContentBlockDeltaEvent))
+        assert isinstance(delta.delta, TextDelta)
+        assert "Bash" in delta.delta.text
+        assert "policy evaluation unavailable" in delta.delta.text
+
+        warning_in_msg = any(isinstance(e, RawContentBlockStartEvent) for e in msg_events)
+        assert not warning_in_msg, "No warning block should be injected in block mode with judge failure"
+
+        delta_ev = next(e for e in msg_events if isinstance(e, RawMessageDeltaEvent))
+        assert delta_ev.delta.stop_reason == "end_turn"
+
+        all_events = tool_events + msg_events
+        validate_anthropic_event_ordering(_full_stream(all_events)).assert_valid()

--- a/tests/luthien_proxy/unit_tests/policies/test_simple_llm_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_simple_llm_policy.py
@@ -13,21 +13,18 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from anthropic.lib.streaming import MessageStreamEvent
 from anthropic.types import (
-    Message,
     RawContentBlockDeltaEvent,
     RawContentBlockStartEvent,
     RawMessageDeltaEvent,
-    RawMessageStartEvent,
-    RawMessageStopEvent,
     TextBlock,
     TextDelta,
     ToolUseBlock,
-    Usage,
 )
 from tests.luthien_proxy.fixtures.anthropic_stream_validator import validate_anthropic_event_ordering
 from tests.luthien_proxy.unit_tests.policies.anthropic_event_builders import (
     block_stop,
     event_types,
+    full_stream,
     message_delta,
     text_delta,
     text_start,
@@ -63,25 +60,6 @@ def _make_policy(on_error: str = "block") -> SimpleLLMPolicy:
 
 def _make_context() -> PolicyContext:
     return PolicyContext.for_testing(transaction_id="test-txn")
-
-
-def _full_stream(events: list) -> list:
-    """Wrap events in message_start + ... + message_stop for the stream validator."""
-    message_start = RawMessageStartEvent(
-        type="message_start",
-        message=Message.model_construct(
-            type="message",
-            id="test",
-            role="assistant",
-            content=[],
-            model="claude-haiku",
-            stop_reason=None,
-            stop_sequence=None,
-            usage=Usage(input_tokens=1, output_tokens=1),
-        ),
-    )
-    message_stop = RawMessageStopEvent(type="message_stop")
-    return [message_start, *events, message_stop]
 
 
 # ============================================================================
@@ -629,7 +607,46 @@ class TestMultiBlockReplacementIndices:
             f"Replacement block indices must be monotonically increasing, got {start_indices}"
         )
 
-        validate_anthropic_event_ordering(_full_stream(all_events)).assert_valid()
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()
+
+    @pytest.mark.asyncio
+    async def test_replacement_then_passthrough_no_index_collision(self):
+        """Replacing one block with 2 then passing the next upstream block must not collide.
+
+        tool@0 → replace([A, B]) emits at [0, 1]; tool@1 → pass must emit at 2 (not 1).
+        """
+        policy = _make_policy()
+        ctx = _make_context()
+
+        replace_action = JudgeAction(
+            action="replace",
+            blocks=(ReplacementBlock(type="text", text="A"), ReplacementBlock(type="text", text="B")),
+        )
+        pass_action = JudgeAction(action="pass")
+
+        with patch.object(policy, "_judge_block", new_callable=AsyncMock) as mock_judge:
+            mock_judge.side_effect = [replace_action, pass_action]
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"cmd":"ls"}', 0)), ctx)
+            replace_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(1)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"cmd":"echo"}', 1)), ctx)
+            pass_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(1)), ctx)
+
+            msg_events = await policy.on_anthropic_stream_event(
+                cast(MessageStreamEvent, message_delta("tool_use")), ctx
+            )
+
+        all_events = replace_events + pass_events + msg_events
+        start_indices = [e.index for e in all_events if isinstance(e, RawContentBlockStartEvent)]
+
+        assert len(start_indices) == 3, f"Expected A, B, tool — got {start_indices}"
+        assert start_indices == sorted(set(start_indices)), (
+            f"Indices must be strictly increasing with no duplicates, got {start_indices}"
+        )
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()
 
 
 # ============================================================================
@@ -669,7 +686,7 @@ class TestEmptyPreambleBlockedTool:
         assert delta_ev.delta.stop_reason == "end_turn"
 
         all_events = tool_events + msg_events
-        validate_anthropic_event_ordering(_full_stream(all_events)).assert_valid()
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()
 
 
 # ============================================================================
@@ -704,7 +721,7 @@ class TestWarningIndexNoCollision:
         delta_ev = next(e for e in msg_events if isinstance(e, RawMessageDeltaEvent))
         assert delta_ev.delta.stop_reason == "tool_use"
 
-        validate_anthropic_event_ordering(_full_stream(all_events)).assert_valid()
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()
 
 
 # ============================================================================
@@ -742,4 +759,4 @@ class TestBlockModeJudgeFailureTool:
         assert delta_ev.delta.stop_reason == "end_turn"
 
         all_events = tool_events + msg_events
-        validate_anthropic_event_ordering(_full_stream(all_events)).assert_valid()
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()

--- a/tests/luthien_proxy/unit_tests/policies/test_string_replacement_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_string_replacement_policy.py
@@ -1485,9 +1485,7 @@ class TestRequestSideFiltering:
     @pytest.mark.asyncio
     async def test_empty_replacements_is_identity_passthrough(self):
         """apply_to='request' with empty replacements returns the original request."""
-        policy = StringReplacementPolicy(
-            config=StringReplacementConfig(replacements=[], apply_to="request")
-        )
+        policy = StringReplacementPolicy(config=StringReplacementConfig(replacements=[], apply_to="request"))
         ctx, _ = _ctx_with_recorder()
         request = _request_with_messages([{"role": "user", "content": "anything goes"}])
 

--- a/tests/luthien_proxy/unit_tests/policies/test_tool_call_judge_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_tool_call_judge_policy.py
@@ -14,12 +14,18 @@ import pytest
 from anthropic.lib.streaming import MessageStreamEvent
 from anthropic.types import (
     InputJSONDelta,
+    Message,
     RawContentBlockDeltaEvent,
     RawContentBlockStartEvent,
+    RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawMessageStopEvent,
     TextBlock,
     TextDelta,
     ToolUseBlock,
+    Usage,
 )
+from tests.luthien_proxy.fixtures.anthropic_stream_validator import validate_anthropic_event_ordering
 from tests.luthien_proxy.unit_tests.policies.anthropic_event_builders import (
     block_stop,
     event_types,
@@ -52,6 +58,25 @@ def _make_policy(**overrides) -> ToolCallJudgePolicy:
 def _make_context() -> PolicyContext:
     """Create a fresh PolicyContext for testing."""
     return PolicyContext.for_testing(transaction_id="test-txn")
+
+
+def _full_stream(events: list) -> list:
+    """Wrap events in message_start + ... + message_stop for the stream validator."""
+    message_start = RawMessageStartEvent(
+        type="message_start",
+        message=Message.model_construct(
+            type="message",
+            id="test",
+            role="assistant",
+            content=[],
+            model="claude-haiku",
+            stop_reason=None,
+            stop_sequence=None,
+            usage=Usage(input_tokens=1, output_tokens=1),
+        ),
+    )
+    message_stop = RawMessageStopEvent(type="message_stop")
+    return [message_start, *events, message_stop]
 
 
 # ============================================================================
@@ -634,3 +659,76 @@ class TestPolicyConfiguration:
         policy = _make_policy(judge_instructions=custom_instructions)
 
         assert policy._judge_instructions == custom_instructions
+
+
+# ============================================================================
+# H5: streaming stop_reason correction when all tools are blocked
+# ============================================================================
+
+
+class TestStreamingStopReasonCorrection:
+    @pytest.mark.asyncio
+    async def test_streaming_all_tools_blocked_corrects_stop_reason_to_end_turn(self):
+        """H5 regression: when all tools blocked in streaming, message_delta stop_reason must
+        be corrected from 'tool_use' to 'end_turn'.
+
+        Before fix: ToolCallJudgePolicy has no message_delta handler → stop_reason stays
+        'tool_use' with text-only content → API rejects next turn with 400.
+        """
+        policy = _make_policy()
+        ctx = _make_context()
+
+        judge_result = JudgeResult(probability=0.9, explanation="blocked", prompt=[], response_text="")
+        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+            mock_eval.return_value = judge_result
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"cmd":"x"}', 0)), ctx)
+            tool_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+
+            msg_events = await policy.on_anthropic_stream_event(
+                cast(MessageStreamEvent, message_delta("tool_use")), ctx
+            )
+
+        delta_ev = next(e for e in msg_events if isinstance(e, RawMessageDeltaEvent))
+        assert delta_ev.delta.stop_reason == "end_turn", (
+            f"Expected 'end_turn' but got {delta_ev.delta.stop_reason!r}; "
+            "ToolCallJudgePolicy must handle message_delta to correct stop_reason when all tools blocked"
+        )
+
+        all_events = tool_events + msg_events
+        validate_anthropic_event_ordering(_full_stream(all_events)).assert_valid()
+
+    @pytest.mark.asyncio
+    async def test_streaming_mixed_tools_partial_block_keeps_tool_use_stop_reason(self):
+        """H5 boundary: when some tool_use blocks remain (not all blocked), stop_reason stays 'tool_use'."""
+        policy = _make_policy()
+        ctx = _make_context()
+
+        judge_blocked = JudgeResult(probability=0.9, explanation="blocked", prompt=[], response_text="")
+        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+            mock_eval.side_effect = [None, judge_blocked]
+
+            await policy.on_anthropic_stream_event(
+                cast(MessageStreamEvent, tool_start(0, tool_id="toolu_0", name="Tool0")), ctx
+            )
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"x":1}', 0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+
+            await policy.on_anthropic_stream_event(
+                cast(MessageStreamEvent, tool_start(1, tool_id="toolu_1", name="Tool1")), ctx
+            )
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"y":2}', 1)), ctx)
+            tool1_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(1)), ctx)
+
+            msg_events = await policy.on_anthropic_stream_event(
+                cast(MessageStreamEvent, message_delta("tool_use")), ctx
+            )
+
+        delta_ev = next(e for e in msg_events if isinstance(e, RawMessageDeltaEvent))
+        assert delta_ev.delta.stop_reason == "tool_use", (
+            f"Expected 'tool_use' (some tools still emitted) but got {delta_ev.delta.stop_reason!r}"
+        )
+
+        all_events = tool1_events + msg_events
+        validate_anthropic_event_ordering(_full_stream(all_events)).assert_valid()

--- a/tests/luthien_proxy/unit_tests/policies/test_tool_call_judge_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_tool_call_judge_policy.py
@@ -14,21 +14,18 @@ import pytest
 from anthropic.lib.streaming import MessageStreamEvent
 from anthropic.types import (
     InputJSONDelta,
-    Message,
     RawContentBlockDeltaEvent,
     RawContentBlockStartEvent,
     RawMessageDeltaEvent,
-    RawMessageStartEvent,
-    RawMessageStopEvent,
     TextBlock,
     TextDelta,
     ToolUseBlock,
-    Usage,
 )
 from tests.luthien_proxy.fixtures.anthropic_stream_validator import validate_anthropic_event_ordering
 from tests.luthien_proxy.unit_tests.policies.anthropic_event_builders import (
     block_stop,
     event_types,
+    full_stream,
     message_delta,
     text_delta,
     text_start,
@@ -58,25 +55,6 @@ def _make_policy(**overrides) -> ToolCallJudgePolicy:
 def _make_context() -> PolicyContext:
     """Create a fresh PolicyContext for testing."""
     return PolicyContext.for_testing(transaction_id="test-txn")
-
-
-def _full_stream(events: list) -> list:
-    """Wrap events in message_start + ... + message_stop for the stream validator."""
-    message_start = RawMessageStartEvent(
-        type="message_start",
-        message=Message.model_construct(
-            type="message",
-            id="test",
-            role="assistant",
-            content=[],
-            model="claude-haiku",
-            stop_reason=None,
-            stop_sequence=None,
-            usage=Usage(input_tokens=1, output_tokens=1),
-        ),
-    )
-    message_stop = RawMessageStopEvent(type="message_stop")
-    return [message_start, *events, message_stop]
 
 
 # ============================================================================
@@ -697,7 +675,7 @@ class TestStreamingStopReasonCorrection:
         )
 
         all_events = tool_events + msg_events
-        validate_anthropic_event_ordering(_full_stream(all_events)).assert_valid()
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()
 
     @pytest.mark.asyncio
     async def test_streaming_mixed_tools_partial_block_keeps_tool_use_stop_reason(self):
@@ -731,4 +709,4 @@ class TestStreamingStopReasonCorrection:
         )
 
         all_events = tool1_events + msg_events
-        validate_anthropic_event_ordering(_full_stream(all_events)).assert_valid()
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()


### PR DESCRIPTION
## Summary

Fixes #708 — `safety judgment unavailable — API 400` when the judge blocks or fails on a tool call.

**Customer impact**: Yash (RealPage) hit this during a live trial on 2026-05-06 when asking Claude Code to install Scrapling. The session died with a 400 error after the judge failed to evaluate the `pip install scrapling` tool call.

## Root causes fixed

| Hypothesis | Status | Fix |
|---|---|---|
| H2: `_emit_anthropic_replacement_events` emits N replacement blocks at same index | **CONFIRMED** | Track `current_index` per block, increment after each |
| H3: Warning index uses `len(emitted_blocks)` which is wrong when preamble suppressed | **CONFIRMED** | Track `max_emitted_index`, use `max_emitted_index + 1` for warning |
| H5: `ToolCallJudgePolicy` streaming never corrects `stop_reason` when all tools blocked | **CONFIRMED** | Add `_handle_anthropic_message_delta` that corrects to `"end_turn"` |
| H1: Blocked tool emits text at non-consecutive index | **NEEDS TEST** (current behavior correct) | Regression guard added |
| H4: Non-streaming vs streaming stop_reason divergence | **RULED OUT** | — |
| H6: `on_error=block` + judge failure warning injection | **RULED OUT** (intentional) | — |

## New tests

**Unit tests** (in `test_simple_llm_policy.py` and `test_tool_call_judge_policy.py`):
- `test_replacement_with_multiple_blocks_uses_monotonic_indices` (H2 regression)
- `test_empty_preamble_then_blocked_tool_does_not_reuse_index` (H1 regression guard)
- `test_single_tool_judge_failure_warning_index_no_collision` (H3 regression guard)
- `test_block_mode_judge_failure_on_tool_emits_judge_failed_text` (H6 regression guard)
- `test_streaming_all_tools_blocked_corrects_stop_reason_to_end_turn` (H5 regression)
- `test_streaming_mixed_tools_partial_block_keeps_tool_use_stop_reason` (H5 boundary)

**Mock e2e tests** (new files):
- `test_mock_simple_llm_single_tool.py`: single-tool judge failure session survives, event ordering valid, Yash scrapling-install scenario
- `test_mock_tool_call_judge_blocked.py`: blocked single tool, session continues on next turn

## Verification

- `./scripts/dev_checks.sh`: PASS
- `./scripts/run_e2e.sh mock`: 136/137 (1 pre-existing unrelated failure in request-log fixture)
- Manual smoke: Yash scenario (pip install scrapling, judge unreachable) — session survives two turns

## Scope

Changes only in `src/luthien_proxy/policies/`, `tests/`, `changelog.d/`, and `dev/context/`.