### PR TITLE
feat: Before/After backend for admin policy test endpoint

### DIFF
--- a/changelog.d/before-after-backend.md
+++ b/changelog.d/before-after-backend.md
@@ -10,7 +10,19 @@ policy does what they think before activating it on real traffic.
   - The endpoint orchestrates the LLM call and policy hooks in-process and
     no longer makes an HTTP roundtrip to `/v1/messages`. The gateway request
     pipeline is untouched and there is no client-facing protocol opt-in.
-  - `body.api_key`, when supplied, is now sent directly to Anthropic
-    (previously it was used to authenticate against the local proxy).
+  - The test path constructs a full `PolicyContext` matching the one the
+    gateway pipeline builds (same emitter, credential manager, policy cache
+    factory, raw HTTP request, user credential shape). Judge-style policies
+    (LLM judges, `ToolCallJudgePolicy`, `DogfoodSafetyPolicy`, the Block
+    presets) now work through the test endpoint exactly as they do for
+    real traffic.
+  - **Observability**: test-path policy execution emits the same events
+    as production runs and appears in the activity monitor. Test sessions
+    have ids prefixed `admin-test-session-` so operators can identify or
+    filter them.
+  - `body.api_key`, when supplied, is now sent directly to Anthropic and
+    surfaced to policies as the request's `user_credential` (passthrough
+    semantics). Without `body.api_key`, `user_credential` is `None`,
+    matching the gateway's client-key-mode semantics.
   - Streaming-only policies appear as no-ops in this preview by design —
     the non-streaming hooks are the source of truth for the test path.

--- a/changelog.d/before-after-backend.md
+++ b/changelog.d/before-after-backend.md
@@ -1,0 +1,16 @@
+---
+category: Features
+---
+
+**Before/After preview backend for the admin policy-test endpoint**:
+The admin `/api/admin/test/chat` endpoint now returns both `before_content`
+(raw LLM output for the original request) and `content` (the active policy's
+output for that same exchange). Operators can use the diff to verify a
+policy does what they think before activating it on real traffic.
+  - The endpoint orchestrates the LLM call and policy hooks in-process and
+    no longer makes an HTTP roundtrip to `/v1/messages`. The gateway request
+    pipeline is untouched and there is no client-facing protocol opt-in.
+  - `body.api_key`, when supplied, is now sent directly to Anthropic
+    (previously it was used to authenticate against the local proxy).
+  - Streaming-only policies appear as no-ops in this preview by design —
+    the non-streaming hooks are the source of truth for the test path.

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -9,7 +9,7 @@ import uuid
 from typing import Any, cast
 
 import litellm
