### PR TITLE
chore: set objective to add per-key rate limiting on /v1/ routes (GH #704)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,17 @@
 # LOCALHOST_AUTH_BYPASS=true
 
 
+# === RATE_LIMITING ===============================================
+
+# Per-key request rate limit (requests per minute). 0 disables rate limiting.
+# (can also be set at runtime via admin API)
+# RATE_LIMIT_RPM=0
+
+# Per-key burst size (max tokens above RPM). 0 defaults to RPM value.
+# (can also be set at runtime via admin API)
+# RATE_LIMIT_BURST=0
+
+
 # === POLICY ======================================================
 
 # Policy loading strategy: db, file, db-fallback-file, file-fallback-db

--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@
 
 # === RATE_LIMITING ===============================================
 
-# Per-key request rate limit (requests per minute). 0 disables rate limiting.
+# Per-key request rate limit (requests per minute). 0 disables rate limiting. Keyed on the auth credential — in CLIENT_KEY mode all users share one bucket.
 # RATE_LIMIT_RPM=0
 
 # Per-key burst size (max tokens above RPM). 0 defaults to RPM value.

--- a/.env.example
+++ b/.env.example
@@ -37,11 +37,9 @@
 # === RATE_LIMITING ===============================================
 
 # Per-key request rate limit (requests per minute). 0 disables rate limiting.
-# (can also be set at runtime via admin API)
 # RATE_LIMIT_RPM=0
 
 # Per-key burst size (max tokens above RPM). 0 defaults to RPM value.
-# (can also be set at runtime via admin API)
 # RATE_LIMIT_BURST=0
 
 

--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@
 # Per-key request rate limit (requests per minute). 0 disables rate limiting. Keyed on the auth credential — in CLIENT_KEY mode all users share one bucket.
 # RATE_LIMIT_RPM=0
 
-# Per-key burst size (max tokens above RPM). 0 defaults to RPM value.
+# Per-key burst capacity (absolute token bucket cap). 0 defaults to RPM value. Must be >= 1 if set.
 # RATE_LIMIT_BURST=0
 
 

--- a/changelog.d/feat-per-key-rate-limiting.md
+++ b/changelog.d/feat-per-key-rate-limiting.md
@@ -1,0 +1,6 @@
+---
+category: Features
+pr: 729
+---
+
+**Per-key rate limiting on /v1/ routes**: Token bucket rate limiter (in-process, asyncio-safe) applied to all `/v1/` requests. Configurable via `RATE_LIMIT_RPM` (requests per minute, 0=disabled) and `RATE_LIMIT_BURST` (burst size). Returns HTTP 429 with `Retry-After`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers when exceeded.

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -4,7 +4,8 @@
 set -uo pipefail
 
 # Only act on Python files that are staged (Added, Modified, Copied, Renamed)
-mapfile -t staged_py < <(git diff --cached --name-only --diff-filter=ACMR -- '*.py')
+staged_py=()
+while IFS= read -r line; do [[ -n "$line" ]] && staged_py+=("$line"); done < <(git diff --cached --name-only --diff-filter=ACMR -- '*.py')
 [ "${#staged_py[@]}" -eq 0 ] && exit 0
 
 echo "pre-commit: formatting ${#staged_py[@]} staged Python file(s)..."

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -4,8 +4,7 @@
 set -uo pipefail
 
 # Only act on Python files that are staged (Added, Modified, Copied, Renamed)
-staged_py=()
-while IFS= read -r line; do [[ -n "$line" ]] && staged_py+=("$line"); done < <(git diff --cached --name-only --diff-filter=ACMR -- '*.py')
+mapfile -t staged_py < <(git diff --cached --name-only --diff-filter=ACMR -- '*.py')
 [ "${#staged_py[@]}" -eq 0 ] && exit 0
 
 echo "pre-commit: formatting ${#staged_py[@]} staged Python file(s)..."

--- a/src/luthien_proxy/config_fields.py
+++ b/src/luthien_proxy/config_fields.py
@@ -98,6 +98,18 @@ CONFIG_FIELDS: tuple[ConfigFieldMeta, ...] = (
         category="auth", db_settable=True, restart_required=False,
     ),
 
+    # ── rate limiting ─────────────────────────────────────────────────────────
+    ConfigFieldMeta(
+        "rate_limit_rpm", "RATE_LIMIT_RPM", int, 0,
+        "Per-key request rate limit (requests per minute). 0 disables rate limiting.",
+        category="rate_limiting", restart_required=True,
+    ),
+    ConfigFieldMeta(
+        "rate_limit_burst", "RATE_LIMIT_BURST", int, 0,
+        "Per-key burst size (max tokens above RPM). 0 defaults to RPM value.",
+        category="rate_limiting", restart_required=True,
+    ),
+
     # ── policy ────────────────────────────────────────────────────────────
     ConfigFieldMeta(
         "policy_source", "POLICY_SOURCE", str, "db-fallback-file",
@@ -162,18 +174,6 @@ CONFIG_FIELDS: tuple[ConfigFieldMeta, ...] = (
         "anthropic_client_cache_size", "ANTHROPIC_CLIENT_CACHE_SIZE", int, 16,
         "Max number of cached Anthropic client instances for passthrough auth",
         category="llm",
-    ),
-
-    # ── rate limiting ─────────────────────────────────────────────────────────
-    ConfigFieldMeta(
-        "rate_limit_rpm", "RATE_LIMIT_RPM", int, 0,
-        "Per-key request rate limit (requests per minute). 0 disables rate limiting.",
-        category="rate_limiting", db_settable=True, restart_required=False,
-    ),
-    ConfigFieldMeta(
-        "rate_limit_burst", "RATE_LIMIT_BURST", int, 0,
-        "Per-key burst size (max tokens above RPM). 0 defaults to RPM value.",
-        category="rate_limiting", db_settable=True, restart_required=False,
     ),
 
     # ── security ──────────────────────────────────────────────────────────

--- a/src/luthien_proxy/config_fields.py
+++ b/src/luthien_proxy/config_fields.py
@@ -164,6 +164,18 @@ CONFIG_FIELDS: tuple[ConfigFieldMeta, ...] = (
         category="llm",
     ),
 
+    # ── rate limiting ─────────────────────────────────────────────────────────
+    ConfigFieldMeta(
+        "rate_limit_rpm", "RATE_LIMIT_RPM", int, 0,
+        "Per-key request rate limit (requests per minute). 0 disables rate limiting.",
+        category="rate_limiting", db_settable=True, restart_required=False,
+    ),
+    ConfigFieldMeta(
+        "rate_limit_burst", "RATE_LIMIT_BURST", int, 0,
+        "Per-key burst size (max tokens above RPM). 0 defaults to RPM value.",
+        category="rate_limiting", db_settable=True, restart_required=False,
+    ),
+
     # ── security ──────────────────────────────────────────────────────────
     ConfigFieldMeta(
         "credential_encryption_key", "CREDENTIAL_ENCRYPTION_KEY", str, None,
@@ -264,6 +276,7 @@ CONFIG_FIELDS_BY_NAME: dict[str, ConfigFieldMeta] = {f.name: f for f in CONFIG_F
 CONFIG_CATEGORIES: tuple[str, ...] = (
     "server",
     "auth",
+    "rate_limiting",
     "policy",
     "database",
     "llm",

--- a/src/luthien_proxy/config_fields.py
+++ b/src/luthien_proxy/config_fields.py
@@ -106,7 +106,7 @@ CONFIG_FIELDS: tuple[ConfigFieldMeta, ...] = (
     ),
     ConfigFieldMeta(
         "rate_limit_burst", "RATE_LIMIT_BURST", int, 0,
-        "Per-key burst size (max tokens above RPM). 0 defaults to RPM value.",
+        "Per-key burst capacity (absolute token bucket cap). 0 defaults to RPM value. Must be >= 1 if set.",
         category="rate_limiting", restart_required=True,
     ),
 

--- a/src/luthien_proxy/config_fields.py
+++ b/src/luthien_proxy/config_fields.py
@@ -101,7 +101,7 @@ CONFIG_FIELDS: tuple[ConfigFieldMeta, ...] = (
     # ── rate limiting ─────────────────────────────────────────────────────────
     ConfigFieldMeta(
         "rate_limit_rpm", "RATE_LIMIT_RPM", int, 0,
-        "Per-key request rate limit (requests per minute). 0 disables rate limiting.",
+        "Per-key request rate limit (requests per minute). 0 disables rate limiting. Keyed on the auth credential — in CLIENT_KEY mode all users share one bucket.",
         category="rate_limiting", restart_required=True,
     ),
     ConfigFieldMeta(

--- a/src/luthien_proxy/dependencies.py
+++ b/src/luthien_proxy/dependencies.py
@@ -18,6 +18,7 @@ from luthien_proxy.policy_core.anthropic_execution_interface import (
     AnthropicExecutionInterface,
 )
 from luthien_proxy.policy_manager import PolicyManager
+from luthien_proxy.rate_limit import TokenBucketRateLimiter
 from luthien_proxy.usage_telemetry.collector import UsageCollector
 from luthien_proxy.utils import db
 
@@ -44,6 +45,7 @@ class Dependencies:
     enable_request_logging: bool = field(default=False)
     usage_collector: UsageCollector | None = field(default=None)
     config_registry: ConfigRegistry | None = field(default=None)
+    rate_limiter: TokenBucketRateLimiter | None = field(default=None)
     last_credential_info: dict[str, Any] = field(default_factory=dict)
 
     def get_anthropic_policy(self) -> AnthropicExecutionInterface:
@@ -199,6 +201,11 @@ def get_config_registry(request: Request) -> ConfigRegistry | None:
     return get_dependencies(request).config_registry
 
 
+def get_rate_limiter(request: Request) -> TokenBucketRateLimiter | None:
+    """Get rate limiter from dependencies."""
+    return get_dependencies(request).rate_limiter
+
+
 async def require_config_registry(
     config_registry: ConfigRegistry | None = Depends(get_config_registry),
 ) -> ConfigRegistry:
@@ -250,4 +257,5 @@ __all__ = [
     "get_usage_collector",
     "get_config_registry",
     "require_config_registry",
+    "get_rate_limiter",
 ]

--- a/src/luthien_proxy/gateway_routes.py
+++ b/src/luthien_proxy/gateway_routes.py
@@ -221,7 +221,6 @@ async def anthropic_messages(
 async def proxy_passthrough(
     request: Request,
     path: str,
-    _credential: Credential = Depends(verify_token),
     _rate_limit: None = Depends(check_rate_limit),
 ):
     """Transparent proxy for /v1/* endpoints not explicitly handled.

--- a/src/luthien_proxy/gateway_routes.py
+++ b/src/luthien_proxy/gateway_routes.py
@@ -221,7 +221,8 @@ async def anthropic_messages(
 async def proxy_passthrough(
     request: Request,
     path: str,
-    _rate_limit: None = Depends(check_rate_limit),  # auth enforced transitively via check_rate_limit → verify_token
+    _credential: Credential = Depends(verify_token),
+    _rate_limit: None = Depends(check_rate_limit),
 ):
     """Transparent proxy for /v1/* endpoints not explicitly handled.
 

--- a/src/luthien_proxy/gateway_routes.py
+++ b/src/luthien_proxy/gateway_routes.py
@@ -180,6 +180,7 @@ async def check_rate_limit(
     credential: Credential = Depends(verify_token),
     rate_limiter: TokenBucketRateLimiter | None = Depends(get_rate_limiter),
 ) -> None:
+    """Enforce per-key rate limit. Raises HTTP 429 if the key's bucket is exhausted."""
     if rate_limiter is not None:
         await rate_limiter.check(credential.value)
 

--- a/src/luthien_proxy/gateway_routes.py
+++ b/src/luthien_proxy/gateway_routes.py
@@ -221,7 +221,7 @@ async def anthropic_messages(
 async def proxy_passthrough(
     request: Request,
     path: str,
-    _rate_limit: None = Depends(check_rate_limit),
+    _rate_limit: None = Depends(check_rate_limit),  # auth enforced transitively via check_rate_limit → verify_token
 ):
     """Transparent proxy for /v1/* endpoints not explicitly handled.
 

--- a/src/luthien_proxy/gateway_routes.py
+++ b/src/luthien_proxy/gateway_routes.py
@@ -221,7 +221,6 @@ async def anthropic_messages(
 async def proxy_passthrough(
     request: Request,
     path: str,
-    _: Credential = Depends(verify_token),
     _rate_limit: None = Depends(check_rate_limit),
 ):
     """Transparent proxy for /v1/* endpoints not explicitly handled.

--- a/src/luthien_proxy/gateway_routes.py
+++ b/src/luthien_proxy/gateway_routes.py
@@ -190,13 +190,13 @@ async def check_rate_limit(
 @router.post("/v1/messages")
 async def anthropic_messages(
     request: Request,
+    _rate_limit: None = Depends(check_rate_limit),
     client_and_credential: tuple[AnthropicClient, Credential | None] = Depends(resolve_anthropic_client),
     anthropic_policy: AnthropicExecutionInterface = Depends(get_anthropic_policy),
     emitter: EventEmitterProtocol = Depends(get_emitter),
     db_pool: db.DatabasePool | None = Depends(get_db_pool),
     usage_collector: UsageCollector | None = Depends(get_usage_collector),
     credential_manager: CredentialManager | None = Depends(get_credential_manager),
-    _rate_limit: None = Depends(check_rate_limit),
 ):
     """Anthropic Messages API endpoint (native Anthropic path)."""
     anthropic_client, forwarding_credential = client_and_credential

--- a/src/luthien_proxy/gateway_routes.py
+++ b/src/luthien_proxy/gateway_routes.py
@@ -21,6 +21,7 @@ from luthien_proxy.dependencies import (
     get_db_pool,
     get_dependencies,
     get_emitter,
+    get_rate_limiter,
     get_usage_collector,
 )
 from luthien_proxy.llm import anthropic_client_cache
@@ -30,6 +31,7 @@ from luthien_proxy.pipeline import process_anthropic_request
 from luthien_proxy.policy_core.anthropic_execution_interface import (
     AnthropicExecutionInterface,
 )
+from luthien_proxy.rate_limit import TokenBucketRateLimiter
 from luthien_proxy.usage_telemetry.collector import UsageCollector
 from luthien_proxy.utils import db
 
@@ -174,6 +176,14 @@ async def resolve_anthropic_client(
     return base_client, None
 
 
+async def check_rate_limit(
+    credential: Credential = Depends(verify_token),
+    rate_limiter: TokenBucketRateLimiter | None = Depends(get_rate_limiter),
+) -> None:
+    if rate_limiter is not None:
+        await rate_limiter.check(credential.value)
+
+
 # === ROUTES ===
 
 
@@ -186,6 +196,7 @@ async def anthropic_messages(
     db_pool: db.DatabasePool | None = Depends(get_db_pool),
     usage_collector: UsageCollector | None = Depends(get_usage_collector),
     credential_manager: CredentialManager | None = Depends(get_credential_manager),
+    _rate_limit: None = Depends(check_rate_limit),
 ):
     """Anthropic Messages API endpoint (native Anthropic path)."""
     anthropic_client, forwarding_credential = client_and_credential
@@ -210,6 +221,7 @@ async def proxy_passthrough(
     request: Request,
     path: str,
     _: Credential = Depends(verify_token),
+    _rate_limit: None = Depends(check_rate_limit),
 ):
     """Transparent proxy for /v1/* endpoints not explicitly handled.
 

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -43,6 +43,7 @@ from luthien_proxy.observability.redis_event_publisher import RedisEventPublishe
 from luthien_proxy.observability.sentry import init_sentry
 from luthien_proxy.pipeline.upstream_headers import validate_upstream_headers_at_startup
 from luthien_proxy.policy_manager import PolicyManager
+from luthien_proxy.rate_limit import TokenBucketRateLimiter
 from luthien_proxy.request_log import router as request_log_router
 from luthien_proxy.session import login_page_router
 from luthien_proxy.session import router as session_router
@@ -298,7 +299,15 @@ def create_app(
         else:
             logger.info("Usage telemetry disabled")
 
-        # Create Dependencies container with all services
+        _rate_limit_rpm = settings.rate_limit_rpm
+        _rate_limit_burst = settings.rate_limit_burst
+        _rate_limiter: TokenBucketRateLimiter | None = None
+        if _rate_limit_rpm and _rate_limit_rpm > 0:
+            _rate_limiter = TokenBucketRateLimiter(rpm=_rate_limit_rpm, burst=_rate_limit_burst)
+            logger.info(f"Rate limiting enabled: {_rate_limit_rpm} RPM, burst={_rate_limiter.burst}")
+        else:
+            logger.info("Rate limiting disabled (RATE_LIMIT_RPM=0)")
+
         _dependencies = Dependencies(
             db_pool=db_pool,
             redis_client=redis_client,
@@ -313,6 +322,7 @@ def create_app(
             enable_request_logging=_enable_request_logging,
             usage_collector=_usage_collector,
             config_registry=_config_registry,
+            rate_limiter=_rate_limiter,
         )
 
         # Store dependencies container in app state

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -302,9 +302,9 @@ def create_app(
         _rate_limit_rpm = settings.rate_limit_rpm
         _rate_limit_burst = settings.rate_limit_burst
         _rate_limiter: TokenBucketRateLimiter | None = None
-        if _rate_limit_rpm and _rate_limit_rpm > 0:
+        if _rate_limit_rpm > 0:
             _rate_limiter = TokenBucketRateLimiter(rpm=_rate_limit_rpm, burst=_rate_limit_burst)
-            logger.info(f"Rate limiting enabled: {_rate_limit_rpm} RPM, burst={_rate_limiter.burst}")
+            logger.info(f"Rate limiting enabled: {_rate_limit_rpm} RPM, burst={int(_rate_limiter.burst)}")
         else:
             logger.info("Rate limiting disabled (RATE_LIMIT_RPM=0)")
 

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -299,12 +299,10 @@ def create_app(
         else:
             logger.info("Usage telemetry disabled")
 
-        _rate_limit_rpm = settings.rate_limit_rpm
-        _rate_limit_burst = settings.rate_limit_burst
         _rate_limiter: TokenBucketRateLimiter | None = None
-        if _rate_limit_rpm > 0:
-            _rate_limiter = TokenBucketRateLimiter(rpm=_rate_limit_rpm, burst=_rate_limit_burst)
-            logger.info(f"Rate limiting enabled: {_rate_limit_rpm} RPM, burst={int(_rate_limiter.burst)}")
+        if settings.rate_limit_rpm > 0:
+            _rate_limiter = TokenBucketRateLimiter(rpm=settings.rate_limit_rpm, burst=settings.rate_limit_burst)
+            logger.info(f"Rate limiting enabled: {settings.rate_limit_rpm} RPM, burst={int(_rate_limiter.burst)}")
         else:
             logger.info("Rate limiting disabled (RATE_LIMIT_RPM=0)")
 

--- a/src/luthien_proxy/rate_limit.py
+++ b/src/luthien_proxy/rate_limit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import math
 import time
 
@@ -15,36 +16,51 @@ class TokenBucketRateLimiter:
     Uses one asyncio.Lock per key to ensure concurrency safety without a global
     bottleneck. A meta-lock serialises only the short dict lookup/creation step.
 
+    Keys are SHA-256 hashed before storage so raw credential values are never
+    held in memory.
+
     RPM=0 disables limiting entirely (all requests pass through unchecked).
     """
 
-    def __init__(self, rpm: int, burst: int) -> None:
+    def __init__(self, rpm: int, burst: int, max_keys: int = 10_000) -> None:
         """Initialise the rate limiter.
 
         Args:
             rpm: Requests per minute. 0 disables rate limiting.
             burst: Maximum token accumulation above RPM. 0 defaults to rpm.
+            max_keys: Maximum number of per-key buckets to retain (LRU-style
+                eviction removes the oldest entry when exceeded).
         """
         self.rpm = rpm
         self.burst = burst if burst > 0 else rpm
+        self.max_keys = max_keys
         # Per-key state: (asyncio.Lock, mutable_state)
         # mutable_state is [tokens: float, last_refill_time: float]
+        # Keys are SHA-256 hex digests — raw credential values are never stored.
         self._buckets: dict[str, tuple[asyncio.Lock, list[float]]] = {}
         self._meta_lock = asyncio.Lock()
 
+    def _hash_key(self, key: str) -> str:
+        return hashlib.sha256(key.encode()).hexdigest()
+
     async def _get_or_create_bucket(self, key: str) -> tuple[asyncio.Lock, list[float]]:
+        # Fast-path: bucket already exists, no lock needed.
+        bucket = self._buckets.get(key)
+        if bucket is not None:
+            return bucket
         async with self._meta_lock:
             if key not in self._buckets:
-                lock = asyncio.Lock()
-                state: list[float] = [float(self.burst), time.monotonic()]
-                self._buckets[key] = (lock, state)
+                self._buckets[key] = (asyncio.Lock(), [float(self.burst), time.monotonic()])
+                # LRU-style eviction: drop oldest insertion when over cap.
+                if len(self._buckets) > self.max_keys:
+                    self._buckets.pop(next(iter(self._buckets)))
             return self._buckets[key]
 
     async def check(self, key: str) -> None:
         """Check whether key is within rate limit, raising HTTP 429 if exceeded.
 
         Args:
-            key: Rate limit key (e.g. credential token value).
+            key: Rate limit key (e.g. credential token value). Hashed internally.
 
         Raises:
             HTTPException: 429 with Retry-After, X-RateLimit-* headers if exceeded.
@@ -52,7 +68,8 @@ class TokenBucketRateLimiter:
         if self.rpm == 0:
             return
 
-        lock, state = await self._get_or_create_bucket(key)
+        hashed = self._hash_key(key)
+        lock, state = await self._get_or_create_bucket(hashed)
 
         async with lock:
             now = time.monotonic()
@@ -64,6 +81,8 @@ class TokenBucketRateLimiter:
             if tokens < 1.0:
                 tokens_needed = 1.0 - tokens
                 retry_after = math.ceil(tokens_needed / (self.rpm / 60.0))
+                # Wall-clock time for X-RateLimit-Reset: clients expect a unix timestamp,
+                # not a monotonic offset.
                 reset_unix = int(time.time()) + retry_after
                 state[0] = tokens
                 raise HTTPException(

--- a/src/luthien_proxy/rate_limit.py
+++ b/src/luthien_proxy/rate_limit.py
@@ -35,6 +35,11 @@ class TokenBucketRateLimiter:
     on verify_token, so only authenticated callers consume bucket capacity. This is
     intentional: it prevents unauthenticated attackers from evicting legitimate
     users' buckets.
+
+    Note: if a bucket is evicted while a coroutine is holding its per-key lock,
+    that coroutine's state update is lost and the next request for the same key
+    gets a fresh full-burst bucket. This breaks serialization across the eviction
+    boundary but is acceptable for an in-process limiter under normal load.
     """
 
     def __init__(self, rpm: int, burst: int, max_keys: int = 10_000) -> None:
@@ -100,7 +105,8 @@ class TokenBucketRateLimiter:
             tokens, last_time = state[0], state[1]
             elapsed = now - last_time
             tokens = min(self.burst, tokens + elapsed * (self.rpm / 60.0))
-            state[1] = now
+            state[1] = now  # advance timestamp on both allow and deny paths so
+            # Retry-After is computed from the deny moment, not the last success
 
             if tokens < 1.0:
                 tokens_needed = 1.0 - tokens

--- a/src/luthien_proxy/rate_limit.py
+++ b/src/luthien_proxy/rate_limit.py
@@ -40,8 +40,9 @@ class TokenBucketRateLimiter:
 
     Note: if a bucket is evicted while a coroutine is holding its per-key lock,
     that coroutine's state update is lost and the next request for the same key
-    gets a fresh full-burst bucket. This breaks serialization across the eviction
-    boundary but is acceptable for an in-process limiter under normal load.
+    gets a fresh full-burst bucket — the key can briefly exceed its limit by up
+    to burst tokens. This is acceptable for an in-process limiter under normal
+    load (requires sustained churn at cardinality > max_keys).
 
     Note: rate limiting is keyed on the raw credential value (after hashing).
     In auth_mode=CLIENT_KEY or the client-key branch of BOTH, all users share
@@ -55,7 +56,8 @@ class TokenBucketRateLimiter:
 
         Args:
             rpm: Requests per minute. 0 disables rate limiting. Must be >= 0.
-            burst: Maximum token accumulation. 0 defaults to rpm.
+            burst: Absolute token bucket capacity (maximum tokens held at any time).
+                0 defaults to rpm. Must be >= rpm to allow sustained throughput.
             max_keys: Maximum number of per-key buckets (LRU eviction when exceeded).
 
         Raises:

--- a/src/luthien_proxy/rate_limit.py
+++ b/src/luthien_proxy/rate_limit.py
@@ -1,0 +1,83 @@
+"""In-process asyncio-safe token bucket rate limiter for per-key request limiting."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+
+from fastapi import HTTPException
+
+
+class TokenBucketRateLimiter:
+    """Per-key token bucket rate limiter.
+
+    Uses one asyncio.Lock per key to ensure concurrency safety without a global
+    bottleneck. A meta-lock serialises only the short dict lookup/creation step.
+
+    RPM=0 disables limiting entirely (all requests pass through unchecked).
+    """
+
+    def __init__(self, rpm: int, burst: int) -> None:
+        """Initialise the rate limiter.
+
+        Args:
+            rpm: Requests per minute. 0 disables rate limiting.
+            burst: Maximum token accumulation above RPM. 0 defaults to rpm.
+        """
+        self.rpm = rpm
+        self.burst = burst if burst > 0 else rpm
+        # Per-key state: (asyncio.Lock, mutable_state)
+        # mutable_state is [tokens: float, last_refill_time: float]
+        self._buckets: dict[str, tuple[asyncio.Lock, list[float]]] = {}
+        self._meta_lock = asyncio.Lock()
+
+    async def _get_or_create_bucket(self, key: str) -> tuple[asyncio.Lock, list[float]]:
+        async with self._meta_lock:
+            if key not in self._buckets:
+                lock = asyncio.Lock()
+                state: list[float] = [float(self.burst), time.monotonic()]
+                self._buckets[key] = (lock, state)
+            return self._buckets[key]
+
+    async def check(self, key: str) -> None:
+        """Check whether key is within rate limit, raising HTTP 429 if exceeded.
+
+        Args:
+            key: Rate limit key (e.g. credential token value).
+
+        Raises:
+            HTTPException: 429 with Retry-After, X-RateLimit-* headers if exceeded.
+        """
+        if self.rpm == 0:
+            return
+
+        lock, state = await self._get_or_create_bucket(key)
+
+        async with lock:
+            now = time.monotonic()
+            tokens, last_time = state[0], state[1]
+            elapsed = now - last_time
+            tokens = min(float(self.burst), tokens + elapsed * (self.rpm / 60.0))
+            state[1] = now
+
+            if tokens < 1.0:
+                tokens_needed = 1.0 - tokens
+                retry_after = math.ceil(tokens_needed / (self.rpm / 60.0))
+                reset_unix = int(time.time()) + retry_after
+                state[0] = tokens
+                raise HTTPException(
+                    status_code=429,
+                    detail="Rate limit exceeded",
+                    headers={
+                        "Retry-After": str(retry_after),
+                        "X-RateLimit-Limit": str(self.rpm),
+                        "X-RateLimit-Remaining": "0",
+                        "X-RateLimit-Reset": str(reset_unix),
+                    },
+                )
+
+            state[0] = tokens - 1.0
+
+
+__all__ = ["TokenBucketRateLimiter"]

--- a/src/luthien_proxy/rate_limit.py
+++ b/src/luthien_proxy/rate_limit.py
@@ -23,8 +23,10 @@ class TokenBucketRateLimiter:
     RPM=0 disables limiting entirely (all requests pass through unchecked).
 
     Eviction: when _buckets exceeds max_keys, the least recently used entry is
-    evicted (true LRU via OrderedDict.move_to_end). This prevents an evicted
-    rate-limited key from getting a fresh full-burst bucket on its next request.
+    evicted (true LRU via OrderedDict.move_to_end). Every check — allow or deny —
+    calls move_to_end, so a key that is actively retrying is never the LRU victim.
+    An evicted key does get a fresh full-burst bucket on its next request; the
+    primary purpose of eviction is bounding memory, not preventing limit resets.
 
     Note: in multi-replica deployments each replica maintains independent buckets,
     so the effective per-key limit is replicas × RPM. This is an in-process

--- a/src/luthien_proxy/rate_limit.py
+++ b/src/luthien_proxy/rate_limit.py
@@ -107,8 +107,9 @@ class TokenBucketRateLimiter:
             tokens, last_time = state[0], state[1]
             elapsed = now - last_time
             tokens = min(self.burst, tokens + elapsed * (self.rpm / 60.0))
-            state[1] = now  # advance timestamp on both allow and deny paths so
-            # Retry-After is computed from the deny moment, not the last success
+            # Advance timestamp on both allow and deny paths so Retry-After is
+            # computed from the deny moment, not the last successful request.
+            state[1] = now
 
             if tokens < 1.0:
                 tokens_needed = 1.0 - tokens

--- a/src/luthien_proxy/rate_limit.py
+++ b/src/luthien_proxy/rate_limit.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import math
 import time
+from collections import OrderedDict
 
 from fastapi import HTTPException
 
@@ -20,24 +21,45 @@ class TokenBucketRateLimiter:
     held in memory.
 
     RPM=0 disables limiting entirely (all requests pass through unchecked).
+
+    Eviction: when _buckets exceeds max_keys, the least recently used entry is
+    evicted (true LRU via OrderedDict.move_to_end). This prevents an evicted
+    rate-limited key from getting a fresh full-burst bucket on its next request.
+
+    Note: in multi-replica deployments each replica maintains independent buckets,
+    so the effective per-key limit is replicas × RPM. This is an in-process
+    implementation; a shared Redis backend would be needed for exact cross-replica
+    limiting.
+
+    Note: unauthenticated requests are not rate-limited — check_rate_limit depends
+    on verify_token, so only authenticated callers consume bucket capacity. This is
+    intentional: it prevents unauthenticated attackers from evicting legitimate
+    users' buckets.
     """
 
     def __init__(self, rpm: int, burst: int, max_keys: int = 10_000) -> None:
         """Initialise the rate limiter.
 
         Args:
-            rpm: Requests per minute. 0 disables rate limiting.
-            burst: Maximum token accumulation above RPM. 0 defaults to rpm.
-            max_keys: Maximum number of per-key buckets to retain (LRU-style
-                eviction removes the oldest entry when exceeded).
+            rpm: Requests per minute. 0 disables rate limiting. Must be >= 0.
+            burst: Maximum token accumulation. 0 defaults to rpm.
+            max_keys: Maximum number of per-key buckets (LRU eviction when exceeded).
+
+        Raises:
+            ValueError: If rpm or burst is negative.
         """
+        if rpm < 0:
+            raise ValueError(f"rpm must be >= 0, got {rpm}")
+        if burst < 0:
+            raise ValueError(f"burst must be >= 0, got {burst}")
         self.rpm = rpm
-        self.burst = burst if burst > 0 else rpm
+        self.burst: float = float(burst if burst > 0 else rpm)
         self.max_keys = max_keys
         # Per-key state: (asyncio.Lock, mutable_state)
         # mutable_state is [tokens: float, last_refill_time: float]
         # Keys are SHA-256 hex digests — raw credential values are never stored.
-        self._buckets: dict[str, tuple[asyncio.Lock, list[float]]] = {}
+        # OrderedDict preserves access order for true LRU eviction.
+        self._buckets: OrderedDict[str, tuple[asyncio.Lock, list[float]]] = OrderedDict()
         self._meta_lock = asyncio.Lock()
 
     def _hash_key(self, key: str) -> str:
@@ -47,13 +69,15 @@ class TokenBucketRateLimiter:
         # Fast-path: bucket already exists, no lock needed.
         bucket = self._buckets.get(key)
         if bucket is not None:
+            self._buckets.move_to_end(key)
             return bucket
         async with self._meta_lock:
             if key not in self._buckets:
-                self._buckets[key] = (asyncio.Lock(), [float(self.burst), time.monotonic()])
-                # LRU-style eviction: drop oldest insertion when over cap.
+                self._buckets[key] = (asyncio.Lock(), [self.burst, time.monotonic()])
                 if len(self._buckets) > self.max_keys:
-                    self._buckets.pop(next(iter(self._buckets)))
+                    self._buckets.popitem(last=False)
+            else:
+                self._buckets.move_to_end(key)
             return self._buckets[key]
 
     async def check(self, key: str) -> None:
@@ -75,14 +99,14 @@ class TokenBucketRateLimiter:
             now = time.monotonic()
             tokens, last_time = state[0], state[1]
             elapsed = now - last_time
-            tokens = min(float(self.burst), tokens + elapsed * (self.rpm / 60.0))
+            tokens = min(self.burst, tokens + elapsed * (self.rpm / 60.0))
             state[1] = now
 
             if tokens < 1.0:
                 tokens_needed = 1.0 - tokens
                 retry_after = math.ceil(tokens_needed / (self.rpm / 60.0))
-                # Wall-clock time for X-RateLimit-Reset: clients expect a unix timestamp,
-                # not a monotonic offset.
+                # Wall-clock time for X-RateLimit-Reset: clients expect a unix
+                # timestamp, not a monotonic offset.
                 reset_unix = int(time.time()) + retry_after
                 state[0] = tokens
                 raise HTTPException(

--- a/src/luthien_proxy/rate_limit.py
+++ b/src/luthien_proxy/rate_limit.py
@@ -17,8 +17,8 @@ class TokenBucketRateLimiter:
     Uses one asyncio.Lock per key to ensure concurrency safety without a global
     bottleneck. A meta-lock serialises only the short dict lookup/creation step.
 
-    Keys are SHA-256 hashed before storage so raw credential values are never
-    held in memory.
+    Keys are SHA-256 hashed before storage — raw credential values are never
+    retained; only their digests are stored in _buckets.
 
     RPM=0 disables limiting entirely (all requests pass through unchecked).
 
@@ -42,6 +42,12 @@ class TokenBucketRateLimiter:
     that coroutine's state update is lost and the next request for the same key
     gets a fresh full-burst bucket. This breaks serialization across the eviction
     boundary but is acceptable for an in-process limiter under normal load.
+
+    Note: rate limiting is keyed on the raw credential value (after hashing).
+    In auth_mode=CLIENT_KEY or the client-key branch of BOTH, all users share
+    one CLIENT_API_KEY, so they share one bucket — this is a global rate limit
+    in those modes, not per-user. In PASSTHROUGH mode each user has their own
+    key and gets their own bucket.
     """
 
     def __init__(self, rpm: int, burst: int, max_keys: int = 10_000) -> None:
@@ -53,12 +59,14 @@ class TokenBucketRateLimiter:
             max_keys: Maximum number of per-key buckets (LRU eviction when exceeded).
 
         Raises:
-            ValueError: If rpm or burst is negative.
+            ValueError: If rpm or burst is negative, or max_keys < 1.
         """
         if rpm < 0:
             raise ValueError(f"rpm must be >= 0, got {rpm}")
         if burst < 0:
             raise ValueError(f"burst must be >= 0, got {burst}")
+        if max_keys < 1:
+            raise ValueError(f"max_keys must be >= 1, got {max_keys}")
         self.rpm = rpm
         self.burst: float = float(burst if burst > 0 else rpm)
         self.max_keys = max_keys

--- a/src/luthien_proxy/settings.py
+++ b/src/luthien_proxy/settings.py
@@ -52,6 +52,10 @@ class Settings(_SettingsBase):
     auth_mode: AuthMode = AuthMode.BOTH
     localhost_auth_bypass: bool = True
 
+    # ── rate_limiting ───────────────────────────────────────────────
+    rate_limit_rpm: int = 0
+    rate_limit_burst: int = 0
+
     # ── policy ──────────────────────────────────────────────────────
     policy_source: str = "db-fallback-file"
     policy_config: str = ""

--- a/tests/luthien_proxy/unit_tests/test_gateway_routes.py
+++ b/tests/luthien_proxy/unit_tests/test_gateway_routes.py
@@ -629,7 +629,10 @@ class TestRateLimitingRouteIntegration:
     def test_rate_limited_request_returns_429_with_headers(self, rate_limited_app):
         from tests.constants import DEFAULT_TEST_MODEL
 
-        with patch("luthien_proxy.gateway_routes.process_anthropic_request", new_callable=AsyncMock) as mock_process:
+        with (
+            patch("luthien_proxy.gateway_routes.process_anthropic_request", new_callable=AsyncMock) as mock_process,
+            patch("luthien_proxy.rate_limit.time.monotonic", return_value=1000.0),
+        ):
             mock_process.return_value = MagicMock()
             client = TestClient(rate_limited_app, raise_server_exceptions=False)
             payload = {
@@ -647,3 +650,44 @@ class TestRateLimitingRouteIntegration:
             assert "x-ratelimit-limit" in response2.headers
             assert "x-ratelimit-remaining" in response2.headers
             assert "x-ratelimit-reset" in response2.headers
+
+    def test_rate_limit_short_circuits_before_process_anthropic_request(self, rate_limited_app):
+        from tests.constants import DEFAULT_TEST_MODEL
+
+        with (
+            patch("luthien_proxy.gateway_routes.process_anthropic_request", new_callable=AsyncMock) as mock_process,
+            patch("luthien_proxy.rate_limit.time.monotonic", return_value=1000.0),
+        ):
+            mock_process.return_value = MagicMock()
+            client = TestClient(rate_limited_app, raise_server_exceptions=False)
+            payload = {
+                "model": DEFAULT_TEST_MODEL,
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 10,
+            }
+            headers = {"Authorization": "Bearer test-proxy-key"}
+            client.post("/v1/messages", json=payload, headers=headers)
+            mock_process.reset_mock()
+
+            response = client.post("/v1/messages", json=payload, headers=headers)
+            assert response.status_code == 429
+            mock_process.assert_not_called()
+
+    def test_proxy_passthrough_rate_limited(self, rate_limited_app):
+        with (
+            patch("luthien_proxy.gateway_routes._passthrough_client") as mock_client,
+            patch("luthien_proxy.rate_limit.time.monotonic", return_value=1000.0),
+        ):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.content = b"{}"
+            mock_response.headers = {}
+            mock_client.request = AsyncMock(return_value=mock_response)
+
+            client = TestClient(rate_limited_app, raise_server_exceptions=False)
+            headers = {"Authorization": "Bearer test-proxy-key"}
+            response1 = client.get("/v1/models", headers=headers)
+            assert response1.status_code == 200
+
+            response2 = client.get("/v1/models", headers=headers)
+            assert response2.status_code == 429

--- a/tests/luthien_proxy/unit_tests/test_gateway_routes.py
+++ b/tests/luthien_proxy/unit_tests/test_gateway_routes.py
@@ -89,6 +89,7 @@ class TestGatewayAuthAndClientResolution:
         deps.emitter = MagicMock()
         deps.db_pool = None
         deps.enable_request_logging = False
+        deps.rate_limiter = None
         deps.get_anthropic_policy.return_value = mock_anthropic_policy
 
         app.state.dependencies = deps
@@ -548,6 +549,7 @@ class TestProxyPassthrough:
         deps.anthropic_client = None
         deps.db_pool = None
         deps.enable_request_logging = False
+        deps.rate_limiter = None
         app.state.dependencies = deps
         return app
 

--- a/tests/luthien_proxy/unit_tests/test_gateway_routes.py
+++ b/tests/luthien_proxy/unit_tests/test_gateway_routes.py
@@ -579,3 +579,71 @@ class TestProxyPassthrough:
         client = TestClient(mock_app, raise_server_exceptions=False)
         response = client.get("/v1/models")
         assert response.status_code == 401
+
+
+class TestRateLimitingRouteIntegration:
+    """Test that rate limiting 429s surface correctly through the FastAPI route."""
+
+    @pytest.fixture
+    def rate_limited_app(self):
+        from luthien_proxy.dependencies import Dependencies
+        from luthien_proxy.gateway_routes import router
+        from luthien_proxy.policy_core import AnthropicExecutionInterface
+        from luthien_proxy.rate_limit import TokenBucketRateLimiter
+
+        app = FastAPI()
+        app.include_router(router)
+
+        mock_policy_manager = MagicMock()
+        mock_policy = MagicMock()
+        mock_policy.__class__.__name__ = "TestPolicy"
+        mock_policy_manager.current_policy = mock_policy
+
+        mock_anthropic_client = MagicMock(spec=AnthropicClient)
+        mock_anthropic_client._base_url = None
+
+        mock_credential_manager = MagicMock(spec=CredentialManager)
+        mock_credential_manager.config = AuthConfig(
+            auth_mode=AuthMode.CLIENT_KEY,
+            validate_credentials=True,
+            valid_cache_ttl_seconds=3600,
+            invalid_cache_ttl_seconds=300,
+        )
+        mock_credential_manager.validate_credential = AsyncMock(return_value=True)
+
+        mock_anthropic_policy = MagicMock(spec=AnthropicExecutionInterface)
+
+        deps = MagicMock(spec=Dependencies)
+        deps.api_key = "test-proxy-key"
+        deps.anthropic_client = mock_anthropic_client
+        deps.credential_manager = mock_credential_manager
+        deps.emitter = MagicMock()
+        deps.db_pool = None
+        deps.enable_request_logging = False
+        deps.rate_limiter = TokenBucketRateLimiter(rpm=60, burst=1)
+        deps.get_anthropic_policy.return_value = mock_anthropic_policy
+
+        app.state.dependencies = deps
+        return app
+
+    def test_rate_limited_request_returns_429_with_headers(self, rate_limited_app):
+        from tests.constants import DEFAULT_TEST_MODEL
+
+        with patch("luthien_proxy.gateway_routes.process_anthropic_request", new_callable=AsyncMock) as mock_process:
+            mock_process.return_value = MagicMock()
+            client = TestClient(rate_limited_app, raise_server_exceptions=False)
+            payload = {
+                "model": DEFAULT_TEST_MODEL,
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 10,
+            }
+            headers = {"Authorization": "Bearer test-proxy-key"}
+            response1 = client.post("/v1/messages", json=payload, headers=headers)
+            assert response1.status_code == 200
+
+            response2 = client.post("/v1/messages", json=payload, headers=headers)
+            assert response2.status_code == 429
+            assert "Retry-After" in response2.headers
+            assert "x-ratelimit-limit" in response2.headers
+            assert "x-ratelimit-remaining" in response2.headers
+            assert "x-ratelimit-reset" in response2.headers

--- a/tests/luthien_proxy/unit_tests/test_rate_limit.py
+++ b/tests/luthien_proxy/unit_tests/test_rate_limit.py
@@ -100,3 +100,85 @@ async def test_burst_custom_value():
 
     with pytest.raises(HTTPException):
         await limiter.check("key")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_key():
+    import asyncio as asyncio_mod
+
+    from fastapi import HTTPException
+
+    limiter = TokenBucketRateLimiter(rpm=60, burst=60)
+    await asyncio_mod.gather(*[limiter.check("key") for _ in range(60)])
+    with pytest.raises(HTTPException) as exc_info:
+        await limiter.check("key")
+    assert exc_info.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_retry_after_math():
+    from fastapi import HTTPException
+
+    limiter = TokenBucketRateLimiter(rpm=60, burst=1)
+    await limiter.check("key")
+    with pytest.raises(HTTPException) as exc_info:
+        await limiter.check("key")
+    headers = exc_info.value.headers
+    assert headers is not None
+    assert int(headers["Retry-After"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_reset_timestamp_is_unix():
+    import time as time_module
+
+    from fastapi import HTTPException
+
+    limiter = TokenBucketRateLimiter(rpm=60, burst=1)
+    await limiter.check("key")
+    with pytest.raises(HTTPException) as exc_info:
+        await limiter.check("key")
+    headers = exc_info.value.headers
+    assert headers is not None
+    reset = int(headers["X-RateLimit-Reset"])
+    now = int(time_module.time())
+    assert now <= reset <= now + 5
+
+
+@pytest.mark.asyncio
+async def test_refill_math(monkeypatch):
+    import time as time_module
+
+    from fastapi import HTTPException
+
+    limiter = TokenBucketRateLimiter(rpm=60, burst=10)
+    for _ in range(10):
+        await limiter.check("key")
+    original_monotonic = time_module.monotonic
+    monkeypatch.setattr(time_module, "monotonic", lambda: original_monotonic() + 5.0)
+    for _ in range(5):
+        await limiter.check("key")
+    with pytest.raises(HTTPException):
+        await limiter.check("key")
+
+
+@pytest.mark.asyncio
+async def test_lru_eviction():
+    limiter = TokenBucketRateLimiter(rpm=60, burst=60, max_keys=3)
+    await limiter.check("key1")
+    await limiter.check("key2")
+    await limiter.check("key3")
+    assert len(limiter._buckets) == 3
+    await limiter.check("key4")
+    assert len(limiter._buckets) == 3
+
+
+@pytest.mark.asyncio
+async def test_key_is_hashed():
+    limiter = TokenBucketRateLimiter(rpm=60, burst=60)
+    raw_key = "sk-secret-token-12345"
+    await limiter.check(raw_key)
+    assert raw_key not in limiter._buckets
+    stored_key = next(iter(limiter._buckets))
+    assert len(stored_key) == 64
+    assert all(c in "0123456789abcdef" for c in stored_key)

--- a/tests/luthien_proxy/unit_tests/test_rate_limit.py
+++ b/tests/luthien_proxy/unit_tests/test_rate_limit.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from luthien_proxy.rate_limit import TokenBucketRateLimiter
+
+
+@pytest.mark.asyncio
+async def test_disabled_never_raises():
+    limiter = TokenBucketRateLimiter(rpm=0, burst=0)
+    for _ in range(100):
+        await limiter.check("key")
+
+
+@pytest.mark.asyncio
+async def test_first_request_allowed():
+    limiter = TokenBucketRateLimiter(rpm=60, burst=5)
+    await limiter.check("key")
+
+
+@pytest.mark.asyncio
+async def test_requests_within_burst_allowed():
+    limiter = TokenBucketRateLimiter(rpm=60, burst=5)
+    for _ in range(5):
+        await limiter.check("key")
+
+
+@pytest.mark.asyncio
+async def test_exceeding_rpm_raises_429():
+    from fastapi import HTTPException
+
+    limiter = TokenBucketRateLimiter(rpm=60, burst=3)
+    for _ in range(3):
+        await limiter.check("key")
+    with pytest.raises(HTTPException) as exc_info:
+        await limiter.check("key")
+    assert exc_info.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_429_has_correct_headers():
+    from fastapi import HTTPException
+
+    limiter = TokenBucketRateLimiter(rpm=60, burst=1)
+    await limiter.check("key")
+    with pytest.raises(HTTPException) as exc_info:
+        await limiter.check("key")
+    exc = exc_info.value
+    assert exc.status_code == 429
+    assert exc.headers is not None
+    assert "Retry-After" in exc.headers
+    assert exc.headers["X-RateLimit-Limit"] == "60"
+    assert exc.headers["X-RateLimit-Remaining"] == "0"
+    assert "X-RateLimit-Reset" in exc.headers
+    retry_after = int(exc.headers["Retry-After"])
+    assert retry_after >= 1
+
+
+@pytest.mark.asyncio
+async def test_different_keys_independent_buckets():
+    from fastapi import HTTPException
+
+    limiter = TokenBucketRateLimiter(rpm=60, burst=1)
+    await limiter.check("key_a")
+    await limiter.check("key_b")
+    with pytest.raises(HTTPException):
+        await limiter.check("key_a")
+    with pytest.raises(HTTPException):
+        await limiter.check("key_b")
+    await limiter.check("key_c")
+
+
+@pytest.mark.asyncio
+async def test_tokens_refill_over_time():
+    limiter = TokenBucketRateLimiter(rpm=60, burst=1)
+
+    t0 = 1000.0
+    with patch("luthien_proxy.rate_limit.time.monotonic", return_value=t0):
+        await limiter.check("key")
+
+    with patch("luthien_proxy.rate_limit.time.monotonic", return_value=t0 + 1.5):
+        await limiter.check("key")
+
+
+@pytest.mark.asyncio
+async def test_burst_defaults_to_rpm_when_zero():
+    limiter = TokenBucketRateLimiter(rpm=10, burst=0)
+    assert limiter.burst == 10
+
+
+@pytest.mark.asyncio
+async def test_burst_custom_value():
+    limiter = TokenBucketRateLimiter(rpm=10, burst=20)
+    assert limiter.burst == 20
+    for _ in range(20):
+        await limiter.check("key")
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException):
+        await limiter.check("key")

--- a/tests/luthien_proxy/unit_tests/test_rate_limit.py
+++ b/tests/luthien_proxy/unit_tests/test_rate_limit.py
@@ -22,20 +22,26 @@ async def test_first_request_allowed():
 
 @pytest.mark.asyncio
 async def test_requests_within_burst_allowed():
+    from unittest.mock import patch
+
     limiter = TokenBucketRateLimiter(rpm=60, burst=5)
-    for _ in range(5):
-        await limiter.check("key")
+    with patch("luthien_proxy.rate_limit.time.monotonic", return_value=1000.0):
+        for _ in range(5):
+            await limiter.check("key")
 
 
 @pytest.mark.asyncio
 async def test_exceeding_rpm_raises_429():
+    from unittest.mock import patch
+
     from fastapi import HTTPException
 
     limiter = TokenBucketRateLimiter(rpm=60, burst=3)
-    for _ in range(3):
-        await limiter.check("key")
-    with pytest.raises(HTTPException) as exc_info:
-        await limiter.check("key")
+    with patch("luthien_proxy.rate_limit.time.monotonic", return_value=1000.0):
+        for _ in range(3):
+            await limiter.check("key")
+        with pytest.raises(HTTPException) as exc_info:
+            await limiter.check("key")
     assert exc_info.value.status_code == 429
 
 
@@ -234,3 +240,41 @@ async def test_refill_capped_at_burst():
         with pytest.raises(HTTPException) as exc_info:
             await limiter.check("key")
         assert exc_info.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_steady_state_rate():
+    from unittest.mock import patch
+
+    from fastapi import HTTPException
+
+    limiter = TokenBucketRateLimiter(rpm=60, burst=1)
+    t0 = 1000.0
+    with patch("luthien_proxy.rate_limit.time.monotonic", return_value=t0):
+        await limiter.check("key")
+
+    for elapsed, expected_admitted in [(0.9, 0), (1.0, 1), (1.5, 1), (2.0, 1)]:
+        limiter2 = TokenBucketRateLimiter(rpm=60, burst=1)
+        with patch("luthien_proxy.rate_limit.time.monotonic", return_value=t0):
+            await limiter2.check("key")
+        with patch("luthien_proxy.rate_limit.time.monotonic", return_value=t0 + elapsed):
+            if expected_admitted:
+                await limiter2.check("key")
+            else:
+                with pytest.raises(HTTPException):
+                    await limiter2.check("key")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_different_keys():
+    import asyncio as asyncio_mod
+    from unittest.mock import patch
+
+    limiter = TokenBucketRateLimiter(rpm=60, burst=1)
+    with patch("luthien_proxy.rate_limit.time.monotonic", return_value=1000.0):
+        await asyncio_mod.gather(
+            limiter.check("key_a"),
+            limiter.check("key_b"),
+            limiter.check("key_c"),
+        )
+    assert len(limiter._buckets) == 3

--- a/tests/luthien_proxy/unit_tests/test_rate_limit.py
+++ b/tests/luthien_proxy/unit_tests/test_rate_limit.py
@@ -105,13 +105,15 @@ async def test_burst_custom_value():
 @pytest.mark.asyncio
 async def test_concurrent_same_key():
     import asyncio as asyncio_mod
+    from unittest.mock import patch
 
     from fastapi import HTTPException
 
-    limiter = TokenBucketRateLimiter(rpm=60, burst=60)
-    await asyncio_mod.gather(*[limiter.check("key") for _ in range(60)])
-    with pytest.raises(HTTPException) as exc_info:
-        await limiter.check("key")
+    with patch("luthien_proxy.rate_limit.time.monotonic", return_value=1000.0):
+        limiter = TokenBucketRateLimiter(rpm=60, burst=60)
+        await asyncio_mod.gather(*[limiter.check("key") for _ in range(60)])
+        with pytest.raises(HTTPException) as exc_info:
+            await limiter.check("key")
     assert exc_info.value.status_code == 429
 
 

--- a/tests/luthien_proxy/unit_tests/test_rate_limit.py
+++ b/tests/luthien_proxy/unit_tests/test_rate_limit.py
@@ -163,14 +163,29 @@ async def test_refill_math(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_lru_eviction():
+async def test_lru_eviction_fifo_when_no_access():
     limiter = TokenBucketRateLimiter(rpm=60, burst=60, max_keys=3)
     await limiter.check("key1")
     await limiter.check("key2")
     await limiter.check("key3")
     assert len(limiter._buckets) == 3
+    key1_hash = limiter._hash_key("key1")
     await limiter.check("key4")
     assert len(limiter._buckets) == 3
+    assert key1_hash not in limiter._buckets
+
+
+@pytest.mark.asyncio
+async def test_lru_eviction_spares_recently_accessed():
+    limiter = TokenBucketRateLimiter(rpm=60, burst=60, max_keys=3)
+    await limiter.check("key1")
+    await limiter.check("key2")
+    await limiter.check("key3")
+    await limiter.check("key1")
+    key2_hash = limiter._hash_key("key2")
+    await limiter.check("key4")
+    assert len(limiter._buckets) == 3
+    assert key2_hash not in limiter._buckets
 
 
 @pytest.mark.asyncio

--- a/tests/luthien_proxy/unit_tests/test_rate_limit.py
+++ b/tests/luthien_proxy/unit_tests/test_rate_limit.py
@@ -155,7 +155,7 @@ async def test_refill_math(monkeypatch):
     for _ in range(10):
         await limiter.check("key")
     original_monotonic = time_module.monotonic
-    monkeypatch.setattr(time_module, "monotonic", lambda: original_monotonic() + 5.0)
+    monkeypatch.setattr("luthien_proxy.rate_limit.time.monotonic", lambda: original_monotonic() + 5.0)
     for _ in range(5):
         await limiter.check("key")
     with pytest.raises(HTTPException):
@@ -190,10 +190,21 @@ async def test_lru_eviction_spares_recently_accessed():
 
 @pytest.mark.asyncio
 async def test_key_is_hashed():
+    import hashlib
+
     limiter = TokenBucketRateLimiter(rpm=60, burst=60)
     raw_key = "sk-secret-token-12345"
     await limiter.check(raw_key)
     assert raw_key not in limiter._buckets
     stored_key = next(iter(limiter._buckets))
-    assert len(stored_key) == 64
-    assert all(c in "0123456789abcdef" for c in stored_key)
+    assert stored_key == hashlib.sha256(raw_key.encode()).hexdigest()
+
+
+def test_negative_rpm_raises():
+    with pytest.raises(ValueError, match="rpm"):
+        TokenBucketRateLimiter(rpm=-1, burst=0)
+
+
+def test_negative_burst_raises():
+    with pytest.raises(ValueError, match="burst"):
+        TokenBucketRateLimiter(rpm=60, burst=-1)

--- a/tests/luthien_proxy/unit_tests/test_rate_limit.py
+++ b/tests/luthien_proxy/unit_tests/test_rate_limit.py
@@ -210,3 +210,27 @@ def test_negative_rpm_raises():
 def test_negative_burst_raises():
     with pytest.raises(ValueError, match="burst"):
         TokenBucketRateLimiter(rpm=60, burst=-1)
+
+
+def test_zero_max_keys_raises():
+    with pytest.raises(ValueError, match="max_keys"):
+        TokenBucketRateLimiter(rpm=60, burst=0, max_keys=0)
+
+
+@pytest.mark.asyncio
+async def test_refill_capped_at_burst():
+    from unittest.mock import patch
+
+    limiter = TokenBucketRateLimiter(rpm=60, burst=5)
+    with patch("luthien_proxy.rate_limit.time.monotonic", return_value=1000.0):
+        for _ in range(5):
+            await limiter.check("key")
+
+    with patch("luthien_proxy.rate_limit.time.monotonic", return_value=1000.0 + 3600.0):
+        for _ in range(5):
+            await limiter.check("key")
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await limiter.check("key")
+        assert exc_info.value.status_code == 429


### PR DESCRIPTION
## Summary

Adds per-key token bucket rate limiting to all \`/v1/\` routes. Disabled by default (\`RATE_LIMIT_RPM=0\`).

- In-process, asyncio-safe token bucket keyed by SHA-256 hash of the credential value
- True LRU eviction cap (10k keys) via \`OrderedDict.move_to_end\` — prevents rate-limited keys from getting a fresh bucket after eviction
- HTTP 429 with \`Retry-After\`, \`X-RateLimit-Limit\`, \`X-RateLimit-Remaining\`, \`X-RateLimit-Reset\` headers
- Rate limit check runs before \`resolve_anthropic_client\` — rejects early under load
- Configurable via \`RATE_LIMIT_RPM\` and \`RATE_LIMIT_BURST\` (both require restart)

**Design notes (in class docstring):**
- Multi-replica: each replica maintains independent buckets; effective limit is replicas × RPM
- Auth layer: unauthenticated requests bypass rate limiting (intentional — prevents attackers from evicting legitimate users' buckets)

Closes #704

## Follow-up
- Structured log / metric on 429: https://trello.com/c/tvP3cVkB
- \`scripts/pre-commit\` bash 3.2 fix also in PR #730 (canonical home)