-from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi import APIRouter, Depends, HTTPException, Path, Request
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from luthien_proxy.admin.policy_discovery import discover_policies, validate_policy_config
@@ -22,6 +22,7 @@ from luthien_proxy.dependencies import (
     Dependencies,
     get_db_pool,
     get_dependencies,
+    get_emitter,
     get_policy_manager,
     require_config_registry,
     require_credential_manager,
@@ -37,6 +38,7 @@ from luthien_proxy.inference.registry import (
 from luthien_proxy.llm import anthropic_client_cache
 from luthien_proxy.llm.anthropic_client import AnthropicClient
 from luthien_proxy.llm.types.anthropic import AnthropicRequest, AnthropicResponse
+from luthien_proxy.observability.emitter import EventEmitterProtocol
 from luthien_proxy.policy_core.anthropic_execution_interface import AnthropicExecutionInterface
 from luthien_proxy.policy_core.policy_context import PolicyContext
 from luthien_proxy.policy_manager import (
@@ -45,8 +47,10 @@ from luthien_proxy.policy_manager import (
     PolicyManager,
 )
 from luthien_proxy.settings import client_error_detail, get_settings
+from luthien_proxy.types import RawHttpRequest
 from luthien_proxy.usage_telemetry.config import resolve_telemetry_config
 from luthien_proxy.utils import db
+from luthien_proxy.utils.policy_cache import PolicyCache, PolicyCacheFactory
 
 logger = logging.getLogger(__name__)
 
@@ -421,11 +425,124 @@ async def _resolve_test_anthropic_client(
     )
 
 
+def _build_test_user_credential(body_api_key: str | None) -> Credential | None:
+    """Construct the user_credential a test-path policy should observe.
+
+    Mirrors the gateway's credential-shape semantics:
+      - body.api_key supplied → passthrough-style ``Credential(API_KEY)`` so
+        policies that key off ``ctx.user_credential`` see exactly what they
+        would for a passthrough request.
+      - Otherwise → None, matching the gateway's "client-key match" branch
+        where the inbound credential authenticated the request but the
+        upstream call uses the server's ANTHROPIC_API_KEY (no per-user
+        credential to forward). Policies that strictly require a user
+        credential will surface the same error they would for a real
+        client-key request — that's the realistic preview, not a bug.
+    """
+    if body_api_key is not None and body_api_key.strip():
+        return Credential(
+            value=body_api_key.strip(),
+            credential_type=CredentialType.API_KEY,
+            platform="anthropic",
+        )
+    return None
+
+
+def _build_policy_cache_factory(db_pool: db.DatabasePool | None) -> PolicyCacheFactory | None:
+    """Build a policy cache factory the same way the gateway pipeline does.
+
+    Mirrors :mod:`luthien_proxy.pipeline.anthropic_processor` (the cap is
+    pulled fresh from settings so admin-side overrides resolved after import
+    take effect, matching the gateway path). ``None`` is returned when no
+    database is configured — policies that require persistent caching will
+    raise from ``ctx.policy_cache(...)`` exactly as they do for real traffic
+    in dockerless dev without DB.
+    """
+    if db_pool is None:
+        return None
+    cache_cap_setting = get_settings().policy_cache_max_entries
+    cache_cap: int | None = cache_cap_setting if cache_cap_setting > 0 else None
+    return lambda name: PolicyCache(db_pool, name, max_entries=cache_cap)
+
+
+def _build_test_raw_http_request(
+    fastapi_request: Request,
+    original_request: AnthropicRequest,
+) -> RawHttpRequest:
+    """Build a RawHttpRequest that reflects the admin test invocation.
+
+    ``RawHttpRequest`` exists so policies can recover headers/body that the
+    typed ``AnthropicRequest`` doesn't carry. For the admin test path we
+    expose the inbound headers (e.g. ``anthropic-beta``, ``x-session-id``)
+    from the admin caller and the synthetic Anthropic body — the exact
+    surface a policy would see if this same request had landed on
+    ``/v1/messages``.
+
+    Note: the inbound path is the admin URL, not ``/v1/messages``. Policies
+    that gate behavior on the request path (uncommon) will see
+    ``/api/admin/test/chat`` and can reasonably treat that as a test
+    invocation.
+    """
+    headers = {k.lower(): v for k, v in fastapi_request.headers.items()}
+    body = cast(dict[str, Any], dict(original_request))
+    return RawHttpRequest(
+        body=body,
+        headers=headers,
+        method=fastapi_request.method,
+        path=fastapi_request.url.path,
+    )
+
+
+def _build_test_policy_context(
+    *,
+    transaction_id: str,
+    original_request: AnthropicRequest,
+    fastapi_request: Request,
+    emitter: EventEmitterProtocol,
+    credential_manager: CredentialManager,
+    db_pool: db.DatabasePool | None,
+    body_api_key: str | None,
+) -> PolicyContext:
+    """Build a full PolicyContext matching the one the gateway pipeline creates.
+
+    The directive: a test-path policy must see the same context shape it
+    would for real ``/v1/messages`` traffic. That means the same emitter
+    (test-path events DO appear in the activity monitor — by design, see
+    the changelog), the same credential manager, the same policy cache
+    factory, and a credential whose type/value matches what a passthrough
+    request would carry. The session_id is a per-test synthetic marker so
+    the activity monitor groups a Before/After run as one logical session
+    and operators can identify test traffic at a glance.
+    """
+    raw_http_request = _build_test_raw_http_request(fastapi_request, original_request)
+    user_credential = _build_test_user_credential(body_api_key)
+    policy_cache_factory = _build_policy_cache_factory(db_pool)
+    # Synthetic but stable-shaped session id; prefix marks the run as admin
+    # test traffic for anyone reading the activity stream. Operators who
+    # filter for production traffic can drop ``admin-test-*`` sessions.
+    session_id = f"admin-test-session-{uuid.uuid4().hex[:8]}"
+
+    return PolicyContext(
+        transaction_id=transaction_id,
+        request=None,  # No OpenAI-format request — native Anthropic path.
+        emitter=emitter,
+        raw_http_request=raw_http_request,
+        session_id=session_id,
+        user_credential=user_credential,
+        credential_manager=credential_manager,
+        policy_cache_factory=policy_cache_factory,
+    )
+
+
 @router.post("/test/chat", response_model=ChatResponse)
 async def send_chat(
     body: ChatRequest,
+    fastapi_request: Request,
     _: str = Depends(verify_admin_token),
     deps: Dependencies = Depends(get_dependencies),
+    db_pool: db.DatabasePool | None = Depends(get_db_pool),
+    credential_manager: CredentialManager = Depends(require_credential_manager),
+    emitter: EventEmitterProtocol = Depends(get_emitter),
 ):
     """Send a test message and return Before/After previews of the active policy.
 
@@ -435,13 +552,25 @@ async def send_chat(
       1. Call Anthropic with the operator's original request → ``before_content``
          (what the LLM would have said with no policy in the way).
       2. Run the active policy's ``on_anthropic_request`` and ``on_anthropic_response``
-         hooks; re-call Anthropic if the request was transformed → ``content``
-         (what the policy turned the LLM's response into).
+         hooks against a full ``PolicyContext`` (same emitter, credential
+         manager, and policy cache the gateway pipeline uses) and re-call
+         Anthropic if the request was transformed → ``content`` (what the
+         policy turned the LLM's response into).
 
     Architectural note: policies decide what happens to a request — clients
     (including this admin test path) do not. The orchestration runs the policy
     hooks programmatically, so the gateway's request/response pipeline is never
-    involved and no client-facing protocol opt-in is required.
+    involved and no client-facing protocol opt-in is required. The
+    PolicyContext is built with the same dependencies the gateway hands to
+    its pipeline so judge-style policies (LLM judges, ToolCallJudgePolicy,
+    DogfoodSafety, the Block presets) can run against test traffic exactly
+    as they would against real traffic.
+
+    Observability note: the test-path PolicyContext shares the production
+    emitter. Test-run policy events DO appear in the activity monitor and
+    are recorded for observability — the session_id is prefixed
+    ``admin-test-session-`` so operators can identify or filter test
+    traffic. (See changelog.)
 
     Streaming-only policies (those that only implement ``on_anthropic_stream_event``)
     will appear as no-ops in the After view. The non-streaming hooks are the
@@ -494,7 +623,15 @@ async def send_chat(
     )
 
     transaction_id = f"admin-test-{uuid.uuid4().hex[:12]}"
-    ctx = PolicyContext(transaction_id=transaction_id)
+    ctx = _build_test_policy_context(
+        transaction_id=transaction_id,
+        original_request=original_request,
+        fastapi_request=fastapi_request,
+        emitter=emitter,
+        credential_manager=credential_manager,
+        db_pool=db_pool,
+        body_api_key=body.api_key,
+    )
 
     # Step 1: Before — call Anthropic with the unmodified original request.
     try:

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -489,13 +489,15 @@ def _build_test_raw_http_request(
     invocation.
     """
     headers = {k.lower(): v for k, v in fastapi_request.headers.items()}
-    # Shallow copy intentionally — mirrors the aliasing semantics of the
-    # gateway pipeline at anthropic_processor.py (`raw_http_request = RawHttpRequest(body=body, ...)`
-    # where `body` is the parsed inbound JSON), so policy hooks reading
-    # raw_http_request.body see the same nested-list/dict identities they
-    # would in production. A future deep-copy on either side should be
-    # made on both sides to keep the contract consistent.
-    body = cast(dict[str, Any], dict(original_request))
+    # Same identity as production: pipeline/anthropic_processor.py constructs
+    # RawHttpRequest with the parsed JSON body and uses that same dict as the
+    # AnthropicRequest, so ``raw_http_request.body is anthropic_request`` in
+    # production. Mirror that here by aliasing the request directly — without
+    # this, a policy that mutates ``original_request`` in ``on_anthropic_request``
+    # and then reads ``ctx.raw_http_request.body`` would see different state in
+    # the test path than in production, and the Before/After preview would lie
+    # about what production would do.
+    body = cast(dict[str, Any], original_request)
     return RawHttpRequest(
         body=body,
         headers=headers,
@@ -522,8 +524,11 @@ def _build_test_policy_context(
     the changelog), the same credential manager, the same policy cache
     factory, and a credential whose type/value matches what a passthrough
     request would carry. The session_id is a per-test synthetic marker so
-    the activity monitor groups a Before/After run as one logical session
-    and operators can identify test traffic at a glance.
+    the activity monitor groups *this* Before/After run (a single
+    ``send_chat`` invocation) as one logical session and operators can
+    identify test traffic at a glance. Consecutive admin-test invocations
+    are independent sessions — each call generates a fresh
+    ``admin-test-session-{8-hex}`` id.
     """
     raw_http_request = _build_test_raw_http_request(fastapi_request, original_request)
     user_credential = _build_test_user_credential(body_api_key)
@@ -620,6 +625,8 @@ async def send_chat(
     try:
         policy: AnthropicExecutionInterface = deps.get_anthropic_policy()
     except HTTPException:
+        # Let FastAPI handle HTTPException (preserves status code); fall through
+        # to the catch-all only for unexpected errors. Don't simplify this away.
         raise
     except Exception as e:
         logger.error(f"Failed to resolve active policy: {repr(e)}", exc_info=True)
@@ -669,6 +676,10 @@ async def send_chat(
             model=body.model,
         )
 
+    # Capture before_content/before_usage from the pre-hook response so that
+    # response-hook mutations of ``before_response`` (when ``upstream_for_after
+    # = before_response`` in the request-hook-passthrough path) don't poison
+    # the Before view. Don't reorder these below the response hook.
     before_content = _extract_text_content(before_response)
     before_usage = _coerce_usage(before_response)
 

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from typing import Any
+import uuid
+from typing import Any, cast
 
-import httpx
 import litellm
 from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, Field, ValidationError, field_validator
@@ -34,6 +34,11 @@ from luthien_proxy.inference.registry import (
     ProviderRecord,
     UnknownBackendTypeError,
 )
+from luthien_proxy.llm import anthropic_client_cache
+from luthien_proxy.llm.anthropic_client import AnthropicClient
+from luthien_proxy.llm.types.anthropic import AnthropicRequest, AnthropicResponse
+from luthien_proxy.policy_core.anthropic_execution_interface import AnthropicExecutionInterface
+from luthien_proxy.policy_core.policy_context import PolicyContext
 from luthien_proxy.policy_manager import (
     PolicyEnableResult,
     PolicyInfo,
@@ -108,16 +113,35 @@ class ChatRequest(BaseModel):
     )
     api_key: str | None = Field(
         default=None,
-        description="Optional API key to use for this test request. "
-        "Overrides the server's client key as the credential sent to the gateway.",
+        description="Optional Anthropic API key to use for this test request. "
+        "Overrides the server's configured Anthropic credential. The test endpoint "
+        "calls Anthropic directly (not through the gateway HTTP boundary), so this "
+        "key is sent to Anthropic, not used to authenticate against the proxy.",
     )
 
 
 class ChatResponse(BaseModel):
-    """Response from test chat."""
+    """Response from the admin policy-test endpoint.
+
+    The endpoint runs two steps:
+      1. Call Anthropic directly with the original request → ``before_content``.
+      2. Run the active policy's request/response hooks against that exchange,
+         re-calling Anthropic if the request hook transforms the request → ``content``.
+
+    Operators use the diff between ``before_content`` and ``content`` to verify
+    a policy actually does what they think before activating it on real traffic.
+    """
 
     success: bool
-    content: str | None = None
+    content: str | None = Field(
+        default=None,
+        description="Post-policy content (After). Reflects the active policy's full effect.",
+    )
+    before_content: str | None = Field(
+        default=None,
+        description="Raw LLM content (Before) — what Anthropic returned for the original request "
+        "with no policy in the way. None when the LLM call failed or in mock mode.",
+    )
     error: str | None = None
     model: str | None = None
     usage: dict[str, Any] | None = None
@@ -321,106 +345,223 @@ async def list_models(
     return {"models": get_available_models()}
 
 
+def _coerce_usage(response: AnthropicResponse | None) -> dict[str, Any] | None:
+    """Convert AnthropicUsage TypedDict (or absent usage) to a plain dict.
+
+    Pyright treats TypedDicts as a distinct type from ``dict[str, Any]``;
+    the ChatResponse field is the latter, so coerce explicitly.
+    """
+    if response is None:
+        return None
+    usage = response.get("usage")
+    if usage is None:
+        return None
+    return dict(usage)
+
+
+def _extract_text_content(response: AnthropicResponse | None) -> str | None:
+    """Concatenate text-block content from an Anthropic response.
+
+    Tool-use, thinking, and other non-text blocks are intentionally elided —
+    text concatenation is a useful approximation for the operator-facing
+    Before/After preview, even if the underlying response carries richer
+    structure. The full response object is not surfaced to the UI.
+    """
+    if response is None:
+        return None
+    parts: list[str] = []
+    for block in response.get("content", []):
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    if not parts:
+        return None
+    return "".join(parts)
+
+
+def _request_signature(request: AnthropicRequest) -> str:
+    """Stable JSON signature for detecting whether a policy modified the request.
+
+    If the active policy's ``on_anthropic_request`` is a passthrough we can
+    skip the second LLM call and reuse the Before response as the
+    pre-response-hook input for After. Comparison is by JSON equality (the
+    request is a TypedDict of JSON-serializable values).
+    """
+    return json.dumps(request, sort_keys=True, default=str)
+
+
+async def _resolve_test_anthropic_client(
+    body_api_key: str | None,
+    server_client: AnthropicClient | None,
+) -> tuple[AnthropicClient | None, str | None]:
+    """Resolve the AnthropicClient to use for a test-chat call.
+
+    Precedence:
+      1. Caller-supplied api_key (forwards directly to Anthropic, cached).
+      2. Server's configured upstream client (set via ANTHROPIC_API_KEY).
+    Returns (client, error_message). On failure, client is None.
+    """
+    if body_api_key is not None and body_api_key.strip():
+        try:
+            client = await anthropic_client_cache.get_client(
+                body_api_key.strip(),
+                auth_type="api_key",
+            )
+            return client, None
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error(f"Failed to build AnthropicClient from supplied api_key: {repr(exc)}")
+            return None, "Failed to initialize Anthropic client with supplied api_key"
+
+    if server_client is not None:
+        return server_client, None
+
+    return None, (
+        "No Anthropic API key available — set ANTHROPIC_API_KEY on the server or supply api_key in the request body"
+    )
+
+
 @router.post("/test/chat", response_model=ChatResponse)
 async def send_chat(
     body: ChatRequest,
     _: str = Depends(verify_admin_token),
+    deps: Dependencies = Depends(get_dependencies),
 ):
-    """Send a test message through the proxy with the active policy.
+    """Send a test message and return Before/After previews of the active policy.
 
-    Forwards the request to the gateway's /v1/messages endpoint using either
-    the server's CLIENT_API_KEY or a custom API key. In mock mode, returns the
-    user's message as an echo without calling the LLM or running the policy
-    pipeline (useful for quick checks without API credits).
+    This endpoint orchestrates two steps directly, never crossing the
+    ``/v1/messages`` HTTP boundary:
+
+      1. Call Anthropic with the operator's original request → ``before_content``
+         (what the LLM would have said with no policy in the way).
+      2. Run the active policy's ``on_anthropic_request`` and ``on_anthropic_response``
+         hooks; re-call Anthropic if the request was transformed → ``content``
+         (what the policy turned the LLM's response into).
+
+    Architectural note: policies decide what happens to a request — clients
+    (including this admin test path) do not. The orchestration runs the policy
+    hooks programmatically, so the gateway's request/response pipeline is never
+    involved and no client-facing protocol opt-in is required.
+
+    Streaming-only policies (those that only implement ``on_anthropic_stream_event``)
+    will appear as no-ops in the After view. The non-streaming hooks are the
+    source of truth for this endpoint by design — faking a stream would be
+    misleading. Tool-use and thinking blocks are elided from the text preview.
 
     Requires admin authentication.
     """
-    settings = get_settings()
-
-    # Mock mode: echo the user's message back as if the LLM responded with it.
-    # Useful for testing how a policy transforms text without spending API credits.
+    # Mock mode: skip both the LLM call and the policy. This is the lightest
+    # operator-facing smoke test (no API credits, no policy needed). Before
+    # and After are both the echoed message — the diff is intentionally empty
+    # so the operator sees that mock mode is a no-op end-to-end.
     if body.use_mock:
         return ChatResponse(
             success=True,
             content=body.message,
+            before_content=body.message,
             model=body.model,
         )
 
-    # Determine which API key to use: custom key takes precedence over server client key
-    test_api_key = settings.client_api_key
-    if body.api_key is not None and body.api_key.strip():
-        test_api_key = body.api_key.strip()
+    # Resolve the upstream Anthropic client first — fast-fail if no creds.
+    client, key_error = await _resolve_test_anthropic_client(body.api_key, deps.anthropic_client)
+    if client is None:
+        return ChatResponse(success=False, error=key_error, model=body.model)
 
-    if not test_api_key:
+    # Resolve the active policy. If the active policy doesn't implement the
+    # Anthropic hook surface this raises HTTPException(500) — same behavior as
+    # the gateway path.
+    try:
+        policy: AnthropicExecutionInterface = deps.get_anthropic_policy()
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to resolve active policy: {repr(e)}", exc_info=True)
         return ChatResponse(
             success=False,
-            error="No API key available — set CLIENT_API_KEY on the server or provide a custom key",
+            error=client_error_detail(str(e), "Failed to resolve active policy"),
             model=body.model,
         )
 
-    # Use the internal self-URL so this works both on the host and inside Docker,
-    # where the external port mapping (e.g. 8001) is not reachable from the container.
-    base_url = f"http://localhost:{settings.gateway_port}"
+    # Build the original Anthropic request. Kept minimal on purpose — the test
+    # endpoint is a preview tool, not a full conversation harness.
+    original_request: AnthropicRequest = cast(
+        AnthropicRequest,
+        {
+            "model": body.model,
+            "messages": [{"role": "user", "content": body.message}],
+            "max_tokens": 1024,
+        },
+    )
 
-    # Build Anthropic-format request payload
-    payload: dict[str, Any] = {
-        "model": body.model,
-        "messages": [{"role": "user", "content": body.message}],
-        "max_tokens": 1024,
-        "stream": False,
-    }
+    transaction_id = f"admin-test-{uuid.uuid4().hex[:12]}"
+    ctx = PolicyContext(transaction_id=transaction_id)
 
+    # Step 1: Before — call Anthropic with the unmodified original request.
     try:
-        async with httpx.AsyncClient(timeout=120.0, follow_redirects=True) as client:
-            response = await client.post(
-                f"{base_url}/v1/messages",
-                json=payload,
-                headers={"x-api-key": test_api_key},
-            )
+        before_response = await client.complete(original_request)
+    except Exception as e:
+        logger.error(f"Test chat: LLM call (before) failed: {repr(e)}", exc_info=True)
+        return ChatResponse(
+            success=False,
+            error=client_error_detail(str(e), "Anthropic API call failed"),
+            model=body.model,
+        )
 
-        if response.status_code != 200:
-            error_detail = response.text
-            try:
-                error_json = response.json()
-                error_detail = error_json.get("detail", error_detail)
-            except ValueError as e:
-                logger.debug(f"Could not parse error response as JSON: {repr(e)}")
+    before_content = _extract_text_content(before_response)
+
+    # Step 2: After — run policy hooks. on_anthropic_request may rewrite the
+    # request; if it did, we re-call Anthropic with the transformed request so
+    # the After preview reflects the realistic full-pipeline outcome. If the
+    # request hook is a passthrough, reuse the Before response (one LLM call).
+    try:
+        transformed_request = await policy.on_anthropic_request(original_request, ctx)
+    except Exception as e:
+        logger.error(f"Test chat: policy.on_anthropic_request failed: {repr(e)}", exc_info=True)
+        return ChatResponse(
+            success=False,
+            before_content=before_content,
+            error=client_error_detail(str(e), "Policy request hook failed"),
+            model=body.model,
+            usage=_coerce_usage(before_response),
+        )
+
+    if _request_signature(transformed_request) == _request_signature(original_request):
+        upstream_for_after = before_response
+    else:
+        try:
+            upstream_for_after = await client.complete(transformed_request)
+        except Exception as e:
+            logger.error(f"Test chat: LLM call (after, transformed request) failed: {repr(e)}", exc_info=True)
             return ChatResponse(
                 success=False,
-                error=f"Proxy returned {response.status_code}: {error_detail}",
+                before_content=before_content,
+                error=client_error_detail(str(e), "Anthropic API call (post-request-hook) failed"),
                 model=body.model,
+                usage=_coerce_usage(before_response),
             )
 
-        data = response.json()
-
-        # Extract content from Anthropic response format
-        content = None
-        for block in data.get("content", []):
-            if isinstance(block, dict) and block.get("type") == "text":
-                content = (content or "") + block.get("text", "")
-
-        # Extract usage
-        usage = data.get("usage")
-
-        return ChatResponse(
-            success=True,
-            content=content,
-            model=body.model,
-            usage=usage,
-        )
-    except httpx.TimeoutException:
-        return ChatResponse(
-            success=False,
-            error="Request timed out (120s limit)",
-            model=body.model,
-        )
+    try:
+        after_response = await policy.on_anthropic_response(upstream_for_after, ctx)
     except Exception as e:
-        logger.error(f"Test chat failed: {repr(e)}", exc_info=True)
+        logger.error(f"Test chat: policy.on_anthropic_response failed: {repr(e)}", exc_info=True)
         return ChatResponse(
             success=False,
-            error=client_error_detail(str(e), "An unexpected error occurred"),
+            before_content=before_content,
+            error=client_error_detail(str(e), "Policy response hook failed"),
             model=body.model,
+            usage=_coerce_usage(before_response),
         )
+
+    after_content = _extract_text_content(after_response)
+    usage = _coerce_usage(after_response if isinstance(after_response, dict) else None)
+
+    return ChatResponse(
+        success=True,
+        content=after_content,
+        before_content=before_content,
+        model=body.model,
+        usage=usage,
+    )
 
 
 def _config_to_response(config: AuthConfig) -> AuthConfigResponse:

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -134,6 +135,13 @@ class ChatResponse(BaseModel):
 
     Operators use the diff between ``before_content`` and ``content`` to verify
     a policy actually does what they think before activating it on real traffic.
+
+    Caveat — model jitter: when the request hook rewrites the request and
+    triggers a second LLM call, ``before_content`` and ``content`` reflect
+    *two independent* LLM samples. Differences can come from sampling
+    variance, not just from the policy. For a strict "policy effect only"
+    diff, prefer policies that transform responses rather than requests, or
+    set ``temperature=0`` upstream.
     """
 
     success: bool
@@ -144,11 +152,24 @@ class ChatResponse(BaseModel):
     before_content: str | None = Field(
         default=None,
         description="Raw LLM content (Before) — what Anthropic returned for the original request "
-        "with no policy in the way. None when the LLM call failed or in mock mode.",
+        "with no policy in the way. None when the LLM call failed or in mock mode. "
+        "When the active policy rewrites the request and a second LLM call is "
+        "issued for After, the Before/After diff includes sampling variance from "
+        "two independent draws, not just the policy's effect.",
     )
     error: str | None = None
     model: str | None = None
-    usage: dict[str, Any] | None = None
+    usage: dict[str, Any] | None = Field(
+        default=None,
+        description="Usage stats from the After-side LLM call. When the request was not "
+        "transformed (single-call optimization), this equals ``before_usage``.",
+    )
+    before_usage: dict[str, Any] | None = Field(
+        default=None,
+        description="Usage stats from the Before-side LLM call. Surfaced so operators can "
+        "see total cost when the policy triggers a second LLM call (Before + After). "
+        "When no second call is issued, equals ``usage``.",
+    )
 
 
 class AuthConfigResponse(BaseModel):
@@ -384,15 +405,16 @@ def _extract_text_content(response: AnthropicResponse | None) -> str | None:
     return "".join(parts)
 
 
-def _request_signature(request: AnthropicRequest) -> str:
-    """Stable JSON signature for detecting whether a policy modified the request.
+def _snapshot_request(request: AnthropicRequest) -> AnthropicRequest:
+    """Deep-copy a request so we can compare pre- and post-hook state.
 
-    If the active policy's ``on_anthropic_request`` is a passthrough we can
-    skip the second LLM call and reuse the Before response as the
-    pre-response-hook input for After. Comparison is by JSON equality (the
-    request is a TypedDict of JSON-serializable values).
+    A policy whose ``on_anthropic_request`` mutates the input dict in place
+    and returns the same reference will defeat any post-hook equality check
+    that reads the dict on both sides — both sides see post-mutation state,
+    look equal, and the optimizer would wrongly skip the second LLM call.
+    Snapshot before invoking the hook to keep the comparison honest.
     """
-    return json.dumps(request, sort_keys=True, default=str)
+    return cast(AnthropicRequest, copy.deepcopy(request))
 
 
 async def _resolve_test_anthropic_client(
@@ -577,6 +599,13 @@ async def send_chat(
     source of truth for this endpoint by design — faking a stream would be
     misleading. Tool-use and thinking blocks are elided from the text preview.
 
+    Caveat — model jitter: when ``on_anthropic_request`` rewrites the
+    request and triggers a second LLM call, ``before_content`` and
+    ``content`` are *two independent* LLM samples. The diff includes
+    sampling variance, not just the policy's effect. Operators should
+    prefer ``temperature=0`` for clean policy-effect previews of
+    request-transforming policies.
+
     Requires admin authentication.
     """
     # Mock mode: skip both the LLM call and the policy. This is the lightest
@@ -633,9 +662,16 @@ async def send_chat(
         body_api_key=body.api_key,
     )
 
+    # Mirror the gateway's anthropic-beta header forwarding so beta features
+    # (prompt caching, etc.) behave identically in this preview and in
+    # production. See pipeline/anthropic_processor.py — same line.
+    forwarded_headers: dict[str, str] | None = None
+    if beta := fastapi_request.headers.get("anthropic-beta"):
+        forwarded_headers = {"anthropic-beta": beta}
+
     # Step 1: Before — call Anthropic with the unmodified original request.
     try:
-        before_response = await client.complete(original_request)
+        before_response = await client.complete(original_request, extra_headers=forwarded_headers)
     except Exception as e:
         logger.error(f"Test chat: LLM call (before) failed: {repr(e)}", exc_info=True)
         return ChatResponse(
@@ -645,11 +681,18 @@ async def send_chat(
         )
 
     before_content = _extract_text_content(before_response)
+    before_usage = _coerce_usage(before_response)
 
     # Step 2: After — run policy hooks. on_anthropic_request may rewrite the
     # request; if it did, we re-call Anthropic with the transformed request so
     # the After preview reflects the realistic full-pipeline outcome. If the
     # request hook is a passthrough, reuse the Before response (one LLM call).
+    #
+    # The pre-hook snapshot is critical: a policy that mutates the input dict
+    # in place and returns the same reference would defeat any post-hook
+    # equality check that reads the live dict on both sides. Comparison is
+    # against the snapshot taken BEFORE the hook ran.
+    pre_hook_snapshot = _snapshot_request(original_request)
     try:
         transformed_request = await policy.on_anthropic_request(original_request, ctx)
     except Exception as e:
@@ -657,24 +700,26 @@ async def send_chat(
         return ChatResponse(
             success=False,
             before_content=before_content,
+            before_usage=before_usage,
             error=client_error_detail(str(e), "Policy request hook failed"),
             model=body.model,
-            usage=_coerce_usage(before_response),
+            usage=before_usage,
         )
 
-    if _request_signature(transformed_request) == _request_signature(original_request):
+    if transformed_request == pre_hook_snapshot:
         upstream_for_after = before_response
     else:
         try:
-            upstream_for_after = await client.complete(transformed_request)
+            upstream_for_after = await client.complete(transformed_request, extra_headers=forwarded_headers)
         except Exception as e:
             logger.error(f"Test chat: LLM call (after, transformed request) failed: {repr(e)}", exc_info=True)
             return ChatResponse(
                 success=False,
                 before_content=before_content,
+                before_usage=before_usage,
                 error=client_error_detail(str(e), "Anthropic API call (post-request-hook) failed"),
                 model=body.model,
-                usage=_coerce_usage(before_response),
+                usage=before_usage,
             )
 
     try:
@@ -684,18 +729,20 @@ async def send_chat(
         return ChatResponse(
             success=False,
             before_content=before_content,
+            before_usage=before_usage,
             error=client_error_detail(str(e), "Policy response hook failed"),
             model=body.model,
-            usage=_coerce_usage(before_response),
+            usage=before_usage,
         )
 
     after_content = _extract_text_content(after_response)
-    usage = _coerce_usage(after_response if isinstance(after_response, dict) else None)
+    usage = _coerce_usage(after_response)
 
     return ChatResponse(
         success=True,
         content=after_content,
         before_content=before_content,
+        before_usage=before_usage,
         model=body.model,
         usage=usage,
     )

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -51,7 +51,7 @@ from luthien_proxy.settings import client_error_detail, get_settings
 from luthien_proxy.types import RawHttpRequest
 from luthien_proxy.usage_telemetry.config import resolve_telemetry_config
 from luthien_proxy.utils import db
-from luthien_proxy.utils.policy_cache import PolicyCache, PolicyCacheFactory
+from luthien_proxy.utils import policy_cache as policy_cache_utils
 
 logger = logging.getLogger(__name__)
 
@@ -470,23 +470,6 @@ def _build_test_user_credential(body_api_key: str | None) -> Credential | None:
     return None
 
 
-def _build_policy_cache_factory(db_pool: db.DatabasePool | None) -> PolicyCacheFactory | None:
-    """Build a policy cache factory the same way the gateway pipeline does.
-
-    Mirrors :mod:`luthien_proxy.pipeline.anthropic_processor` (the cap is
-    pulled fresh from settings so admin-side overrides resolved after import
-    take effect, matching the gateway path). ``None`` is returned when no
-    database is configured — policies that require persistent caching will
-    raise from ``ctx.policy_cache(...)`` exactly as they do for real traffic
-    in dockerless dev without DB.
-    """
-    if db_pool is None:
-        return None
-    cache_cap_setting = get_settings().policy_cache_max_entries
-    cache_cap: int | None = cache_cap_setting if cache_cap_setting > 0 else None
-    return lambda name: PolicyCache(db_pool, name, max_entries=cache_cap)
-
-
 def _build_test_raw_http_request(
     fastapi_request: Request,
     original_request: AnthropicRequest,
@@ -538,7 +521,7 @@ def _build_test_policy_context(
     """
     raw_http_request = _build_test_raw_http_request(fastapi_request, original_request)
     user_credential = _build_test_user_credential(body_api_key)
-    policy_cache_factory = _build_policy_cache_factory(db_pool)
+    policy_cache_factory = policy_cache_utils.build_factory(db_pool)
     # Synthetic but stable-shaped session id; prefix marks the run as admin
     # test traffic for anyone reading the activity stream. Operators who
     # filter for production traffic can drop ``admin-test-*`` sessions.

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -435,7 +435,7 @@ async def _resolve_test_anthropic_client(
                 auth_type="api_key",
             )
             return client, None
-        except Exception as exc:  # pragma: no cover - defensive
+        except Exception as exc:
             logger.error(f"Failed to build AnthropicClient from supplied api_key: {repr(exc)}")
             return None, "Failed to initialize Anthropic client with supplied api_key"
 
@@ -489,6 +489,12 @@ def _build_test_raw_http_request(
     invocation.
     """
     headers = {k.lower(): v for k, v in fastapi_request.headers.items()}
+    # Shallow copy intentionally — mirrors the aliasing semantics of the
+    # gateway pipeline at anthropic_processor.py (`raw_http_request = RawHttpRequest(body=body, ...)`
+    # where `body` is the parsed inbound JSON), so policy hooks reading
+    # raw_http_request.body see the same nested-list/dict identities they
+    # would in production. A future deep-copy on either side should be
+    # made on both sides to keep the contract consistent.
     body = cast(dict[str, Any], dict(original_request))
     return RawHttpRequest(
         body=body,

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -67,8 +67,8 @@ from luthien_proxy.telemetry import restore_context
 from luthien_proxy.types import RawHttpRequest
 from luthien_proxy.usage_telemetry.collector import UsageCollector
 from luthien_proxy.utils import db
+from luthien_proxy.utils import policy_cache as policy_cache_utils
 from luthien_proxy.utils.constants import MAX_REQUEST_PAYLOAD_BYTES
-from luthien_proxy.utils.policy_cache import PolicyCache
 
 
 class _ErrorDetail(TypedDict):
@@ -406,9 +406,9 @@ async def process_anthropic_request(
         # Create policy cache factory if database is available. The cap is
         # configured once here so every policy's cache honors the same limit;
         # 0-or-negative in settings means "unbounded" (pass None to the cache).
-        cache_cap_setting = get_settings().policy_cache_max_entries
-        cache_cap: int | None = cache_cap_setting if cache_cap_setting > 0 else None
-        policy_cache_factory = (lambda name: PolicyCache(db_pool, name, max_entries=cache_cap)) if db_pool else None
+        # Shared with the admin policy-test endpoint via utils.policy_cache so
+        # both call sites stay in lockstep on the cap-resolution rule.
+        policy_cache_factory = policy_cache_utils.build_factory(db_pool)
 
         # Create policy context
         policy_ctx = PolicyContext(

--- a/src/luthien_proxy/utils/policy_cache.py
+++ b/src/luthien_proxy/utils/policy_cache.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from luthien_proxy.settings import get_settings
 from luthien_proxy.utils.db import DatabasePool
 
 # Type alias for the factory function injected into PolicyContext
@@ -22,6 +23,31 @@ type PolicyCacheFactory = Callable[[str], PolicyCache]
 # realistic workloads while still providing a hard ceiling that prevents a leaky
 # caller from filling the shared table. Override via constructor or factory.
 DEFAULT_MAX_ENTRIES = 10_000
+
+
+def build_factory(db_pool: DatabasePool | None) -> PolicyCacheFactory | None:
+    """Build a PolicyCacheFactory wired to the current policy_cache_max_entries setting.
+
+    Single source of truth for both the gateway pipeline and any other call
+    site (e.g. the admin policy-test endpoint) that needs to construct a
+    PolicyContext. The settings read is intentionally lazy so CLI/env/DB
+    overrides resolved after import take effect — same reasoning as
+    anthropic_client_cache._max_cache_size.
+
+    Returns ``None`` when no DB is configured: policies that require
+    persistent caching will raise from ``ctx.policy_cache(...)`` exactly as
+    they do for real traffic in dockerless dev without a DB.
+
+    A non-positive ``policy_cache_max_entries`` is treated as "unbounded"
+    (the underlying ``PolicyCache`` accepts ``None`` for max_entries). This
+    lets operators uncap the cache via config without changing call sites.
+    """
+    if db_pool is None:
+        return None
+    cap_setting = get_settings().policy_cache_max_entries
+    cap: int | None = cap_setting if cap_setting > 0 else None
+    return lambda name: PolicyCache(db_pool, name, max_entries=cap)
+
 
 # SQLite stores expires_at as TEXT and compares it with datetime('now'), which
 # relies on lexicographic ordering over the "YYYY-MM-DD HH:MM:SS" format.
@@ -242,4 +268,4 @@ class PolicyCache:
         return count_raw
 
 
-__all__ = ["PolicyCache", "PolicyCacheFactory", "DEFAULT_MAX_ENTRIES"]
+__all__ = ["PolicyCache", "PolicyCacheFactory", "DEFAULT_MAX_ENTRIES", "build_factory"]

--- a/tests/luthien_proxy/e2e_tests/test_mock_uat04_api_key_errors.py
+++ b/tests/luthien_proxy/e2e_tests/test_mock_uat04_api_key_errors.py
@@ -126,9 +126,7 @@ async def test_wrong_admin_key_returns_clear_error(
             (f for f in snapshot.json()["config"] if f["name"] == "localhost_auth_bypass"),
             None,
         )
-        assert bypass_field is not None, (
-            "localhost_auth_bypass missing from config dashboard — was the field renamed?"
-        )
+        assert bypass_field is not None, "localhost_auth_bypass missing from config dashboard — was the field renamed?"
         original_value = bypass_field["value"]
         original_source = bypass_field["source"]
         # If the field's flagged sensitive in the future, dashboard_view masks

--- a/tests/luthien_proxy/unit_tests/policies/test_string_replacement_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_string_replacement_policy.py
@@ -1485,9 +1485,7 @@ class TestRequestSideFiltering:
     @pytest.mark.asyncio
     async def test_empty_replacements_is_identity_passthrough(self):
         """apply_to='request' with empty replacements returns the original request."""
-        policy = StringReplacementPolicy(
-            config=StringReplacementConfig(replacements=[], apply_to="request")
-        )
+        policy = StringReplacementPolicy(config=StringReplacementConfig(replacements=[], apply_to="request"))
         ctx, _ = _ctx_with_recorder()
         request = _request_with_messages([{"role": "user", "content": "anything goes"}])
 

--- a/tests/luthien_proxy/unit_tests/test_admin_routes.py
+++ b/tests/luthien_proxy/unit_tests/test_admin_routes.py
@@ -43,7 +43,7 @@ from luthien_proxy.admin.routes import (
     update_telemetry_config,
 )
 from luthien_proxy.credential_manager import AuthConfig, AuthMode, CachedCredential, CredentialManager
-from luthien_proxy.credentials import CredentialError
+from luthien_proxy.credentials import Credential, CredentialError, CredentialType
 from luthien_proxy.dependencies import require_credential_manager
 from luthien_proxy.policy_manager import PolicyEnableResult
 
@@ -326,6 +326,61 @@ def _make_deps(*, policy=None, anthropic_client=None, raise_on_get_policy=False)
     return deps
 
 
+def _make_fastapi_request(headers: dict[str, str] | None = None) -> MagicMock:
+    """Build a minimal FastAPI Request stand-in.
+
+    send_chat reads ``request.headers`` (dict-like), ``request.method``, and
+    ``request.url.path`` to build the RawHttpRequest. A MagicMock with
+    those attributes is sufficient.
+    """
+    fastapi_request = MagicMock()
+    fastapi_request.headers = dict(headers or {"x-test": "1"})
+    fastapi_request.method = "POST"
+    fastapi_request.url = MagicMock()
+    fastapi_request.url.path = "/api/admin/test/chat"
+    return fastapi_request
+
+
+def _make_emitter() -> MagicMock:
+    """Build a recording emitter stand-in (matches EventEmitterProtocol's record(...))."""
+    emitter = MagicMock()
+    emitter.record = MagicMock()
+    return emitter
+
+
+def _make_credential_manager() -> MagicMock:
+    """Build a CredentialManager stand-in.
+
+    Tests don't exercise credential_manager methods directly; they only need
+    something to thread through PolicyContext. Policies that consume the
+    manager get a MagicMock — they can patch around it as needed.
+    """
+    return MagicMock()
+
+
+def _send_chat_kwargs(
+    *,
+    deps,
+    fastapi_request=None,
+    db_pool=None,
+    credential_manager=None,
+    emitter=None,
+):
+    """Build the keyword args for send_chat with sensible defaults.
+
+    The route handler now takes 6 dependencies; tests don't all care about
+    every one. This helper centralizes the defaults.
+    """
+    return {
+        "fastapi_request": fastapi_request or _make_fastapi_request(),
+        "_": AUTH_TOKEN,
+        "deps": deps,
+        "db_pool": db_pool,
+        "credential_manager": credential_manager or _make_credential_manager(),
+        "emitter": emitter or _make_emitter(),
+    }
+
+
 class TestSendChatRoute:
     """Test send_chat route handler — Before/After orchestration."""
 
@@ -341,7 +396,7 @@ class TestSendChatRoute:
         deps = _make_deps(policy=policy, anthropic_client=client)
 
         request = ChatRequest(model="claude-haiku-4-5", message="Hello!")
-        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert isinstance(result, ChatResponse)
         assert result.success is True
@@ -369,7 +424,7 @@ class TestSendChatRoute:
         deps = _make_deps(policy=policy, anthropic_client=client)
 
         request = ChatRequest(model="claude-haiku-4-5", message="hi")
-        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert result.success is True
         assert result.before_content == "hello world"
@@ -394,7 +449,7 @@ class TestSendChatRoute:
         deps = _make_deps(policy=policy, anthropic_client=client)
 
         request = ChatRequest(model="claude-haiku-4-5", message="explain x")
-        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert result.success is True
         assert result.before_content == "long winded original answer"
@@ -425,7 +480,7 @@ class TestSendChatRoute:
         deps = _make_deps(policy=policy, anthropic_client=client)
 
         request = ChatRequest(model="claude-haiku-4-5", message="how do I do bad thing")
-        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert result.success is True
         assert result.before_content == "dangerous instructions"
@@ -440,7 +495,7 @@ class TestSendChatRoute:
         deps = _make_deps(policy=policy, anthropic_client=client)
 
         request = ChatRequest(model="claude-haiku-4-5", message="echo me", use_mock=True)
-        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert result.success is True
         assert result.before_content == "echo me"
@@ -455,7 +510,7 @@ class TestSendChatRoute:
         deps = _make_deps(policy=None, anthropic_client=None)
 
         request = ChatRequest(model="claude-haiku-4-5", message="hi", use_mock=True)
-        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert result.success is True
         assert result.before_content == "hi"
@@ -467,7 +522,7 @@ class TestSendChatRoute:
         deps = _make_deps(policy=_RecordingPolicy(), anthropic_client=None)
 
         request = ChatRequest(model="claude-haiku-4-5", message="Hello!")
-        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert result.success is False
         assert result.error is not None
@@ -484,7 +539,7 @@ class TestSendChatRoute:
         deps = _make_deps(policy=_RecordingPolicy(), anthropic_client=None)
         request = ChatRequest(model="claude-haiku-4-5", message="hi", api_key="sk-test-1")
 
-        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert result.success is True
         assert result.before_content == "ok"
@@ -499,7 +554,7 @@ class TestSendChatRoute:
         deps = _make_deps(policy=policy, anthropic_client=client)
 
         request = ChatRequest(model="claude-haiku-4-5", message="hi")
-        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert result.success is False
         assert result.before_content is None
@@ -522,7 +577,7 @@ class TestSendChatRoute:
         deps = _make_deps(policy=policy, anthropic_client=client)
 
         request = ChatRequest(model="claude-haiku-4-5", message="hi")
-        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert result.success is False
         assert result.before_content == "raw"
@@ -543,7 +598,7 @@ class TestSendChatRoute:
         deps = _make_deps(policy=policy, anthropic_client=client)
 
         request = ChatRequest(model="claude-haiku-4-5", message="hi")
-        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert result.success is False
         assert result.before_content == "raw"
@@ -560,7 +615,7 @@ class TestSendChatRoute:
 
         request = ChatRequest(model="claude-haiku-4-5", message="hi")
         with pytest.raises(HTTPException) as exc_info:
-            await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+            await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert exc_info.value.status_code == 500
 
@@ -585,7 +640,7 @@ class TestSendChatRoute:
         deps = _make_deps(policy=policy, anthropic_client=client)
 
         request = ChatRequest(model="claude-haiku-4-5", message="use a tool")
-        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
 
         assert result.success is True
         assert result.before_content is None
@@ -623,6 +678,196 @@ class TestSendChatRoute:
         resp = ChatResponse(success=True, content="after", before_content="before")
         assert resp.content == "after"
         assert resp.before_content == "before"
+
+    @pytest.mark.asyncio
+    @patch("luthien_proxy.admin.routes.anthropic_client_cache.get_client")
+    async def test_full_policy_context_is_threaded_through_hooks(self, mock_get_client):
+        """The PolicyContext passed to hooks carries emitter, credential_manager, raw_http_request, session_id."""
+
+        captured_contexts: list = []
+
+        class _ContextCapturingPolicy(_RecordingPolicy):
+            async def on_anthropic_request(self, request, context):
+                captured_contexts.append(context)
+                return await super().on_anthropic_request(request, context)
+
+            async def on_anthropic_response(self, response, context):
+                captured_contexts.append(context)
+                return await super().on_anthropic_response(response, context)
+
+        policy = _ContextCapturingPolicy()
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=_anthropic_response("ok"))
+        mock_get_client.return_value = client
+        deps = _make_deps(policy=policy, anthropic_client=None)
+        emitter = _make_emitter()
+        cred_mgr = _make_credential_manager()
+        fastapi_request = _make_fastapi_request({"x-session-id": "abc", "anthropic-beta": "prompt-caching-2024-07-31"})
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi", api_key="sk-test-1")
+        result = await send_chat(
+            body=request,
+            **_send_chat_kwargs(
+                deps=deps,
+                fastapi_request=fastapi_request,
+                emitter=emitter,
+                credential_manager=cred_mgr,
+            ),
+        )
+        assert result.success is True
+
+        # Both hooks saw the same ctx; ctx is fully populated.
+        assert len(captured_contexts) == 2
+        ctx = captured_contexts[0]
+        assert ctx is captured_contexts[1]
+        # transaction_id is per-test (uuid prefix).
+        assert ctx.transaction_id.startswith("admin-test-")
+        # session_id marks it as test traffic.
+        assert ctx.session_id is not None
+        assert ctx.session_id.startswith("admin-test-session-")
+        # Emitter and credential manager are the wired dependencies.
+        assert ctx.emitter is emitter
+        # credential_manager flows through; access via the property does not raise.
+        assert ctx._credential_manager is cred_mgr  # noqa: SLF001 — testing wiring
+        # user_credential reflects body.api_key (passthrough-style API key credential).
+        assert ctx.user_credential is not None
+        assert ctx.user_credential.value == "sk-test-1"
+        assert ctx.user_credential.credential_type == CredentialType.API_KEY
+        # raw_http_request carries the inbound headers from the admin caller.
+        assert ctx.raw_http_request is not None
+        assert ctx.raw_http_request.headers.get("anthropic-beta") == "prompt-caching-2024-07-31"
+        assert ctx.raw_http_request.path == "/api/admin/test/chat"
+
+    @pytest.mark.asyncio
+    async def test_user_credential_is_none_when_no_api_key_supplied(self):
+        """Without body.api_key, user_credential is None — matches client-key-mode semantics."""
+
+        captured: list = []
+
+        class _Cap(_RecordingPolicy):
+            async def on_anthropic_request(self, request, context):
+                captured.append(context)
+                return await super().on_anthropic_request(request, context)
+
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=_anthropic_response("x"))
+        # Server has its own anthropic client configured (client-key mode).
+        deps = _make_deps(policy=_Cap(), anthropic_client=client)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")  # no api_key
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
+        assert result.success is True
+        assert captured[0].user_credential is None
+
+    @pytest.mark.asyncio
+    async def test_policy_cache_factory_is_set_when_db_pool_present(self):
+        """When db_pool is present, ctx.has_policy_cache is True (factory was wired)."""
+
+        captured: list = []
+
+        class _Cap(_RecordingPolicy):
+            async def on_anthropic_request(self, request, context):
+                captured.append(context)
+                return await super().on_anthropic_request(request, context)
+
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=_anthropic_response("x"))
+        deps = _make_deps(policy=_Cap(), anthropic_client=client)
+        # db_pool is a stand-in — PolicyCache won't actually run, the factory is just installed.
+        db_pool = MagicMock()
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps, db_pool=db_pool))
+        assert result.success is True
+        assert captured[0].has_policy_cache is True
+
+    @pytest.mark.asyncio
+    async def test_policy_cache_factory_is_none_without_db_pool(self):
+        """Without a db_pool, ctx.has_policy_cache is False — same as dockerless dev without DB."""
+
+        captured: list = []
+
+        class _Cap(_RecordingPolicy):
+            async def on_anthropic_request(self, request, context):
+                captured.append(context)
+                return await super().on_anthropic_request(request, context)
+
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=_anthropic_response("x"))
+        deps = _make_deps(policy=_Cap(), anthropic_client=client)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps, db_pool=None))
+        assert result.success is True
+        assert captured[0].has_policy_cache is False
+
+    @pytest.mark.asyncio
+    @patch("luthien_proxy.admin.routes.anthropic_client_cache.get_client")
+    async def test_simple_llm_policy_runs_end_to_end_via_test_endpoint(self, mock_get_client):
+        """End-to-end: a SimpleLLMPolicy runs through the test endpoint with a real PolicyContext.
+
+        Mocks at the Anthropic-client and judge boundaries only — the policy's
+        own machinery (block descriptors, credential resolution via
+        credential_manager.resolve, judge invocation, response rebuilding)
+        runs unmodified. This pins that the test endpoint can preview the
+        most operationally-interesting class of policies (LLM judges) and
+        not just trivial response transformers.
+        """
+        from luthien_proxy.policies.simple_llm_policy import SimpleLLMPolicy
+        from luthien_proxy.policies.simple_llm_utils import (
+            JudgeAction,
+            ReplacementBlock,
+            SimpleLLMJudgeConfig,
+        )
+
+        config = SimpleLLMJudgeConfig(
+            instructions="Replace any mention of 'cat' with 'dog'.",
+            on_error="pass",
+            auth_provider="user_credentials",
+        )
+        policy = SimpleLLMPolicy(config=config)
+
+        # Anthropic-client returns a text block; judge returns a "replace" action.
+        before = _anthropic_response("I love cats.")
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=before)
+        mock_get_client.return_value = client
+
+        # credential_manager.resolve must return a Credential (the user_credential
+        # from the test ctx, since auth_provider='user_credentials').
+        cred_mgr = MagicMock()
+        cred_mgr.resolve = AsyncMock(
+            return_value=Credential(
+                value="sk-test-1",
+                credential_type=CredentialType.API_KEY,
+                platform="anthropic",
+            )
+        )
+
+        deps = _make_deps(policy=policy, anthropic_client=None)
+        request = ChatRequest(model="claude-haiku-4-5", message="tell me about cats", api_key="sk-test-1")
+
+        with patch(
+            "luthien_proxy.policies.simple_llm_policy.call_simple_llm_judge",
+            new=AsyncMock(
+                return_value=JudgeAction(
+                    action="replace",
+                    blocks=(ReplacementBlock(type="text", text="I love dogs."),),
+                )
+            ),
+        ):
+            result = await send_chat(
+                body=request,
+                **_send_chat_kwargs(deps=deps, credential_manager=cred_mgr),
+            )
+
+        assert result.success is True
+        assert result.before_content == "I love cats."
+        assert result.content == "I love dogs."
+        # credential_manager.resolve was actually called by the policy — proves
+        # the full PolicyContext (with credential_manager wired) threaded
+        # through the hooks.
+        cred_mgr.resolve.assert_awaited()
 
 
 class TestAuthConfigUpdateRequestValidation:

--- a/tests/luthien_proxy/unit_tests/test_admin_routes.py
+++ b/tests/luthien_proxy/unit_tests/test_admin_routes.py
@@ -384,6 +384,18 @@ def _send_chat_kwargs(
 class TestSendChatRoute:
     """Test send_chat route handler — Before/After orchestration."""
 
+    def test_recording_policy_satisfies_anthropic_execution_interface(self):
+        """Pin that the test stub structurally matches the AnthropicExecutionInterface protocol.
+
+        AnthropicExecutionInterface is runtime_checkable; if the stub diverges
+        from the protocol (e.g. a hook signature changes), this test fails
+        loudly instead of letting the rest of the suite test against a stub
+        that no longer represents what production policies look like.
+        """
+        from luthien_proxy.policy_core.anthropic_execution_interface import AnthropicExecutionInterface
+
+        assert isinstance(_RecordingPolicy(), AnthropicExecutionInterface)
+
     @pytest.mark.asyncio
     async def test_passthrough_policy_runs_one_llm_call(self):
         """Policy that doesn't transform request: single LLM call, Before == After."""
@@ -868,6 +880,175 @@ class TestSendChatRoute:
         # the full PolicyContext (with credential_manager wired) threaded
         # through the hooks.
         cred_mgr.resolve.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_in_place_mutating_request_hook_still_triggers_second_llm_call(self):
+        """Regression: pre-hook snapshot detects mutation even when the hook returns the same ref.
+
+        The earlier signature-comparison code read the live request dict on
+        both sides of the hook call. A policy that mutates in place and
+        returns the same reference would defeat that — both sides see the
+        post-mutation state, look equal, and the optimizer wrongly skipped
+        the second LLM call. This test pins that we now snapshot before the
+        hook runs.
+        """
+
+        def mutate_in_place_return_same_ref(req):
+            # Mutate the input dict and return the same reference.
+            req["system"] = "mutated-by-policy"
+            return req
+
+        policy = _RecordingPolicy(request_transform=mutate_in_place_return_same_ref)
+        before = _anthropic_response("original")
+        after_upstream = _anthropic_response("mutated-context-answer")
+
+        client = MagicMock()
+        client.complete = AsyncMock(side_effect=[before, after_upstream])
+        deps = _make_deps(policy=policy, anthropic_client=client)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
+
+        assert result.success is True
+        # Two LLM calls — the snapshot-vs-transformed comparison correctly
+        # detects the mutation despite the same-reference return.
+        assert client.complete.call_count == 2
+        assert result.before_content == "original"
+        assert result.content == "mutated-context-answer"
+        # Second call carried the mutated request.
+        second_call_request = client.complete.call_args_list[1][0][0]
+        assert second_call_request.get("system") == "mutated-by-policy"
+
+    @pytest.mark.asyncio
+    async def test_anthropic_beta_header_forwarded_to_upstream(self):
+        """anthropic-beta on the inbound admin request flows into both LLM calls.
+
+        Mirrors the gateway's beta-header forwarding so beta features (prompt
+        caching with scope, etc.) behave identically in the preview and in
+        production.
+        """
+
+        def add_system(req):
+            new = dict(req)
+            new["system"] = "Be terse."
+            return new
+
+        # Two-LLM-call path so we can assert the header on both calls.
+        policy = _RecordingPolicy(request_transform=add_system)
+        client = MagicMock()
+        client.complete = AsyncMock(
+            side_effect=[_anthropic_response("a"), _anthropic_response("b")],
+        )
+        deps = _make_deps(policy=policy, anthropic_client=client)
+        fastapi_request = _make_fastapi_request({"anthropic-beta": "prompt-caching-2024-07-31"})
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(
+            body=request,
+            **_send_chat_kwargs(deps=deps, fastapi_request=fastapi_request),
+        )
+        assert result.success is True
+
+        # Both LLM calls carried the beta header.
+        assert client.complete.call_count == 2
+        for call in client.complete.call_args_list:
+            assert call.kwargs.get("extra_headers") == {"anthropic-beta": "prompt-caching-2024-07-31"}
+
+    @pytest.mark.asyncio
+    async def test_no_extra_headers_forwarded_when_no_beta(self):
+        """Without anthropic-beta on the inbound request, extra_headers is None."""
+        policy = _RecordingPolicy()
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=_anthropic_response("ok"))
+        deps = _make_deps(policy=policy, anthropic_client=client)
+        # Default _make_fastapi_request has no anthropic-beta header.
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
+        assert result.success is True
+
+        assert client.complete.call_count == 1
+        assert client.complete.call_args.kwargs.get("extra_headers") is None
+
+    @pytest.mark.asyncio
+    async def test_before_usage_equals_usage_when_single_llm_call(self):
+        """No request transformation: before_usage and usage are populated identically."""
+        policy = _RecordingPolicy()
+        usage = {"input_tokens": 11, "output_tokens": 22}
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=_anthropic_response("ok", usage=usage))
+        deps = _make_deps(policy=policy, anthropic_client=client)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
+
+        assert result.success is True
+        assert result.before_usage == usage
+        assert result.usage == usage
+
+    @pytest.mark.asyncio
+    async def test_before_usage_distinct_when_two_llm_calls(self):
+        """Request-transforming policy: before_usage and usage carry independent counts."""
+
+        def add_system(req):
+            new = dict(req)
+            new["system"] = "Be terse."
+            return new
+
+        policy = _RecordingPolicy(request_transform=add_system)
+        before_usage = {"input_tokens": 100, "output_tokens": 50}
+        after_usage = {"input_tokens": 110, "output_tokens": 5}
+        client = MagicMock()
+        client.complete = AsyncMock(
+            side_effect=[
+                _anthropic_response("long answer", usage=before_usage),
+                _anthropic_response("terse.", usage=after_usage),
+            ],
+        )
+        deps = _make_deps(policy=policy, anthropic_client=client)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
+
+        assert result.success is True
+        assert result.before_usage == before_usage
+        assert result.usage == after_usage
+
+    @pytest.mark.asyncio
+    async def test_before_usage_surfaced_on_policy_failure_paths(self):
+        """When a policy hook fails, before_usage is preserved alongside before_content."""
+
+        def boom(_resp):
+            raise RuntimeError("policy response hook crashed")
+
+        policy = _RecordingPolicy(response_transform=boom)
+        before_usage = {"input_tokens": 7, "output_tokens": 9}
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=_anthropic_response("raw", usage=before_usage))
+        deps = _make_deps(policy=policy, anthropic_client=client)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
+
+        assert result.success is False
+        assert result.before_content == "raw"
+        assert result.before_usage == before_usage
+        # On error, usage falls back to before_usage too — operators still see cost.
+        assert result.usage == before_usage
+
+    @pytest.mark.asyncio
+    @patch("luthien_proxy.admin.routes.anthropic_client_cache.get_client")
+    async def test_supplied_api_key_cache_failure_returns_user_facing_error(self, mock_get_client):
+        """If the AnthropicClient cache raises, send_chat returns a clean error string."""
+        mock_get_client.side_effect = RuntimeError("boom")
+        deps = _make_deps(policy=_RecordingPolicy(), anthropic_client=None)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi", api_key="sk-bad")
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
+
+        assert result.success is False
+        assert result.error is not None
+        assert "Failed to initialize Anthropic client" in result.error
 
 
 class TestAuthConfigUpdateRequestValidation:

--- a/tests/luthien_proxy/unit_tests/test_admin_routes.py
+++ b/tests/luthien_proxy/unit_tests/test_admin_routes.py
@@ -1050,6 +1050,55 @@ class TestSendChatRoute:
         assert result.error is not None
         assert "Failed to initialize Anthropic client" in result.error
 
+    @pytest.mark.asyncio
+    async def test_raw_http_request_body_aliases_anthropic_request(self):
+        """Pin the production-parity contract: ``ctx.raw_http_request.body is request``.
+
+        In the gateway pipeline (pipeline/anthropic_processor.py) the parsed
+        JSON body is reused as both ``RawHttpRequest.body`` and the typed
+        ``AnthropicRequest`` — same dict identity. The admin test path must
+        match: a policy that mutates ``request`` in ``on_anthropic_request``
+        and then reads ``ctx.raw_http_request.body`` must see the mutation.
+        Without this parity, the Before/After preview would lie about what
+        production does for any policy that writes through ``request`` and
+        reads through ``raw_http_request.body``.
+
+        Two assertions: (1) direct identity — the request the hook receives
+        IS the body on raw_http_request; (2) mutation propagation — a
+        top-level write on ``request`` is visible via ``raw_http_request.body``
+        without going through the AnthropicRequest path again.
+        """
+
+        observations: dict[str, object] = {}
+
+        class _IdentityCheckingPolicy(_RecordingPolicy):
+            async def on_anthropic_request(self, request, context):
+                # Record identity at hook-entry time.
+                observations["request_is_body"] = request is context.raw_http_request.body
+                # Mutate the request and verify the mutation is visible via
+                # raw_http_request.body — the operator-visible contract.
+                request["system"] = "mutated-by-test"
+                observations["body_sees_mutation"] = context.raw_http_request.body.get("system") == "mutated-by-test"
+                return request
+
+        policy = _IdentityCheckingPolicy()
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=_anthropic_response("ok"))
+        deps = _make_deps(policy=policy, anthropic_client=client)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(body=request, **_send_chat_kwargs(deps=deps))
+
+        assert result.success is True
+        assert observations["request_is_body"] is True, (
+            "raw_http_request.body must alias the AnthropicRequest the hook receives — "
+            "production parity at pipeline/anthropic_processor.py."
+        )
+        assert observations["body_sees_mutation"] is True, (
+            "Top-level mutations on the AnthropicRequest must be visible through "
+            "raw_http_request.body. If not, the Before/After preview lies about production."
+        )
+
 
 class TestAuthConfigUpdateRequestValidation:
     """Test Pydantic validation on AuthConfigUpdateRequest."""

--- a/tests/luthien_proxy/unit_tests/test_admin_routes.py
+++ b/tests/luthien_proxy/unit_tests/test_admin_routes.py
@@ -11,7 +11,6 @@ These tests focus on the HTTP layer - ensuring routes properly:
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
 import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
@@ -255,383 +254,359 @@ class TestListModelsRoute:
         assert result["models"] == ["gpt-4o", "claude-3-5-sonnet-20241022"]
 
 
+class _RecordingPolicy:
+    """Stub Anthropic-execution policy that records hook calls.
+
+    Honors AnthropicExecutionInterface via duck-typing — the protocol is
+    runtime_checkable but we only need the two non-streaming hooks for
+    these tests.
+    """
+
+    def __init__(
+        self,
+        *,
+        request_transform=None,
+        response_transform=None,
+        block_response=None,
+    ):
+        self._request_transform = request_transform
+        self._response_transform = response_transform
+        self._block_response = block_response
+        self.request_calls: list[dict] = []
+        self.response_calls: list[dict] = []
+
+    async def on_anthropic_request(self, request, context):
+        self.request_calls.append(dict(request))
+        if self._request_transform is not None:
+            return self._request_transform(request)
+        return request
+
+    async def on_anthropic_response(self, response, context):
+        self.response_calls.append(dict(response))
+        if self._block_response is not None:
+            return self._block_response
+        if self._response_transform is not None:
+            return self._response_transform(response)
+        return response
+
+    # Stream hooks unused by send_chat but required for protocol completeness
+    async def on_anthropic_stream_event(self, event, context):
+        return [event]
+
+    async def on_anthropic_stream_complete(self, context):
+        return []
+
+
+def _anthropic_response(text: str, *, usage: dict | None = None) -> dict:
+    return {
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": text}],
+        "model": "claude-haiku-4-5",
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": usage or {"input_tokens": 5, "output_tokens": 7},
+    }
+
+
+def _make_deps(*, policy=None, anthropic_client=None, raise_on_get_policy=False):
+    """Build a Dependencies-like stub adequate for send_chat's call sites."""
+    deps = MagicMock()
+    deps.anthropic_client = anthropic_client
+    if raise_on_get_policy:
+        deps.get_anthropic_policy = MagicMock(
+            side_effect=HTTPException(
+                status_code=500,
+                detail="Current policy FooPolicy does not implement AnthropicExecutionInterface",
+            )
+        )
+    else:
+        deps.get_anthropic_policy = MagicMock(return_value=policy)
+    return deps
+
+
 class TestSendChatRoute:
-    """Test send_chat route handler."""
+    """Test send_chat route handler — Before/After orchestration."""
 
     @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    @patch("luthien_proxy.admin.routes.httpx.AsyncClient")
-    async def test_successful_chat_request(self, mock_client_class, mock_get_settings):
-        """Test successful test chat request."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = "test-proxy-key"
-        mock_settings.gateway_port = 8000
-        mock_get_settings.return_value = mock_settings
+    async def test_passthrough_policy_runs_one_llm_call(self):
+        """Policy that doesn't transform request: single LLM call, Before == After."""
+        policy = _RecordingPolicy()  # passthrough on both hooks
+        before = _anthropic_response("raw LLM output")
 
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "id": "msg_123",
-            "content": [{"type": "text", "text": "Hello from the LLM!"}],
-            "usage": {"input_tokens": 10, "output_tokens": 5},
-        }
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=before)
 
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
+        deps = _make_deps(policy=policy, anthropic_client=client)
 
-        request = ChatRequest(model="claude-3-haiku-20240307", message="Hello!")
-
-        result = await send_chat(body=request, _=AUTH_TOKEN)
+        request = ChatRequest(model="claude-haiku-4-5", message="Hello!")
+        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
 
         assert isinstance(result, ChatResponse)
         assert result.success is True
-        assert result.content == "Hello from the LLM!"
-        assert result.model == "claude-3-haiku-20240307"
-        assert result.usage is not None
-        assert result.usage["input_tokens"] == 10
-
-        mock_client.post.assert_called_once()
-        call_args = mock_client.post.call_args
-        assert call_args[0][0] == "http://localhost:8000/v1/messages"
-        assert call_args[1]["json"]["model"] == "claude-3-haiku-20240307"
-        assert call_args[1]["json"]["messages"][0]["content"] == "Hello!"
-        assert call_args[1]["headers"]["x-api-key"] == "test-proxy-key"
+        assert result.before_content == "raw LLM output"
+        assert result.content == "raw LLM output"
+        # Only one LLM call when request hook is a passthrough.
+        assert client.complete.call_count == 1
+        assert len(policy.request_calls) == 1
+        assert len(policy.response_calls) == 1
 
     @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    async def test_missing_client_api_key_and_no_custom(self, mock_get_settings):
-        """Test send_chat returns error when no API key is available."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = None
-        mock_get_settings.return_value = mock_settings
+    async def test_response_transforming_policy_changes_after(self):
+        """Policy transforms response only: Before is raw, After reflects transform."""
 
-        request = ChatRequest(model="gpt-4o", message="Hello!")
+        def upper(response):
+            new = dict(response)
+            new["content"] = [{"type": "text", "text": response["content"][0]["text"].upper()}]
+            return new
 
-        result = await send_chat(body=request, _=AUTH_TOKEN)
+        policy = _RecordingPolicy(response_transform=upper)
+        before = _anthropic_response("hello world")
 
-        assert isinstance(result, ChatResponse)
-        assert result.success is False
-        assert "No API key available" in result.error
-        assert result.model == "gpt-4o"
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=before)
+        deps = _make_deps(policy=policy, anthropic_client=client)
 
-    @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    @patch("luthien_proxy.admin.routes.httpx.AsyncClient")
-    async def test_custom_key_works_without_client_key(self, mock_client_class, mock_get_settings):
-        """Custom api_key works even when CLIENT_API_KEY is not configured."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = None
-        mock_settings.gateway_port = 8000
-        mock_get_settings.return_value = mock_settings
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "id": "msg_123",
-            "content": [{"type": "text", "text": "OK"}],
-        }
-
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
-
-        request = ChatRequest(model="claude-3-haiku-20240307", message="Hello!", api_key="custom-key")
-
-        result = await send_chat(body=request, _=AUTH_TOKEN)
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
 
         assert result.success is True
-        call_args = mock_client.post.call_args
-        assert call_args[1]["headers"]["x-api-key"] == "custom-key"
+        assert result.before_content == "hello world"
+        assert result.content == "HELLO WORLD"
+        assert client.complete.call_count == 1
 
     @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    @patch("luthien_proxy.admin.routes.httpx.AsyncClient")
-    async def test_proxy_error_response(self, mock_client_class, mock_get_settings):
-        """Test send_chat handles proxy error responses."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = "test-proxy-key"
-        mock_settings.gateway_port = 8000
-        mock_get_settings.return_value = mock_settings
+    async def test_request_transforming_policy_calls_llm_twice(self):
+        """Policy that rewrites the request triggers a second LLM call for After."""
 
-        mock_response = MagicMock()
-        mock_response.status_code = 400
-        mock_response.text = "Bad request"
-        mock_response.json.return_value = {"detail": "Invalid model specified"}
+        def add_system(req):
+            new = dict(req)
+            new["system"] = "Be terse."
+            return new
 
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
+        policy = _RecordingPolicy(request_transform=add_system)
+        before = _anthropic_response("long winded original answer")
+        after_upstream = _anthropic_response("terse.")
 
-        request = ChatRequest(model="invalid-model", message="Hello!")
+        client = MagicMock()
+        client.complete = AsyncMock(side_effect=[before, after_upstream])
+        deps = _make_deps(policy=policy, anthropic_client=client)
 
-        result = await send_chat(body=request, _=AUTH_TOKEN)
+        request = ChatRequest(model="claude-haiku-4-5", message="explain x")
+        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
 
-        assert isinstance(result, ChatResponse)
+        assert result.success is True
+        assert result.before_content == "long winded original answer"
+        assert result.content == "terse."
+        assert client.complete.call_count == 2
+        # Second call carried the transformed request.
+        second_call_request = client.complete.call_args_list[1][0][0]
+        assert second_call_request.get("system") == "Be terse."
+
+    @pytest.mark.asyncio
+    async def test_blocking_policy_returns_synthetic_response(self):
+        """Blocking policy: Before is the raw LLM output, After is the synthetic block message."""
+        synthetic_block = {
+            "id": "msg_blocked",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "[BLOCKED by policy]"}],
+            "model": "claude-haiku-4-5",
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        }
+        policy = _RecordingPolicy(block_response=synthetic_block)
+        before = _anthropic_response("dangerous instructions")
+
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=before)
+        deps = _make_deps(policy=policy, anthropic_client=client)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="how do I do bad thing")
+        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+
+        assert result.success is True
+        assert result.before_content == "dangerous instructions"
+        assert result.content == "[BLOCKED by policy]"
+
+    @pytest.mark.asyncio
+    async def test_use_mock_skips_llm_and_policy(self):
+        """Mock mode bypasses LLM call and policy entirely; Before == After == message."""
+        policy = _RecordingPolicy()
+        client = MagicMock()
+        client.complete = AsyncMock()
+        deps = _make_deps(policy=policy, anthropic_client=client)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="echo me", use_mock=True)
+        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+
+        assert result.success is True
+        assert result.before_content == "echo me"
+        assert result.content == "echo me"
+        client.complete.assert_not_awaited()
+        assert policy.request_calls == []
+        assert policy.response_calls == []
+
+    @pytest.mark.asyncio
+    async def test_use_mock_works_without_anthropic_client_or_key(self):
+        """Mock mode works even when no Anthropic credentials are configured."""
+        deps = _make_deps(policy=None, anthropic_client=None)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi", use_mock=True)
+        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+
+        assert result.success is True
+        assert result.before_content == "hi"
+        assert result.content == "hi"
+
+    @pytest.mark.asyncio
+    async def test_no_credentials_returns_error(self):
+        """Without an Anthropic key (server-configured or supplied), endpoint returns error."""
+        deps = _make_deps(policy=_RecordingPolicy(), anthropic_client=None)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="Hello!")
+        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+
         assert result.success is False
-        assert "400" in result.error
-        assert "Invalid model specified" in result.error
+        assert result.error is not None
+        assert "Anthropic API key" in result.error
 
     @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    @patch("luthien_proxy.admin.routes.httpx.AsyncClient")
-    async def test_timeout_exception(self, mock_client_class, mock_get_settings):
-        """Test send_chat handles timeout exceptions."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = "test-proxy-key"
-        mock_get_settings.return_value = mock_settings
+    @patch("luthien_proxy.admin.routes.anthropic_client_cache.get_client")
+    async def test_supplied_api_key_routes_through_cache(self, mock_get_client):
+        """A caller-supplied api_key resolves a client via the anthropic client cache."""
+        cached_client = MagicMock()
+        cached_client.complete = AsyncMock(return_value=_anthropic_response("ok"))
+        mock_get_client.return_value = cached_client
 
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(side_effect=httpx.TimeoutException("Request timed out"))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
+        deps = _make_deps(policy=_RecordingPolicy(), anthropic_client=None)
+        request = ChatRequest(model="claude-haiku-4-5", message="hi", api_key="sk-test-1")
 
-        mock_settings.gateway_port = 8000
-        request = ChatRequest(model="gpt-4o", message="Hello!")
+        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
 
-        result = await send_chat(body=request, _=AUTH_TOKEN)
+        assert result.success is True
+        assert result.before_content == "ok"
+        mock_get_client.assert_awaited_once_with("sk-test-1", auth_type="api_key")
 
-        assert isinstance(result, ChatResponse)
+    @pytest.mark.asyncio
+    async def test_llm_failure_is_reported(self):
+        """LLM call failure surfaces as an error response (no content, no Before)."""
+        policy = _RecordingPolicy()
+        client = MagicMock()
+        client.complete = AsyncMock(side_effect=RuntimeError("anthropic 500"))
+        deps = _make_deps(policy=policy, anthropic_client=client)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+
         assert result.success is False
-        assert "timed out" in result.error
-        assert "120s" in result.error
+        assert result.before_content is None
+        assert result.content is None
+        assert result.error is not None
+        # Policy hooks should not have run if the LLM call failed.
+        assert policy.request_calls == []
+        assert policy.response_calls == []
 
     @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    @patch("luthien_proxy.admin.routes.httpx.AsyncClient")
-    async def test_unexpected_exception_does_not_leak_details(self, mock_client_class, mock_get_settings):
-        """Test send_chat returns generic error without leaking internal details."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = "test-proxy-key"
-        mock_settings.gateway_port = 8000
-        mock_settings.verbose_client_errors = False
-        mock_get_settings.return_value = mock_settings
+    async def test_policy_request_hook_failure_surfaces_with_before(self):
+        """If on_anthropic_request raises, Before is preserved and an error is returned."""
 
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(side_effect=RuntimeError("connection to 10.0.0.5:5432 refused"))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
+        def boom(_req):
+            raise RuntimeError("policy request hook crashed")
 
-        request = ChatRequest(model="gpt-4o", message="Hello!")
+        policy = _RecordingPolicy(request_transform=boom)
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=_anthropic_response("raw"))
+        deps = _make_deps(policy=policy, anthropic_client=client)
 
-        result = await send_chat(body=request, _=AUTH_TOKEN)
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
 
-        assert isinstance(result, ChatResponse)
         assert result.success is False
-        assert result.error == "An unexpected error occurred"
-        assert "connection" not in result.error.lower()
-        assert "10.0.0.5" not in result.error
+        assert result.before_content == "raw"
+        assert result.content is None
+        assert result.error is not None
+        assert "request hook" in result.error.lower()
 
     @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    @patch("luthien_proxy.admin.routes.httpx.AsyncClient")
-    async def test_uses_localhost_with_gateway_port(self, mock_client_class, mock_get_settings):
-        """send_chat always calls http://localhost:{gateway_port}, not the external request URL.
+    async def test_policy_response_hook_failure_surfaces_with_before(self):
+        """If on_anthropic_response raises, Before is preserved and an error is returned."""
 
-        This ensures the test chat endpoint works both on the host and inside Docker,
-        where the external port mapping is not reachable from within the container.
+        def boom(_resp):
+            raise RuntimeError("policy response hook crashed")
+
+        policy = _RecordingPolicy(response_transform=boom)
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=_anthropic_response("raw"))
+        deps = _make_deps(policy=policy, anthropic_client=client)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+
+        assert result.success is False
+        assert result.before_content == "raw"
+        assert result.content is None
+        assert result.error is not None
+        assert "response hook" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_active_policy_not_anthropic_raises_500(self):
+        """If the active policy doesn't implement AnthropicExecutionInterface, 500 is raised."""
+        client = MagicMock()
+        client.complete = AsyncMock()
+        deps = _make_deps(policy=None, anthropic_client=client, raise_on_get_policy=True)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="hi")
+        with pytest.raises(HTTPException) as exc_info:
+            await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+
+        assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_no_text_blocks_returns_none_content(self):
+        """Tool-use-only response (no text blocks) returns None content — preview can't render it."""
+        tool_use_response = {
+            "id": "msg_tool",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": "toolu_1", "name": "calc", "input": {"x": 1}},
+            ],
+            "model": "claude-haiku-4-5",
+            "stop_reason": "tool_use",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 5, "output_tokens": 5},
+        }
+        policy = _RecordingPolicy()
+        client = MagicMock()
+        client.complete = AsyncMock(return_value=tool_use_response)
+        deps = _make_deps(policy=policy, anthropic_client=client)
+
+        request = ChatRequest(model="claude-haiku-4-5", message="use a tool")
+        result = await send_chat(body=request, _=AUTH_TOKEN, deps=deps)
+
+        assert result.success is True
+        assert result.before_content is None
+        assert result.content is None
+
+    @pytest.mark.asyncio
+    async def test_does_not_make_http_call_to_v1_messages(self):
+        """Regression guard: send_chat must not import or use httpx for /v1/messages roundtrip.
+
+        Architectural principle — policies decide; clients (including this admin
+        path) do not. The previous design routed test traffic through the
+        gateway HTTP boundary, which let a client opt into a non-default
+        response shape via a header. The current design orchestrates LLM and
+        policy as two in-process steps. This test pins that.
         """
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = "test-proxy-key"
-        mock_settings.gateway_port = 9999
-        mock_get_settings.return_value = mock_settings
+        import luthien_proxy.admin.routes as admin_routes
 
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"id": "msg_123", "content": [{"type": "text", "text": "OK"}]}
-
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
-
-        request = ChatRequest(model="claude-3-haiku-20240307", message="Test")
-
-        await send_chat(body=request, _=AUTH_TOKEN)
-
-        call_args = mock_client.post.call_args
-        url = call_args[0][0]
-        assert url == "http://localhost:9999/v1/messages"
-
-    @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    @patch("luthien_proxy.admin.routes.httpx.AsyncClient")
-    async def test_real_llm_call_by_default(self, mock_client_class, mock_get_settings):
-        """Default use_mock=False does not include mock_response (real LLM call attempted)."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = "test-proxy-key"
-        mock_settings.gateway_port = 8000
-        mock_get_settings.return_value = mock_settings
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"id": "msg_123", "content": [{"type": "text", "text": "real"}]}
-
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
-
-        request = ChatRequest(model="claude-3-haiku-20240307", message="Hello!")  # use_mock defaults to False
-
-        await send_chat(body=request, _=AUTH_TOKEN)
-
-        call_args = mock_client.post.call_args
-        assert "mock_response" not in call_args[1]["json"]
-
-    @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    async def test_mock_response_sent_when_use_mock_true(self, mock_get_settings):
-        """When use_mock=True, function returns directly without calling gateway."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = "test-proxy-key"
-        mock_settings.gateway_port = 8000
-        mock_get_settings.return_value = mock_settings
-
-        request = ChatRequest(model="claude-3-haiku-20240307", message="Hello!", use_mock=True)
-
-        result = await send_chat(body=request, _=AUTH_TOKEN)
-
-        assert isinstance(result, ChatResponse)
-        assert result.success is True
-        assert result.content == "Hello!"
-
-    @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    async def test_mock_mode_works_without_any_api_key(self, mock_get_settings):
-        """Mock mode bypasses API key validation entirely."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = None
-        mock_settings.gateway_port = 8000
-        mock_get_settings.return_value = mock_settings
-
-        request = ChatRequest(model="claude-3-haiku-20240307", message="test echo", use_mock=True)
-
-        result = await send_chat(body=request, _=AUTH_TOKEN)
-
-        assert result.success is True
-        assert result.content == "test echo"
-
-    @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    @patch("luthien_proxy.admin.routes.httpx.AsyncClient")
-    async def test_custom_api_key_overrides_client_key(self, mock_client_class, mock_get_settings):
-        """When api_key is provided, it's used instead of the server's proxy key."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = "server-proxy-key"
-        mock_settings.gateway_port = 8000
-        mock_get_settings.return_value = mock_settings
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"id": "msg_123", "content": [{"type": "text", "text": "OK"}]}
-
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
-
-        request = ChatRequest(model="claude-3-haiku-20240307", message="Hello!", api_key="custom-key-123")
-
-        await send_chat(body=request, _=AUTH_TOKEN)
-
-        call_args = mock_client.post.call_args
-        assert call_args[1]["headers"]["x-api-key"] == "custom-key-123"
-
-    @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    @patch("luthien_proxy.admin.routes.httpx.AsyncClient")
-    async def test_none_api_key_uses_client_key(self, mock_client_class, mock_get_settings):
-        """When api_key is None (default), the server's proxy key is used."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = "server-proxy-key"
-        mock_settings.gateway_port = 8000
-        mock_get_settings.return_value = mock_settings
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"id": "msg_123", "content": [{"type": "text", "text": "OK"}]}
-
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
-
-        request = ChatRequest(model="claude-3-haiku-20240307", message="Hello!")
-
-        await send_chat(body=request, _=AUTH_TOKEN)
-
-        call_args = mock_client.post.call_args
-        assert call_args[1]["headers"]["x-api-key"] == "server-proxy-key"
-
-    @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    @patch("luthien_proxy.admin.routes.httpx.AsyncClient")
-    async def test_empty_api_key_uses_client_key(self, mock_client_class, mock_get_settings):
-        """An empty string api_key falls back to the server's proxy key."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = "server-proxy-key"
-        mock_settings.gateway_port = 8000
-        mock_get_settings.return_value = mock_settings
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"id": "msg_123", "content": [{"type": "text", "text": "OK"}]}
-
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
-
-        request = ChatRequest(model="claude-3-haiku-20240307", message="Hello!", api_key="")
-
-        await send_chat(body=request, _=AUTH_TOKEN)
-
-        call_args = mock_client.post.call_args
-        assert call_args[1]["headers"]["x-api-key"] == "server-proxy-key"
-
-    @pytest.mark.asyncio
-    @patch("luthien_proxy.admin.routes.get_settings")
-    @patch("luthien_proxy.admin.routes.httpx.AsyncClient")
-    async def test_whitespace_api_key_uses_client_key(self, mock_client_class, mock_get_settings):
-        """A whitespace-only api_key falls back to the server's proxy key."""
-        mock_settings = MagicMock()
-        mock_settings.client_api_key = "server-proxy-key"
-        mock_settings.gateway_port = 8000
-        mock_get_settings.return_value = mock_settings
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "id": "msg_123",
-            "content": [{"type": "text", "text": "OK"}],
-        }
-
-        mock_client = AsyncMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=None)
-        mock_client_class.return_value = mock_client
-
-        request = ChatRequest(model="claude-3-haiku-20240307", message="Hello!", api_key="   ")
-
-        await send_chat(body=request, _=AUTH_TOKEN)
-
-        call_args = mock_client.post.call_args
-        assert call_args[1]["headers"]["x-api-key"] == "server-proxy-key"
+        assert not hasattr(admin_routes, "httpx"), (
+            "admin.routes must not import httpx — the test endpoint orchestrates "
+            "LLM + policy in-process and never crosses the /v1/messages HTTP boundary."
+        )
 
     def test_chat_request_api_key_defaults_to_none(self):
         """ChatRequest.api_key defaults to None when not provided."""
@@ -642,6 +617,12 @@ class TestSendChatRoute:
         """ChatRequest accepts api_key parameter."""
         request = ChatRequest(model="claude-3-haiku-20240307", message="Hello!", api_key="sk-test")
         assert request.api_key == "sk-test"
+
+    def test_chat_response_includes_before_content_field(self):
+        """ChatResponse includes the new before_content field."""
+        resp = ChatResponse(success=True, content="after", before_content="before")
+        assert resp.content == "after"
+        assert resp.before_content == "before"
 
 
 class TestAuthConfigUpdateRequestValidation:

--- a/tests/luthien_proxy/unit_tests/utils/test_policy_cache.py
+++ b/tests/luthien_proxy/unit_tests/utils/test_policy_cache.py
@@ -10,7 +10,7 @@ import pytest
 
 from luthien_proxy.utils.db import DatabasePool
 from luthien_proxy.utils.db_sqlite import SqlitePool
-from luthien_proxy.utils.policy_cache import DEFAULT_MAX_ENTRIES, PolicyCache
+from luthien_proxy.utils.policy_cache import DEFAULT_MAX_ENTRIES, PolicyCache, build_factory
 
 
 @pytest.fixture
@@ -815,3 +815,49 @@ class TestPolicyCacheSizeCap:
         # The oldest dead row is gone; the most-recent put always survives.
         assert await cache.get("c_live") == {"v": "live"}
         assert await cache.get("a_dead") is None
+
+
+class TestBuildFactory:
+    """build_factory is the shared call site used by both the gateway pipeline
+    and the admin policy-test endpoint to assemble PolicyCache instances. The
+    rules it encodes (None on no-DB, lazy settings read, non-positive cap →
+    unbounded) live in this one helper rather than being duplicated.
+    """
+
+    def test_returns_none_when_db_pool_is_none(self):
+        """No DB → no factory. Caller (PolicyContext) treats this as 'caching unavailable'."""
+        assert build_factory(None) is None
+
+    def test_returns_callable_when_db_pool_provided(self, monkeypatch):
+        """With a DB, returns a factory that, called with a name, builds a PolicyCache."""
+        from luthien_proxy.utils import policy_cache as policy_cache_module
+
+        # Patch the symbol policy_cache imported (top-level import binds the
+        # callable into this module's namespace; patching settings.get_settings
+        # directly wouldn't affect the bound reference).
+        fake_settings = MagicMock()
+        fake_settings.policy_cache_max_entries = 42
+        monkeypatch.setattr(policy_cache_module, "get_settings", lambda: fake_settings)
+
+        db_pool = MagicMock(spec=DatabasePool)
+        factory = build_factory(db_pool)
+        assert factory is not None
+
+        cache = factory("my-policy")
+        assert isinstance(cache, PolicyCache)
+        assert cache.max_entries == 42
+
+    def test_non_positive_cap_means_unbounded(self, monkeypatch):
+        """policy_cache_max_entries=0 (or negative) → max_entries=None (unbounded)."""
+        from luthien_proxy.utils import policy_cache as policy_cache_module
+
+        fake_settings = MagicMock()
+        fake_settings.policy_cache_max_entries = 0
+        monkeypatch.setattr(policy_cache_module, "get_settings", lambda: fake_settings)
+
+        db_pool = MagicMock(spec=DatabasePool)
+        factory = build_factory(db_pool)
+        assert factory is not None
+
+        cache = factory("my-policy")
+        assert cache.max_entries is None  # unbounded


### PR DESCRIPTION
## Summary

Operators configuring a policy in the admin UI need a side-by-side preview of what their test input looks like with no policy in the way (**Before**) versus what the active policy turned it into (**After**). This PR refactors the admin policy-test endpoint (`POST /api/admin/test/chat`) to orchestrate the LLM call and the active policy as two separate in-process steps and return both values, so operators can verify a policy actually does what they think before activating it on real traffic. UI work (PR #505) will rebase on top of this and add the diff view.

## Architectural principle

**Policies decide what happens to a request. Clients do not.**

The previous shape of this feature (in PR #505) implemented Before/After by adding an `x-luthien-capture-before` HTTP header on `/v1/messages` plus an admin-key-gated body-field injection. That violated the principle: it let a client opt into a non-default response shape by setting a header on the LLM-traffic endpoint. This PR uses a different approach. The admin test endpoint now:

1. Resolves the active policy via `Dependencies.get_anthropic_policy()` (the same source the gateway uses).
2. Resolves an `AnthropicClient` via the existing `anthropic_client_cache`.
3. Calls Anthropic with the original request → `before_content`.
4. Builds a **full `PolicyContext`** matching the one the gateway pipeline constructs (same emitter, credential manager, policy cache factory, raw HTTP request, user credential shape) and runs `policy.on_anthropic_request` / `on_anthropic_response` against it (re-calling Anthropic if the request was transformed) → `content`.

The gateway's `/v1/messages` HTTP boundary is never involved. `pipeline/anthropic_processor.py` and `gateway_routes.py` are otherwise untouched — the only gateway-side change is that `anthropic_processor.py` now calls into the shared `utils.policy_cache.build_factory` helper so the cap-resolution rule isn't duplicated between the admin endpoint and the pipeline.

## Policy compatibility

The full PolicyContext means **judge-style policies work through the test endpoint** — `SimpleLLMPolicy` and similar LLM-judge policies, `ToolCallJudgePolicy`, `DogfoodSafetyPolicy`, the Block presets — exactly as they do for real `/v1/messages` traffic. There's an end-to-end unit test that exercises a `SimpleLLMPolicy` instance through the endpoint with a mocked judge call to pin this.

## Observability

Test-path policy execution emits the same observability events as production runs and appears in the activity monitor. Test session ids are prefixed `admin-test-session-` so operators can identify or filter test traffic. Decision rationale: test-like-production is more useful for debugging than a separate test sink, and a per-event `is_test_run` tag is a future option if telemetry pollution becomes a real concern.

## Caveats

- **Model jitter**: when `on_anthropic_request` rewrites the request and triggers a second LLM call, `before_content` and `content` are two independent LLM samples. The Before/After diff includes sampling variance, not just the policy's effect. Operators wanting clean policy-effect previews of request-transforming policies should set `temperature=0` upstream. Documented on `ChatResponse`, the `before_content` field, and the `send_chat` docstring.
- **Streaming-only policies**: appear as no-ops in the After view by design — the non-streaming hooks are the source of truth for the test path. Faking a stream would mislead the operator.
- **Tool-use / thinking blocks**: elided from the text preview (`before_content` / `content` concatenate text-block content only).

## Notes for the UI PR

PR #505 should rebase on top of this branch and:
  - Drop the `x-luthien-capture-before` header / `_luthien_before` body-field plumbing.
  - Read both `before_content` and `content` (and `before_usage` / `usage`) from `ChatResponse` and render the diff.

## Resolved review items

- **Bug #1 — signature snapshot.** Pre-hook deep-copy snapshot replaces JSON signature; in-place mutating policies that return the same dict reference now correctly trigger a second LLM call. Regression test added.
- **Bug #2 — `anthropic-beta` forwarding.** Mirrors the gateway's behavior; both LLM calls (Before and the request-transformed After) carry the inbound beta header.
- **Improvement #3 — `before_usage` on `ChatResponse`.** Operators see total cost across both LLM calls.
- **Improvement #4 — drop `_request_signature`.** Direct dict equality against the snapshot.
- **Improvement #5 — drop redundant isinstance.** `_coerce_usage(after_response)` directly.
- **Refactor #6 — shared `build_factory`.** Extracted to `utils/policy_cache.py`; both the admin endpoint and `pipeline/anthropic_processor.py` use it.
- **Doc #7 — model jitter caveat.** Documented in three places.
- **Coverage #8 — protocol assert + cache-failure test.** Added.

## Deferred (not this PR)

- `is_test_run` event tag for filtering test traffic in the activity monitor — broader observability decision.
- Surfacing `request_summary` / `response_summary` on `ChatResponse` — UI-coupled; lands with #505 when consumed.
- httpx-import AST guard / import-linter rule — separate hygiene PR.
- Mock-mode policy execution (running the policy on a synthesized response) — current behavior is intentional; operator who wants the policy to run can drop `use_mock=True`.
- `max_tokens` on `ChatRequest` — out of scope.
- Mock-mode UI label / streaming no-op UI hint — UI concerns; lands with #505.

## Test plan

- [x] `uv run pytest tests/luthien_proxy/unit_tests` — 2224 passed
- [x] `./scripts/dev_checks.sh` — clean (format + ruff + pyright + radon)
- [x] 30 tests in `TestSendChatRoute` cover: orchestration happy paths, request/response transforms, request-transform two-LLM-call path, in-place-mutating-request-hook regression, blocking policy, mock mode, missing credentials, supplied `api_key` cache routing + cache failure, anthropic-beta header forwarding (with/without), `before_usage` parity (single call) + distinct counts (two calls) + preservation on hook failure, LLM/policy failure paths, non-Anthropic active policy, tool-use-only response, full-PolicyContext wiring, `user_credential` shape, policy-cache-factory wiring, and a `SimpleLLMPolicy` end-to-end run with real credential resolution + mocked judge call.
- [x] 3 new tests for `utils.policy_cache.build_factory` itself.
- [ ] Manual smoke test against a running gateway with a real judge policy once the UI lands.

---
Posted by Claude Code (claude-opus-4-7[1m]) on behalf of Jai.