### PR TITLE
feat: user identity extraction and storage (commandeers #577)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@
 # (can also be set at runtime via admin API)
 # VERBOSE_CLIENT_ERRORS=false
 
+# Trust the X-Luthien-User-Id request header for user attribution. Disabled by default — only enable when clients are trusted (e.g., behind an authenticated reverse proxy).
+# (can also be set at runtime via admin API)
+# TRUST_USER_ID_HEADER=false
+
 
 # === AUTH ========================================================
 

--- a/changelog.d/user-identity-577.md
+++ b/changelog.d/user-identity-577.md
@@ -16,9 +16,3 @@ users in the history UI and `GET /api/history/sessions?user_id=...`.
     so sessions reused across users render honestly instead of attributing
     to one). Retention/purge tooling that scrubs PII should account for
     both columns.
-
-**EventEmitter.dropped_db_writes** silently changed from a class-level
-counter (shared across all instances) to a per-instance counter. The
-class-level form was a latent bug (test isolation, multi-emitter scrape).
-Anything reading `EventEmitter.dropped_db_writes` directly will now see 0;
-read it from the instance instead.

--- a/changelog.d/user-identity-577.md
+++ b/changelog.d/user-identity-577.md
@@ -1,0 +1,15 @@
+---
+category: Features
+---
+
+**User identity extraction**: The proxy now records a `user_id` against
+each conversation call so operators can attribute traffic to individual
+users in the history UI and `GET /api/history/sessions?user_id=...`.
+
+  - Source 1 (default off): `X-Luthien-User-Id` request header. Trusted
+    only when `TRUST_USER_ID_HEADER=true` — leave disabled unless clients
+    are behind an authenticated reverse proxy.
+  - Source 2: the `sub` claim of a Bearer JWT, decoded **without signature
+    verification**. Treat as user-asserted attribution, never as auth.
+  - Stored in new columns on `conversation_calls` and `conversation_events`
+    (migration 018), and surfaced on `SessionSummary.user_id`.

--- a/changelog.d/user-identity-577.md
+++ b/changelog.d/user-identity-577.md
@@ -12,4 +12,13 @@ users in the history UI and `GET /api/history/sessions?user_id=...`.
   - Source 2: the `sub` claim of a Bearer JWT, decoded **without signature
     verification**. Treat as user-asserted attribution, never as auth.
   - Stored in new columns on `conversation_calls` and `conversation_events`
-    (migration 018), and surfaced on `SessionSummary.user_id`.
+    (migration 018), and surfaced on `SessionSummary.user_ids` (a list,
+    so sessions reused across users render honestly instead of attributing
+    to one). Retention/purge tooling that scrubs PII should account for
+    both columns.
+
+**EventEmitter.dropped_db_writes** silently changed from a class-level
+counter (shared across all instances) to a per-instance counter. The
+class-level form was a latent bug (test isolation, multi-emitter scrape).
+Anything reading `EventEmitter.dropped_db_writes` directly will now see 0;
+read it from the instance instead.

--- a/migrations/postgres/018_add_user_id.sql
+++ b/migrations/postgres/018_add_user_id.sql
@@ -1,0 +1,15 @@
+-- ABOUTME: Adds user_id column to conversation_calls and conversation_events
+-- ABOUTME: Enables tracking which user made each request for team deployments
+-- ABOUTME: Extracted from X-Luthien-User-Id header or JWT Bearer token sub claim
+
+-- Add user_id to conversation_calls (one row per API call)
+ALTER TABLE conversation_calls ADD COLUMN IF NOT EXISTS user_id TEXT;
+
+-- Index for filtering calls by user
+CREATE INDEX IF NOT EXISTS idx_conversation_calls_user ON conversation_calls(user_id) WHERE user_id IS NOT NULL;
+
+-- Add user_id to conversation_events (one row per event within a call)
+ALTER TABLE conversation_events ADD COLUMN IF NOT EXISTS user_id TEXT;
+
+-- Index for filtering events by user
+CREATE INDEX IF NOT EXISTS idx_conversation_events_user ON conversation_events(user_id) WHERE user_id IS NOT NULL;

--- a/migrations/postgres/018_add_user_id.sql
+++ b/migrations/postgres/018_add_user_id.sql
@@ -2,14 +2,14 @@
 -- ABOUTME: Enables tracking which user made each request for team deployments
 -- ABOUTME: Extracted from X-Luthien-User-Id header or JWT Bearer token sub claim
 
--- Add user_id to conversation_calls (one row per API call)
+-- user_id on conversation_calls (one row per API call). This is the column the
+-- history API filters/joins against; it gets a partial index for fast lookup.
 ALTER TABLE conversation_calls ADD COLUMN IF NOT EXISTS user_id TEXT;
-
--- Index for filtering calls by user
 CREATE INDEX IF NOT EXISTS idx_conversation_calls_user ON conversation_calls(user_id) WHERE user_id IS NOT NULL;
 
--- Add user_id to conversation_events (one row per event within a call)
+-- user_id on conversation_events is denormalized for analytical queries that
+-- want per-event attribution (e.g. "raw client_request payloads for user X")
+-- without a join. It is intentionally NOT indexed: every event row gets the
+-- write cost, and the existing query paths all join through conversation_calls.
+-- Add an index when an actual query path filters on conversation_events.user_id.
 ALTER TABLE conversation_events ADD COLUMN IF NOT EXISTS user_id TEXT;
-
--- Index for filtering events by user
-CREATE INDEX IF NOT EXISTS idx_conversation_events_user ON conversation_events(user_id) WHERE user_id IS NOT NULL;

--- a/migrations/sqlite/018_add_user_id.sql
+++ b/migrations/sqlite/018_add_user_id.sql
@@ -2,10 +2,12 @@
 -- ABOUTME: Enables tracking which user made each request for team deployments
 -- ABOUTME: Extracted from X-Luthien-User-Id header or JWT Bearer token sub claim
 
+-- user_id on conversation_calls is the column the history API filters/joins against.
 -- No IF NOT EXISTS on ALTER TABLE ADD COLUMN — migration runner guarantees
 -- each migration runs exactly once, so idempotency is handled by the tracker.
 ALTER TABLE conversation_calls ADD COLUMN user_id TEXT;
 CREATE INDEX IF NOT EXISTS idx_conversation_calls_user ON conversation_calls(user_id) WHERE user_id IS NOT NULL;
 
+-- user_id on conversation_events is denormalized for analytical queries; not indexed
+-- (every event row pays the write cost; current code joins through conversation_calls).
 ALTER TABLE conversation_events ADD COLUMN user_id TEXT;
-CREATE INDEX IF NOT EXISTS idx_conversation_events_user ON conversation_events(user_id) WHERE user_id IS NOT NULL;

--- a/migrations/sqlite/018_add_user_id.sql
+++ b/migrations/sqlite/018_add_user_id.sql
@@ -1,0 +1,11 @@
+-- ABOUTME: Adds user_id column to conversation_calls and conversation_events
+-- ABOUTME: Enables tracking which user made each request for team deployments
+-- ABOUTME: Extracted from X-Luthien-User-Id header or JWT Bearer token sub claim
+
+-- No IF NOT EXISTS on ALTER TABLE ADD COLUMN — migration runner guarantees
+-- each migration runs exactly once, so idempotency is handled by the tracker.
+ALTER TABLE conversation_calls ADD COLUMN user_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_conversation_calls_user ON conversation_calls(user_id) WHERE user_id IS NOT NULL;
+
+ALTER TABLE conversation_events ADD COLUMN user_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_conversation_events_user ON conversation_events(user_id) WHERE user_id IS NOT NULL;

--- a/src/luthien_proxy/config_fields.py
+++ b/src/luthien_proxy/config_fields.py
@@ -75,6 +75,11 @@ CONFIG_FIELDS: tuple[ConfigFieldMeta, ...] = (
         "Include internal details in client-facing error responses",
         category="server", db_settable=True, restart_required=False,
     ),
+    ConfigFieldMeta(
+        "trust_user_id_header", "TRUST_USER_ID_HEADER", bool, False,
+        "Trust the X-Luthien-User-Id request header for user attribution. Disabled by default — only enable when clients are trusted (e.g., behind an authenticated reverse proxy).",
+        category="server", db_settable=True, restart_required=False,
+    ),
 
     # ── auth ──────────────────────────────────────────────────────────────
     ConfigFieldMeta(

--- a/src/luthien_proxy/history/models.py
+++ b/src/luthien_proxy/history/models.py
@@ -9,7 +9,7 @@ Defines Pydantic models for:
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class MessageType(str, Enum):
@@ -80,7 +80,7 @@ class SessionSummary(BaseModel):
     # user_ids are user-asserted (JWT signature not verified) — attribution only, not authentication.
     # All distinct user_ids attributed to calls in this session; multi-element when a session
     # is reused across users (e.g. shared frontend session_id with separate JWTs).
-    user_ids: list[str] = []  # User identities extracted from X-Luthien-User-Id or JWT sub claim
+    user_ids: list[str] = Field(default_factory=list)  # X-Luthien-User-Id or JWT sub claim
 
 
 class SessionListResponse(BaseModel):

--- a/src/luthien_proxy/history/models.py
+++ b/src/luthien_proxy/history/models.py
@@ -77,6 +77,8 @@ class SessionSummary(BaseModel):
     policy_interventions: int
     models_used: list[str]
     preview_message: str | None = None  # Preview of session (last user message, truncated)
+    # user_id is user-asserted (JWT signature not verified) — attribution only, not authentication
+    user_id: str | None = None  # User identity extracted from X-Luthien-User-Id or JWT sub claim
 
 
 class SessionListResponse(BaseModel):

--- a/src/luthien_proxy/history/models.py
+++ b/src/luthien_proxy/history/models.py
@@ -77,8 +77,10 @@ class SessionSummary(BaseModel):
     policy_interventions: int
     models_used: list[str]
     preview_message: str | None = None  # Preview of session (last user message, truncated)
-    # user_id is user-asserted (JWT signature not verified) — attribution only, not authentication
-    user_id: str | None = None  # User identity extracted from X-Luthien-User-Id or JWT sub claim
+    # user_ids are user-asserted (JWT signature not verified) — attribution only, not authentication.
+    # All distinct user_ids attributed to calls in this session; multi-element when a session
+    # is reused across users (e.g. shared frontend session_id with separate JWTs).
+    user_ids: list[str] = []  # User identities extracted from X-Luthien-User-Id or JWT sub claim
 
 
 class SessionListResponse(BaseModel):

--- a/src/luthien_proxy/history/models.py
+++ b/src/luthien_proxy/history/models.py
@@ -78,8 +78,10 @@ class SessionSummary(BaseModel):
     models_used: list[str]
     preview_message: str | None = None  # Preview of session (last user message, truncated)
     # user_ids are user-asserted (JWT signature not verified) — attribution only, not authentication.
-    # All distinct user_ids attributed to calls in this session; multi-element when a session
-    # is reused across users (e.g. shared frontend session_id with separate JWTs).
+    # Distinct user_ids attributed to calls in this session:
+    #   - empty list: no call carried a user_id (TRUST_USER_ID_HEADER off and no JWT) — common default.
+    #   - one element: standard case.
+    #   - multi-element: session reused across users (e.g. shared frontend session_id, rotating JWTs).
     user_ids: list[str] = Field(default_factory=list)  # X-Luthien-User-Id or JWT sub claim
 
 

--- a/src/luthien_proxy/history/routes.py
+++ b/src/luthien_proxy/history/routes.py
@@ -72,6 +72,13 @@ async def list_sessions(
         ge=0,
         description="Number of sessions to skip for pagination",
     ),
+    user_id: str | None = Query(
+        default=None,
+        description=(
+            "Filter by exact user_id. Matches the user_id extracted from "
+            "X-Luthien-User-Id header (when TRUST_USER_ID_HEADER=true) or JWT sub claim."
+        ),
+    ),
 ) -> SessionListResponse:
     """List recent sessions with summaries.
 
@@ -79,7 +86,7 @@ async def list_sessions(
     including turn counts, policy interventions, and models used.
     Supports pagination via limit and offset parameters.
     """
-    return await fetch_session_list(limit, db_pool, offset)
+    return await fetch_session_list(limit, db_pool, offset, user_id=user_id)
 
 
 @api_router.get("/sessions/{session_id}", response_model=SessionDetail)

--- a/src/luthien_proxy/history/service.py
+++ b/src/luthien_proxy/history/service.py
@@ -629,13 +629,16 @@ async def _fetch_session_list_sqlite(
         # lookups to that user's call_ids — without this, preview_message and
         # models_used can leak content from other users' calls that happen to
         # share the session_id.
+        # NOTE: this clause is *separate from* the `user_call_filter` used in
+        # the main aggregation above — different placeholder slot ($N differs
+        # because session_ids are also bound here). Don't fold into one.
         if user_id is not None:
-            user_call_filter = (
+            user_call_filter_lookups = (
                 f"AND ce.call_id IN (SELECT call_id FROM conversation_calls WHERE user_id = ${len(session_ids) + 1})"
             )
             extra_args: list[Any] = [user_id]
         else:
-            user_call_filter = ""
+            user_call_filter_lookups = ""
             extra_args = []
 
         # One query for all models on this page
@@ -646,7 +649,7 @@ async def _fetch_session_list_sqlite(
             WHERE ce.session_id IN ({placeholders})
             AND ce.event_type = 'transaction.request_recorded'
             AND json_extract(ce.payload, '$.final_model') IS NOT NULL
-            {user_call_filter}
+            {user_call_filter_lookups}
             """,
             *session_ids,
             *extra_args,
@@ -663,7 +666,7 @@ async def _fetch_session_list_sqlite(
                 CAST(json_extract(ce.payload, '$.final_request.max_tokens') AS INTEGER),
                 2
             ) > 1
-            {user_call_filter}
+            {user_call_filter_lookups}
             ORDER BY ce.session_id, ce.created_at ASC
             """,
             *session_ids,

--- a/src/luthien_proxy/history/service.py
+++ b/src/luthien_proxy/history/service.py
@@ -580,15 +580,20 @@ async def _fetch_session_list_sqlite(
                 """
             )
 
-        user_filter_clause = "AND cc.user_id = $3" if user_id is not None else ""
+        # PERF: only filter through conversation_calls when a user filter is
+        # actually requested. Unfiltered list calls (the hot path) skip the
+        # conversation_calls subquery entirely. user_ids are populated by a
+        # separate post-query keyed on the page's session_ids (SQLite has no
+        # array_agg, so we can't compute them inside this query anyway).
+        user_call_filter = (
+            "AND ce.call_id IN (SELECT call_id FROM conversation_calls WHERE user_id = $3)"
+            if user_id is not None
+            else ""
+        )
         query_args: list[Any] = [limit, offset]
         if user_id is not None:
             query_args.append(user_id)
 
-        # SQLite has no array_agg, so we cannot return user_ids as a list in a
-        # single query. Fetch the per-session distinct user_ids in a separate
-        # query keyed on the page's session_ids, mirroring the model/preview
-        # batching approach.
         rows = await conn.fetch(
             f"""
             SELECT
@@ -603,9 +608,8 @@ async def _fetch_session_list_sqlite(
                     THEN 1 ELSE 0
                 END) as policy_interventions
             FROM conversation_events ce
-            LEFT JOIN conversation_calls cc ON ce.call_id = cc.call_id
             WHERE ce.session_id IS NOT NULL
-            {user_filter_clause}
+            {user_call_filter}
             GROUP BY ce.session_id
             ORDER BY last_ts DESC
             LIMIT $1 OFFSET $2

--- a/src/luthien_proxy/history/service.py
+++ b/src/luthien_proxy/history/service.py
@@ -388,6 +388,11 @@ async def _fetch_session_list_pg(
     # interpolated into the SQL string. The placeholder slot is fixed,
     # only the WHERE-clause presence is conditional on whether a filter
     # was requested. See test_fetch_session_list_user_filter_sql_injection.
+    #
+    # PERF: the user_id-population join to conversation_calls is intentionally
+    # OUT of the main aggregation query. When no filter is requested we never
+    # touch conversation_calls in the hot CTE — user_ids come from a separate
+    # post-query keyed on the page's session_ids (mirrors the SQLite pattern).
     async with db_pool.connection() as conn:
         if user_id is not None:
             total_count = await conn.fetchval(
@@ -408,13 +413,11 @@ async def _fetch_session_list_pg(
                 """
             )
 
-        # When the caller filters by user_id we must scope every CTE to that
-        # user's call_ids — not just session_stats — otherwise preview_message
-        # / models_used can leak content from a *different* user's calls that
-        # happen to share the session_id. (Sessions can be reused across users
-        # when a frontend passes a stable session_id with rotating identities.)
-        user_filter_clause = "AND cc.user_id = $3" if user_id is not None else ""
-        models_user_filter = (
+        # When the caller filters by user_id we restrict the events under
+        # consideration to call_ids belonging to that user — a single shared
+        # subquery used by every CTE so preview_message / models_used cannot
+        # leak content from another user's calls under a shared session_id.
+        user_call_filter = (
             "AND ce.call_id IN (SELECT call_id FROM conversation_calls WHERE user_id = $3)"
             if user_id is not None
             else ""
@@ -435,19 +438,10 @@ async def _fetch_session_list_pg(
                     COUNT(*) FILTER (
                         WHERE ce.event_type LIKE 'policy.%'
                         AND ce.event_type NOT LIKE 'policy.%judge.evaluation%'
-                    ) as policy_interventions,
-                    -- All distinct user_ids observed across this session's calls.
-                    -- Multi-element arrays signal a session that mixed identities;
-                    -- the consumer decides how to render that. NEVER collapse with
-                    -- MIN/MAX/FIRST — that silently mis-attributes mixed sessions.
-                    COALESCE(
-                        array_agg(DISTINCT cc.user_id) FILTER (WHERE cc.user_id IS NOT NULL),
-                        ARRAY[]::text[]
-                    ) as user_ids
+                    ) as policy_interventions
                 FROM conversation_events ce
-                LEFT JOIN conversation_calls cc ON ce.call_id = cc.call_id
                 WHERE ce.session_id IS NOT NULL
-                {user_filter_clause}
+                {user_call_filter}
                 GROUP BY ce.session_id
             ),
             session_models AS (
@@ -458,7 +452,7 @@ async def _fetch_session_list_pg(
                 WHERE ce.session_id IS NOT NULL
                 AND ce.event_type = 'transaction.request_recorded'
                 AND ce.payload->>'final_model' IS NOT NULL
-                {models_user_filter}
+                {user_call_filter}
             ),
             session_first_message AS (
                 SELECT DISTINCT ON (ce.session_id)
@@ -470,7 +464,7 @@ async def _fetch_session_list_pg(
                 -- Skip probe requests: max_tokens=1 means internal probe (token counting, quota).
                 -- COALESCE to 2 so requests without max_tokens are not skipped.
                 AND COALESCE((ce.payload->'final_request'->>'max_tokens')::int, 2) > 1
-                {models_user_filter}
+                {user_call_filter}
                 ORDER BY ce.session_id, ce.created_at ASC
             )
             SELECT
@@ -480,7 +474,6 @@ async def _fetch_session_list_pg(
                 s.total_events,
                 s.turn_count,
                 s.policy_interventions,
-                s.user_ids,
                 COALESCE(
                     array_agg(DISTINCT m.model) FILTER (WHERE m.model IS NOT NULL),
                     ARRAY[]::text[]
@@ -491,12 +484,45 @@ async def _fetch_session_list_pg(
             LEFT JOIN session_first_message f ON s.session_id = f.session_id
             GROUP BY s.session_id, s.first_ts, s.last_ts,
                      s.total_events, s.turn_count, s.policy_interventions,
-                     s.user_ids, f.request_payload
+                     f.request_payload
             ORDER BY s.last_ts DESC
             LIMIT $1 OFFSET $2
             """,
             *query_args,
         )
+
+        # Separate user_ids lookup keyed on the page's session_ids. Distinct
+        # users only — never collapse via MIN/MAX. When a user filter is in
+        # effect the same scoping is applied so the response doesn't leak the
+        # *existence* of other users sharing the session.
+        user_ids_by_session: dict[str, list[str]] = {}
+        if rows:
+            session_ids_on_page = [str(row["session_id"]) for row in rows]
+            placeholders = ", ".join(f"${i + 1}" for i in range(len(session_ids_on_page)))
+            if user_id is not None:
+                user_id_filter_clause = f"AND cc.user_id = ${len(session_ids_on_page) + 1}"
+                user_id_extra_args: list[Any] = [user_id]
+            else:
+                user_id_filter_clause = ""
+                user_id_extra_args = []
+            user_id_rows = await conn.fetch(
+                f"""
+                SELECT DISTINCT ce.session_id, cc.user_id
+                FROM conversation_events ce
+                JOIN conversation_calls cc ON ce.call_id = cc.call_id
+                WHERE ce.session_id IN ({placeholders})
+                AND cc.user_id IS NOT NULL
+                {user_id_filter_clause}
+                """,
+                *session_ids_on_page,
+                *user_id_extra_args,
+            )
+            for r in user_id_rows:
+                sid = str(r["session_id"])
+                uid = str(r["user_id"])
+                bucket = user_ids_by_session.setdefault(sid, [])
+                if uid not in bucket:
+                    bucket.append(uid)
 
     sessions = [
         SessionSummary(
@@ -508,7 +534,7 @@ async def _fetch_session_list_pg(
             policy_interventions=int(row["policy_interventions"]),  # type: ignore[arg-type]
             models_used=list(row["models"]) if row["models"] else [],  # type: ignore[arg-type]
             preview_message=_extract_preview_message(cast(_PreviewPayload, row["request_payload"])),
-            user_ids=list(row["user_ids"]) if row["user_ids"] else [],  # type: ignore[arg-type]
+            user_ids=user_ids_by_session.get(str(row["session_id"]), []),
         )
         for row in rows
     ]

--- a/src/luthien_proxy/history/service.py
+++ b/src/luthien_proxy/history/service.py
@@ -408,10 +408,17 @@ async def _fetch_session_list_pg(
                 """
             )
 
-        # The user_id filter (when provided) restricts the session_stats CTE
-        # to call_ids belonging to that user. The user_id column is always
-        # selected so SessionSummary can populate user_id even without a filter.
+        # When the caller filters by user_id we must scope every CTE to that
+        # user's call_ids — not just session_stats — otherwise preview_message
+        # / models_used can leak content from a *different* user's calls that
+        # happen to share the session_id. (Sessions can be reused across users
+        # when a frontend passes a stable session_id with rotating identities.)
         user_filter_clause = "AND cc.user_id = $3" if user_id is not None else ""
+        models_user_filter = (
+            "AND ce.call_id IN (SELECT call_id FROM conversation_calls WHERE user_id = $3)"
+            if user_id is not None
+            else ""
+        )
         query_args: list[Any] = [limit, offset]
         if user_id is not None:
             query_args.append(user_id)
@@ -426,13 +433,17 @@ async def _fetch_session_list_pg(
                     COUNT(*) as total_events,
                     COUNT(DISTINCT ce.call_id) as turn_count,
                     COUNT(*) FILTER (
-                        WHERE ce.event_type LIKE 'policy.%%'
-                        AND ce.event_type NOT LIKE 'policy.%%judge.evaluation%%'
+                        WHERE ce.event_type LIKE 'policy.%'
+                        AND ce.event_type NOT LIKE 'policy.%judge.evaluation%'
                     ) as policy_interventions,
-                    -- Surface the first non-null user_id observed for this session.
-                    -- Calls within a session typically carry the same identity, but
-                    -- MIN() guarantees deterministic output if mixed.
-                    MIN(cc.user_id) as user_id
+                    -- All distinct user_ids observed across this session's calls.
+                    -- Multi-element arrays signal a session that mixed identities;
+                    -- the consumer decides how to render that. NEVER collapse with
+                    -- MIN/MAX/FIRST — that silently mis-attributes mixed sessions.
+                    COALESCE(
+                        array_agg(DISTINCT cc.user_id) FILTER (WHERE cc.user_id IS NOT NULL),
+                        ARRAY[]::text[]
+                    ) as user_ids
                 FROM conversation_events ce
                 LEFT JOIN conversation_calls cc ON ce.call_id = cc.call_id
                 WHERE ce.session_id IS NOT NULL
@@ -441,24 +452,26 @@ async def _fetch_session_list_pg(
             ),
             session_models AS (
                 SELECT DISTINCT
-                    session_id,
-                    payload->>'final_model' as model
-                FROM conversation_events
-                WHERE session_id IS NOT NULL
-                AND event_type = 'transaction.request_recorded'
-                AND payload->>'final_model' IS NOT NULL
+                    ce.session_id,
+                    ce.payload->>'final_model' as model
+                FROM conversation_events ce
+                WHERE ce.session_id IS NOT NULL
+                AND ce.event_type = 'transaction.request_recorded'
+                AND ce.payload->>'final_model' IS NOT NULL
+                {models_user_filter}
             ),
             session_first_message AS (
-                SELECT DISTINCT ON (session_id)
-                    session_id,
-                    payload as request_payload
-                FROM conversation_events
-                WHERE session_id IS NOT NULL
-                AND event_type = 'transaction.request_recorded'
+                SELECT DISTINCT ON (ce.session_id)
+                    ce.session_id,
+                    ce.payload as request_payload
+                FROM conversation_events ce
+                WHERE ce.session_id IS NOT NULL
+                AND ce.event_type = 'transaction.request_recorded'
                 -- Skip probe requests: max_tokens=1 means internal probe (token counting, quota).
                 -- COALESCE to 2 so requests without max_tokens are not skipped.
-                AND COALESCE((payload->'final_request'->>'max_tokens')::int, 2) > 1
-                ORDER BY session_id, created_at ASC
+                AND COALESCE((ce.payload->'final_request'->>'max_tokens')::int, 2) > 1
+                {models_user_filter}
+                ORDER BY ce.session_id, ce.created_at ASC
             )
             SELECT
                 s.session_id,
@@ -467,7 +480,7 @@ async def _fetch_session_list_pg(
                 s.total_events,
                 s.turn_count,
                 s.policy_interventions,
-                s.user_id,
+                s.user_ids,
                 COALESCE(
                     array_agg(DISTINCT m.model) FILTER (WHERE m.model IS NOT NULL),
                     ARRAY[]::text[]
@@ -478,7 +491,7 @@ async def _fetch_session_list_pg(
             LEFT JOIN session_first_message f ON s.session_id = f.session_id
             GROUP BY s.session_id, s.first_ts, s.last_ts,
                      s.total_events, s.turn_count, s.policy_interventions,
-                     s.user_id, f.request_payload
+                     s.user_ids, f.request_payload
             ORDER BY s.last_ts DESC
             LIMIT $1 OFFSET $2
             """,
@@ -495,7 +508,7 @@ async def _fetch_session_list_pg(
             policy_interventions=int(row["policy_interventions"]),  # type: ignore[arg-type]
             models_used=list(row["models"]) if row["models"] else [],  # type: ignore[arg-type]
             preview_message=_extract_preview_message(cast(_PreviewPayload, row["request_payload"])),
-            user_id=cast("str | None", row["user_id"]),
+            user_ids=list(row["user_ids"]) if row["user_ids"] else [],  # type: ignore[arg-type]
         )
         for row in rows
     ]
@@ -546,6 +559,10 @@ async def _fetch_session_list_sqlite(
         if user_id is not None:
             query_args.append(user_id)
 
+        # SQLite has no array_agg, so we cannot return user_ids as a list in a
+        # single query. Fetch the per-session distinct user_ids in a separate
+        # query keyed on the page's session_ids, mirroring the model/preview
+        # batching approach.
         rows = await conn.fetch(
             f"""
             SELECT
@@ -558,8 +575,7 @@ async def _fetch_session_list_sqlite(
                     WHEN ce.event_type LIKE 'policy.%'
                     AND ce.event_type NOT LIKE 'policy.%judge.evaluation%'
                     THEN 1 ELSE 0
-                END) as policy_interventions,
-                MIN(cc.user_id) as user_id
+                END) as policy_interventions
             FROM conversation_events ce
             LEFT JOIN conversation_calls cc ON ce.call_id = cc.call_id
             WHERE ce.session_id IS NOT NULL
@@ -579,32 +595,73 @@ async def _fetch_session_list_sqlite(
         session_ids = [str(row["session_id"]) for row in rows]
         placeholders = ", ".join(f"${i + 1}" for i in range(len(session_ids)))
 
+        # When a user_id filter is in effect, restrict the model/preview/user-id
+        # lookups to that user's call_ids — without this, preview_message and
+        # models_used can leak content from other users' calls that happen to
+        # share the session_id.
+        if user_id is not None:
+            user_call_filter = (
+                f"AND ce.call_id IN (SELECT call_id FROM conversation_calls WHERE user_id = ${len(session_ids) + 1})"
+            )
+            extra_args: list[Any] = [user_id]
+        else:
+            user_call_filter = ""
+            extra_args = []
+
         # One query for all models on this page
         model_rows = await conn.fetch(
             f"""
-            SELECT session_id, json_extract(payload, '$.final_model') as model
-            FROM conversation_events
-            WHERE session_id IN ({placeholders})
-            AND event_type = 'transaction.request_recorded'
-            AND json_extract(payload, '$.final_model') IS NOT NULL
+            SELECT ce.session_id, json_extract(ce.payload, '$.final_model') as model
+            FROM conversation_events ce
+            WHERE ce.session_id IN ({placeholders})
+            AND ce.event_type = 'transaction.request_recorded'
+            AND json_extract(ce.payload, '$.final_model') IS NOT NULL
+            {user_call_filter}
             """,
             *session_ids,
+            *extra_args,
         )
 
         # One query for first qualifying preview per session on this page
         preview_rows = await conn.fetch(
             f"""
-            SELECT session_id, payload as request_payload
-            FROM conversation_events
-            WHERE session_id IN ({placeholders})
-            AND event_type = 'transaction.request_recorded'
+            SELECT ce.session_id, ce.payload as request_payload
+            FROM conversation_events ce
+            WHERE ce.session_id IN ({placeholders})
+            AND ce.event_type = 'transaction.request_recorded'
             AND COALESCE(
-                CAST(json_extract(payload, '$.final_request.max_tokens') AS INTEGER),
+                CAST(json_extract(ce.payload, '$.final_request.max_tokens') AS INTEGER),
                 2
             ) > 1
-            ORDER BY session_id, created_at ASC
+            {user_call_filter}
+            ORDER BY ce.session_id, ce.created_at ASC
             """,
             *session_ids,
+            *extra_args,
+        )
+
+        # Distinct user_ids per session — never collapse via MIN/MAX, that lies
+        # on multi-user sessions. Returned as a list so the consumer can render
+        # mixed-identity sessions honestly. When a user filter is in effect
+        # we constrain to that user so the response doesn't leak the *existence*
+        # of other users sharing the session.
+        if user_id is not None:
+            user_id_filter_clause = f"AND cc.user_id = ${len(session_ids) + 1}"
+            user_id_args: list[Any] = [user_id]
+        else:
+            user_id_filter_clause = ""
+            user_id_args = []
+        user_id_rows = await conn.fetch(
+            f"""
+            SELECT DISTINCT ce.session_id, cc.user_id
+            FROM conversation_events ce
+            JOIN conversation_calls cc ON ce.call_id = cc.call_id
+            WHERE ce.session_id IN ({placeholders})
+            AND cc.user_id IS NOT NULL
+            {user_id_filter_clause}
+            """,
+            *session_ids,
+            *user_id_args,
         )
 
     # Build per-session lookup maps from the bulk results
@@ -622,6 +679,14 @@ async def _fetch_session_list_sqlite(
         if sid not in preview_by_session:
             preview_by_session[sid] = _extract_preview_message(cast(_PreviewPayload, r["request_payload"]))
 
+    user_ids_by_session: dict[str, list[str]] = {}
+    for r in user_id_rows:
+        sid = str(r["session_id"])
+        uid = str(r["user_id"])
+        bucket = user_ids_by_session.setdefault(sid, [])
+        if uid not in bucket:
+            bucket.append(uid)
+
     sessions = [
         SessionSummary(
             session_id=str(row["session_id"]),
@@ -632,7 +697,7 @@ async def _fetch_session_list_sqlite(
             policy_interventions=int(row["policy_interventions"]),  # type: ignore[arg-type]
             models_used=models_by_session.get(str(row["session_id"]), []),
             preview_message=preview_by_session.get(str(row["session_id"])),
-            user_id=cast("str | None", row["user_id"]),
+            user_ids=user_ids_by_session.get(str(row["session_id"]), []),
         )
         for row in rows
     ]

--- a/src/luthien_proxy/history/service.py
+++ b/src/luthien_proxy/history/service.py
@@ -352,49 +352,92 @@ def _extract_preview_message(payload: dict[str, Any] | str | None) -> str | None
     return None
 
 
-async def fetch_session_list(limit: int, db_pool: DatabasePool, offset: int = 0) -> SessionListResponse:
+async def fetch_session_list(
+    limit: int,
+    db_pool: DatabasePool,
+    offset: int = 0,
+    *,
+    user_id: str | None = None,
+) -> SessionListResponse:
     """Fetch list of recent sessions with summaries.
 
     Args:
         limit: Maximum number of sessions to return
         db_pool: Database connection pool
         offset: Number of sessions to skip for pagination
+        user_id: If provided, only return sessions whose conversation_calls
+            row has this exact user_id. Used to attribute traffic per user.
 
     Returns:
         List of session summaries ordered by most recent activity
     """
     if db_pool.is_sqlite:
-        return await _fetch_session_list_sqlite(limit, db_pool, offset)
-    return await _fetch_session_list_pg(limit, db_pool, offset)
+        return await _fetch_session_list_sqlite(limit, db_pool, offset, user_id=user_id)
+    return await _fetch_session_list_pg(limit, db_pool, offset, user_id=user_id)
 
 
-async def _fetch_session_list_pg(limit: int, db_pool: DatabasePool, offset: int = 0) -> SessionListResponse:
+async def _fetch_session_list_pg(
+    limit: int,
+    db_pool: DatabasePool,
+    offset: int = 0,
+    *,
+    user_id: str | None = None,
+) -> SessionListResponse:
     """PostgreSQL version using PG-specific features (FILTER, DISTINCT ON, array_agg)."""
+    # SECURITY INVARIANT: user_id is bound as a query parameter, never
+    # interpolated into the SQL string. The placeholder slot is fixed,
+    # only the WHERE-clause presence is conditional on whether a filter
+    # was requested. See test_fetch_session_list_user_filter_sql_injection.
     async with db_pool.connection() as conn:
-        total_count = await conn.fetchval(
-            """
-            SELECT COUNT(DISTINCT session_id)
-            FROM conversation_events
-            WHERE session_id IS NOT NULL
-            """
-        )
-
-        rows = await conn.fetch(
-            """
-            WITH session_stats AS (
-                SELECT
-                    session_id,
-                    MIN(created_at) as first_ts,
-                    MAX(created_at) as last_ts,
-                    COUNT(*) as total_events,
-                    COUNT(DISTINCT call_id) as turn_count,
-                    COUNT(*) FILTER (
-                        WHERE event_type LIKE 'policy.%'
-                        AND event_type NOT LIKE 'policy.%judge.evaluation%'
-                    ) as policy_interventions
+        if user_id is not None:
+            total_count = await conn.fetchval(
+                """
+                SELECT COUNT(DISTINCT ce.session_id)
+                FROM conversation_events ce
+                JOIN conversation_calls cc ON ce.call_id = cc.call_id
+                WHERE ce.session_id IS NOT NULL AND cc.user_id = $1
+                """,
+                user_id,
+            )
+        else:
+            total_count = await conn.fetchval(
+                """
+                SELECT COUNT(DISTINCT session_id)
                 FROM conversation_events
                 WHERE session_id IS NOT NULL
-                GROUP BY session_id
+                """
+            )
+
+        # The user_id filter (when provided) restricts the session_stats CTE
+        # to call_ids belonging to that user. The user_id column is always
+        # selected so SessionSummary can populate user_id even without a filter.
+        user_filter_clause = "AND cc.user_id = $3" if user_id is not None else ""
+        query_args: list[Any] = [limit, offset]
+        if user_id is not None:
+            query_args.append(user_id)
+
+        rows = await conn.fetch(
+            f"""
+            WITH session_stats AS (
+                SELECT
+                    ce.session_id,
+                    MIN(ce.created_at) as first_ts,
+                    MAX(ce.created_at) as last_ts,
+                    COUNT(*) as total_events,
+                    COUNT(DISTINCT ce.call_id) as turn_count,
+                    COUNT(*) FILTER (
+                        WHERE ce.event_type LIKE 'policy.%%'
+                        AND ce.event_type NOT LIKE 'policy.%%judge.evaluation%%'
+                    ) as policy_interventions,
+                    -- Surface the first non-null user_id observed for this session.
+                    -- Calls within a session typically carry the same identity, but
+                    -- MIN() guarantees deterministic output if mixed.
+                    MIN(cc.user_id) as user_id
+                FROM conversation_events ce
+                LEFT JOIN conversation_calls cc ON ce.call_id = cc.call_id
+                WHERE ce.session_id IS NOT NULL
+                {user_filter_clause}
+                GROUP BY ce.session_id
             ),
             session_models AS (
                 SELECT DISTINCT
@@ -424,6 +467,7 @@ async def _fetch_session_list_pg(limit: int, db_pool: DatabasePool, offset: int 
                 s.total_events,
                 s.turn_count,
                 s.policy_interventions,
+                s.user_id,
                 COALESCE(
                     array_agg(DISTINCT m.model) FILTER (WHERE m.model IS NOT NULL),
                     ARRAY[]::text[]
@@ -434,12 +478,11 @@ async def _fetch_session_list_pg(limit: int, db_pool: DatabasePool, offset: int 
             LEFT JOIN session_first_message f ON s.session_id = f.session_id
             GROUP BY s.session_id, s.first_ts, s.last_ts,
                      s.total_events, s.turn_count, s.policy_interventions,
-                     f.request_payload
+                     s.user_id, f.request_payload
             ORDER BY s.last_ts DESC
             LIMIT $1 OFFSET $2
             """,
-            limit,
-            offset,
+            *query_args,
         )
 
     sessions = [
@@ -452,6 +495,7 @@ async def _fetch_session_list_pg(limit: int, db_pool: DatabasePool, offset: int 
             policy_interventions=int(row["policy_interventions"]),  # type: ignore[arg-type]
             models_used=list(row["models"]) if row["models"] else [],  # type: ignore[arg-type]
             preview_message=_extract_preview_message(cast(_PreviewPayload, row["request_payload"])),
+            user_id=cast("str | None", row["user_id"]),
         )
         for row in rows
     ]
@@ -462,43 +506,69 @@ async def _fetch_session_list_pg(limit: int, db_pool: DatabasePool, offset: int 
     return SessionListResponse(sessions=sessions, total=total, offset=offset, has_more=has_more)
 
 
-async def _fetch_session_list_sqlite(limit: int, db_pool: DatabasePool, offset: int = 0) -> SessionListResponse:
+async def _fetch_session_list_sqlite(
+    limit: int,
+    db_pool: DatabasePool,
+    offset: int = 0,
+    *,
+    user_id: str | None = None,
+) -> SessionListResponse:
     """SQLite version: 3 queries total (vs PostgreSQL's 2).
 
     Avoids N+1 by batching models and previews for the whole page in one
     query each, then merging in Python. PostgreSQL uses array_agg/DISTINCT ON
     in a single CTE; SQLite lacks those, so we use IN (session_ids) instead.
     """
+    # SECURITY INVARIANT: user_id is bound as a query parameter, never
+    # interpolated into the SQL string.
     async with db_pool.connection() as conn:
-        total_count = await conn.fetchval(
-            """
-            SELECT COUNT(DISTINCT session_id)
-            FROM conversation_events
-            WHERE session_id IS NOT NULL
-            """
-        )
+        if user_id is not None:
+            total_count = await conn.fetchval(
+                """
+                SELECT COUNT(DISTINCT ce.session_id)
+                FROM conversation_events ce
+                JOIN conversation_calls cc ON ce.call_id = cc.call_id
+                WHERE ce.session_id IS NOT NULL AND cc.user_id = $1
+                """,
+                user_id,
+            )
+        else:
+            total_count = await conn.fetchval(
+                """
+                SELECT COUNT(DISTINCT session_id)
+                FROM conversation_events
+                WHERE session_id IS NOT NULL
+                """
+            )
+
+        user_filter_clause = "AND cc.user_id = $3" if user_id is not None else ""
+        query_args: list[Any] = [limit, offset]
+        if user_id is not None:
+            query_args.append(user_id)
 
         rows = await conn.fetch(
-            """
+            f"""
             SELECT
-                session_id,
-                MIN(created_at) as first_ts,
-                MAX(created_at) as last_ts,
+                ce.session_id,
+                MIN(ce.created_at) as first_ts,
+                MAX(ce.created_at) as last_ts,
                 COUNT(*) as total_events,
-                COUNT(DISTINCT call_id) as turn_count,
+                COUNT(DISTINCT ce.call_id) as turn_count,
                 SUM(CASE
-                    WHEN event_type LIKE 'policy.%'
-                    AND event_type NOT LIKE 'policy.%judge.evaluation%'
+                    WHEN ce.event_type LIKE 'policy.%'
+                    AND ce.event_type NOT LIKE 'policy.%judge.evaluation%'
                     THEN 1 ELSE 0
-                END) as policy_interventions
-            FROM conversation_events
-            WHERE session_id IS NOT NULL
-            GROUP BY session_id
+                END) as policy_interventions,
+                MIN(cc.user_id) as user_id
+            FROM conversation_events ce
+            LEFT JOIN conversation_calls cc ON ce.call_id = cc.call_id
+            WHERE ce.session_id IS NOT NULL
+            {user_filter_clause}
+            GROUP BY ce.session_id
             ORDER BY last_ts DESC
             LIMIT $1 OFFSET $2
             """,
-            limit,
-            offset,
+            *query_args,
         )
 
         total = int(total_count) if total_count is not None else 0  # type: ignore[arg-type]
@@ -562,6 +632,7 @@ async def _fetch_session_list_sqlite(limit: int, db_pool: DatabasePool, offset: 
             policy_interventions=int(row["policy_interventions"]),  # type: ignore[arg-type]
             models_used=models_by_session.get(str(row["session_id"]), []),
             preview_message=preview_by_session.get(str(row["session_id"])),
+            user_id=cast("str | None", row["user_id"]),
         )
         for row in rows
     ]

--- a/src/luthien_proxy/observability/emitter.py
+++ b/src/luthien_proxy/observability/emitter.py
@@ -121,8 +121,6 @@ class NullEventEmitter:
 class EventEmitter:
     """Emits events to multiple sinks: stdout, database, and redis."""
 
-    dropped_db_writes: int = 0
-
     def __init__(
         self,
         db_pool: "DatabasePool | None" = None,
@@ -133,6 +131,7 @@ class EventEmitter:
         self._db_pool = db_pool
         self._event_publisher = event_publisher
         self._stdout_enabled = stdout_enabled
+        self.dropped_db_writes: int = 0
 
     async def emit(
         self,
@@ -228,50 +227,56 @@ class EventEmitter:
     ) -> None:
         """Write event to PostgreSQL.
 
-        Session ID Propagation Convention:
-            The session_id is extracted from the event data dict if present.
-            Callers (e.g., processor.py) should include {"session_id": value}
-            in their event data to persist the session_id to the database.
-            This convention allows session tracking without modifying the
+        Session ID and User ID Propagation Convention:
+            The session_id and user_id are extracted from the event data dict if present.
+            Callers (e.g., processor.py) should include {"session_id": value, "user_id": value}
+            in their event data to persist these fields to the database.
+            This convention allows session and user tracking without modifying the
             EventEmitter interface.
         """
         db_pool = cast(DatabasePool, self._db_pool)
-        # Extract session_id from data if present (set by processor via convention above)
+        # Extract session_id and user_id from data if present (set by processor via convention above)
         session_id = data.get("session_id") if isinstance(data, dict) else None
+        user_id = data.get("user_id") if isinstance(data, dict) else None
 
         try:
             async with db_pool.connection() as conn:
-                # Ensure call row exists with session_id
+                # Ensure call row exists with session_id and user_id
                 await conn.execute(
                     """
-                    INSERT INTO conversation_calls (call_id, created_at, session_id)
-                    VALUES ($1, $2, $3)
+                    INSERT INTO conversation_calls (call_id, created_at, session_id, user_id)
+                    VALUES ($1, $2, $3, $4)
                     ON CONFLICT (call_id) DO UPDATE SET
-                        session_id = COALESCE(conversation_calls.session_id, EXCLUDED.session_id)
+                        session_id = COALESCE(conversation_calls.session_id, EXCLUDED.session_id),
+                        user_id = COALESCE(conversation_calls.user_id, EXCLUDED.user_id)
                     """,
                     transaction_id,
                     timestamp,
                     session_id,
+                    user_id,
                 )
 
-                # Insert event with session_id, ordering by created_at
+                # Insert event with session_id and user_id, ordering by created_at
                 await conn.execute(
                     """
-                    INSERT INTO conversation_events (call_id, event_type, payload, created_at, session_id)
-                    VALUES ($1, $2, $3, $4, $5)
+                    INSERT INTO conversation_events (call_id, event_type, payload, created_at, session_id, user_id)
+                    VALUES ($1, $2, $3, $4, $5, $6)
                     """,
                     transaction_id,
                     event_type,
                     json.dumps(data),
                     timestamp,
                     session_id,
+                    user_id,
                 )
 
-            logger.debug(f"Wrote event to db: {event_type} (transaction_id={transaction_id})")
+            logger.debug("Wrote event to db: %s (transaction_id=%s)", event_type, transaction_id)
         except (OSError, asyncpg.PostgresError, asyncpg.InternalClientError) as e:
-            EventEmitter.dropped_db_writes += 1
+            self.dropped_db_writes += 1
             logger.warning(
-                f"Failed to write event to database ({EventEmitter.dropped_db_writes} total dropped): {repr(e)}",
+                "Failed to write event to database (%d total dropped): %r",
+                self.dropped_db_writes,
+                e,
                 exc_info=True,
             )
 

--- a/src/luthien_proxy/observability/emitter.py
+++ b/src/luthien_proxy/observability/emitter.py
@@ -121,6 +121,8 @@ class NullEventEmitter:
 class EventEmitter:
     """Emits events to multiple sinks: stdout, database, and redis."""
 
+    dropped_db_writes: int = 0
+
     def __init__(
         self,
         db_pool: "DatabasePool | None" = None,
@@ -131,7 +133,6 @@ class EventEmitter:
         self._db_pool = db_pool
         self._event_publisher = event_publisher
         self._stdout_enabled = stdout_enabled
-        self.dropped_db_writes: int = 0
 
     async def emit(
         self,
@@ -270,13 +271,11 @@ class EventEmitter:
                     user_id,
                 )
 
-            logger.debug("Wrote event to db: %s (transaction_id=%s)", event_type, transaction_id)
+            logger.debug(f"Wrote event to db: {event_type} (transaction_id={transaction_id})")
         except (OSError, asyncpg.PostgresError, asyncpg.InternalClientError) as e:
-            self.dropped_db_writes += 1
+            EventEmitter.dropped_db_writes += 1
             logger.warning(
-                "Failed to write event to database (%d total dropped): %r",
-                self.dropped_db_writes,
-                e,
+                f"Failed to write event to database ({EventEmitter.dropped_db_writes} total dropped): {repr(e)}",
                 exc_info=True,
             )
 

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -52,7 +52,7 @@ from luthien_proxy.pipeline.policy_context_injection import inject_policy_awaren
 from luthien_proxy.pipeline.session import (
     extract_session_id_from_anthropic_body,
     extract_session_id_from_headers,
-    extract_user_id_from_bearer_token,
+    extract_user_id_from_authorization_header,
     extract_user_id_from_headers,
 )
 from luthien_proxy.pipeline.stream_protocol_validator import validate_anthropic_event_ordering
@@ -508,9 +508,6 @@ async def _process_request(
             path=request.url.path,
         )
 
-        # Log incoming request
-        emitter.record(call_id, "pipeline.client_request", {"payload": body})
-
         # Extract session ID: try metadata.user_id first (API key mode),
         # fall back to x-session-id header (OAuth passthrough mode)
         session_id = extract_session_id_from_anthropic_body(body) or extract_session_id_from_headers(headers)
@@ -519,14 +516,20 @@ async def _process_request(
         # 1. X-Luthien-User-Id header (only when TRUST_USER_ID_HEADER=true)
         # 2. fall back to JWT Bearer token sub claim — signature is not verified;
         #    treat as user-asserted attribution, never as access control.
-        bearer_token = headers.get("authorization", "")
-        if bearer_token.lower().startswith("bearer "):
-            bearer_token = bearer_token[7:]
-        else:
-            bearer_token = ""
+        # NOTE: JWT extraction only fires for OAuth-passthrough clients; clients
+        # using `x-api-key` (the standard Anthropic SDK auth) carry no Bearer
+        # token, so user_id is None unless TRUST_USER_ID_HEADER and the header
+        # are both set.
         user_id = extract_user_id_from_headers(
             headers, trust_header=get_settings().trust_user_id_header
-        ) or extract_user_id_from_bearer_token(bearer_token)
+        ) or extract_user_id_from_authorization_header(headers.get("authorization"))
+
+        # Log incoming request — record AFTER user_id extraction so the very
+        # first event row of every call carries user_id, not NULL. Otherwise
+        # `WHERE user_id = X` queries silently miss the raw client request.
+        emitter.record(
+            call_id, "pipeline.client_request", {"payload": body, "session_id": session_id, "user_id": user_id}
+        )
 
         # Validate required fields
         if "model" not in body:

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -52,6 +52,8 @@ from luthien_proxy.pipeline.policy_context_injection import inject_policy_awaren
 from luthien_proxy.pipeline.session import (
     extract_session_id_from_anthropic_body,
     extract_session_id_from_headers,
+    extract_user_id_from_bearer_token,
+    extract_user_id_from_headers,
 )
 from luthien_proxy.pipeline.stream_protocol_validator import validate_anthropic_event_ordering
 from luthien_proxy.pipeline.upstream_headers import expand_upstream_headers, merge_forwarded_headers
@@ -101,6 +103,7 @@ class _AnthropicPolicyIO(AnthropicPolicyIOProtocol):
         emitter: EventEmitterProtocol,
         call_id: str,
         session_id: str | None,
+        user_id: str | None,
         request_log_recorder: RequestLogRecorder,
         is_streaming: bool,
         extra_headers: dict[str, str] | None = None,
@@ -111,6 +114,7 @@ class _AnthropicPolicyIO(AnthropicPolicyIOProtocol):
         self._emitter = emitter
         self._call_id = call_id
         self._session_id = session_id
+        self._user_id = user_id
         self._request_log_recorder = request_log_recorder
         self._is_streaming = is_streaming
         self._extra_headers = extra_headers
@@ -152,6 +156,7 @@ class _AnthropicPolicyIO(AnthropicPolicyIOProtocol):
                 "original_request": dict(self._initial_request),
                 "final_request": dict(effective_request),
                 "session_id": self._session_id,
+                "user_id": self._user_id,
             },
         )
         self._request_recorded = True
@@ -164,7 +169,7 @@ class _AnthropicPolicyIO(AnthropicPolicyIOProtocol):
         self._emitter.record(
             self._call_id,
             "pipeline.backend_request",
-            {"payload": request_payload, "session_id": self._session_id},
+            {"payload": request_payload, "session_id": self._session_id, "user_id": self._user_id},
         )
         self._request_log_recorder.record_outbound_request(
             body=request_payload,
@@ -369,7 +374,7 @@ async def process_anthropic_request(
         root_span.set_attribute("luthien.endpoint", "/v1/messages")
 
         # Phase 1: Process incoming request
-        anthropic_request, raw_http_request, session_id = await _process_request(
+        anthropic_request, raw_http_request, session_id, user_id = await _process_request(
             request=request,
             call_id=call_id,
             emitter=emitter,
@@ -384,6 +389,8 @@ async def process_anthropic_request(
         root_span.set_attribute("luthien.stream", is_streaming)
         if session_id:
             root_span.set_attribute("luthien.session_id", session_id)
+        if user_id:
+            root_span.set_attribute("luthien.user_id", user_id)
         if usage_collector:
             usage_collector.record_session(session_id)
 
@@ -428,6 +435,7 @@ async def process_anthropic_request(
             emitter=emitter,
             raw_http_request=raw_http_request,
             session_id=session_id,
+            user_id=user_id,
             user_credential=user_credential,
             credential_manager=credential_manager,
             policy_cache_factory=policy_cache_factory,
@@ -463,7 +471,7 @@ async def _process_request(
     request: Request,
     call_id: str,
     emitter: EventEmitterProtocol,
-) -> tuple[AnthropicRequest, RawHttpRequest, str | None]:
+) -> tuple[AnthropicRequest, RawHttpRequest, str | None, str | None]:
     """Process and validate incoming Anthropic request.
 
     Args:
@@ -472,7 +480,7 @@ async def _process_request(
         emitter: Event emitter
 
     Returns:
-        Tuple of (AnthropicRequest, RawHttpRequest with original data, session_id)
+        Tuple of (AnthropicRequest, RawHttpRequest with original data, session_id, user_id)
 
     Raises:
         HTTPException: On request size exceeded or invalid format
@@ -507,6 +515,19 @@ async def _process_request(
         # fall back to x-session-id header (OAuth passthrough mode)
         session_id = extract_session_id_from_anthropic_body(body) or extract_session_id_from_headers(headers)
 
+        # Extract user identity (attribution-only, NOT authenticated):
+        # 1. X-Luthien-User-Id header (only when TRUST_USER_ID_HEADER=true)
+        # 2. fall back to JWT Bearer token sub claim — signature is not verified;
+        #    treat as user-asserted attribution, never as access control.
+        bearer_token = headers.get("authorization", "")
+        if bearer_token.lower().startswith("bearer "):
+            bearer_token = bearer_token[7:]
+        else:
+            bearer_token = ""
+        user_id = extract_user_id_from_headers(
+            headers, trust_header=get_settings().trust_user_id_header
+        ) or extract_user_id_from_bearer_token(bearer_token)
+
         # Validate required fields
         if "model" not in body:
             raise HTTPException(status_code=400, detail="Missing required field: model")
@@ -522,12 +543,16 @@ async def _process_request(
             span.set_attribute("luthien.session_id", session_id)
             logger.debug(f"[{call_id}] Extracted session_id: {session_id}")
 
+        if user_id:
+            span.set_attribute("luthien.user_id", user_id)
+            logger.debug(f"[{call_id}] Extracted user_id: {user_id}")
+
         logger.info(
             f"[{call_id}] /v1/messages (native): model={anthropic_request['model']}, "
             f"stream={anthropic_request.get('stream', False)}"
         )
 
-        return anthropic_request, raw_http_request, session_id
+        return anthropic_request, raw_http_request, session_id, user_id
 
 
 async def _run_policy_hooks(
@@ -576,6 +601,7 @@ async def _execute_anthropic_policy(
         emitter=emitter,
         call_id=call_id,
         session_id=policy_ctx.session_id,
+        user_id=policy_ctx.user_id,
         request_log_recorder=request_log_recorder,
         is_streaming=is_streaming,
         extra_headers=extra_headers,
@@ -732,6 +758,7 @@ async def _handle_execution_streaming(
                                 else dict(reconstructed),
                                 "final_response": dict(reconstructed),
                                 "session_id": policy_ctx.session_id,
+                                "user_id": policy_ctx.user_id,
                             },
                         )
                     request_log_recorder.record_inbound_response(status=final_status)
@@ -821,6 +848,7 @@ async def _handle_execution_non_streaming(
             "original_response": original_response_payload,
             "final_response": dict(final_response),
             "session_id": policy_ctx.session_id,
+            "user_id": policy_ctx.user_id,
         },
     )
 
@@ -831,7 +859,7 @@ async def _handle_execution_non_streaming(
         emitter.record(
             call_id,
             "pipeline.client_response",
-            {"payload": final_response_payload, "session_id": policy_ctx.session_id},
+            {"payload": final_response_payload, "session_id": policy_ctx.session_id, "user_id": policy_ctx.user_id},
         )
         request_log_recorder.record_outbound_response(body=final_response_payload, status=200)
         request_log_recorder.record_inbound_response(status=200, body=final_response_payload)

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -516,6 +516,14 @@ async def _process_request(
         # 1. X-Luthien-User-Id header (only when TRUST_USER_ID_HEADER=true)
         # 2. fall back to JWT Bearer token sub claim — signature is not verified;
         #    treat as user-asserted attribution, never as access control.
+        #
+        # PRECEDENCE (load-bearing): the trusted header wins over the JWT sub
+        # when both are present. Operators who set TRUST_USER_ID_HEADER=true
+        # have made an explicit decision to trust their proxy's attribution;
+        # the JWT sub is implicit and unauthenticated, so it's the weaker
+        # source. Don't reorder this `... or ...` chain without changing the
+        # threat model.
+        #
         # NOTE: JWT extraction only fires for OAuth-passthrough clients; clients
         # using `x-api-key` (the standard Anthropic SDK auth) carry no Bearer
         # token, so user_id is None unless TRUST_USER_ID_HEADER and the header
@@ -524,9 +532,12 @@ async def _process_request(
             headers, trust_header=get_settings().trust_user_id_header
         ) or extract_user_id_from_authorization_header(headers.get("authorization"))
 
-        # Log incoming request — record AFTER user_id extraction so the very
-        # first event row of every call carries user_id, not NULL. Otherwise
-        # `WHERE user_id = X` queries silently miss the raw client request.
+        # LOAD-BEARING ORDERING: this record() must come AFTER user_id
+        # extraction. Otherwise the first event row of every call has
+        # user_id = NULL and `WHERE user_id = X` queries silently miss the
+        # raw client_request payload — which is the most security-relevant
+        # event in the trail. Do not reorder without re-evaluating the
+        # column-population semantics.
         emitter.record(
             call_id, "pipeline.client_request", {"payload": body, "session_id": session_id, "user_id": user_id}
         )

--- a/src/luthien_proxy/pipeline/session.py
+++ b/src/luthien_proxy/pipeline/session.py
@@ -152,11 +152,12 @@ def extract_user_id_from_authorization_header(header_value: str | None) -> str |
         The JWT ``sub`` claim string if the header carries a decodable Bearer
         JWT, None otherwise (including for non-Bearer schemes like Basic).
     """
+    _BEARER_PREFIX = "Bearer "
     if not header_value:
         return None
-    if not header_value.lower().startswith("bearer "):
+    if not header_value.lower().startswith(_BEARER_PREFIX.lower()):
         return None
-    stripped = header_value[7:].strip()
+    stripped = header_value[len(_BEARER_PREFIX) :].strip()
     return extract_user_id_from_bearer_token(stripped) if stripped else None
 
 

--- a/src/luthien_proxy/pipeline/session.py
+++ b/src/luthien_proxy/pipeline/session.py
@@ -89,6 +89,7 @@ def extract_session_id_from_headers(headers: dict[str, str]) -> str | None:
 
 
 _USER_ID_MAX_LENGTH = 256
+_BEARER_PREFIX = "Bearer "
 
 
 def _sanitize_user_id(value: str) -> str | None:
@@ -152,7 +153,6 @@ def extract_user_id_from_authorization_header(header_value: str | None) -> str |
         The JWT ``sub`` claim string if the header carries a decodable Bearer
         JWT, None otherwise (including for non-Bearer schemes like Basic).
     """
-    _BEARER_PREFIX = "Bearer "
     if not header_value:
         return None
     if not header_value.lower().startswith(_BEARER_PREFIX.lower()):
@@ -206,7 +206,10 @@ def extract_user_id_from_bearer_token(token: str | None) -> str | None:
         standard_b64 = payload_b64.encode("ascii").translate(bytes.maketrans(b"-_", b"+/"))
         payload_bytes = base64.b64decode(standard_b64, validate=True)
         payload = json.loads(payload_bytes)
-    except (ValueError, binascii.Error, json.JSONDecodeError, UnicodeDecodeError):
+    # UnicodeDecodeError and json.JSONDecodeError are both ValueError subclasses;
+    # the explicit `binascii.Error` is the only non-ValueError-derived case worth
+    # naming.
+    except (ValueError, binascii.Error):
         return None
 
     if not isinstance(payload, dict):

--- a/src/luthien_proxy/pipeline/session.py
+++ b/src/luthien_proxy/pipeline/session.py
@@ -1,17 +1,26 @@
-"""Session ID extraction from client requests.
+"""Session ID and user identity extraction from client requests.
 
-Extracts session identifiers from incoming requests to enable tracking
-conversations across multiple API calls.
+Extracts session identifiers and user identities from incoming requests to enable
+tracking conversations across multiple API calls and attributing requests to users.
 """
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
+import logging
 import re
 from typing import Any
 
+logger = logging.getLogger(__name__)
+
 # Header name for clients to provide session ID (used by Claude Code and other integrations)
 SESSION_ID_HEADER = "x-session-id"
+
+# Header name for clients or upstream proxies to provide user identity.
+# Takes precedence over JWT sub claim extraction.
+USER_ID_HEADER = "x-luthien-user-id"
 
 # Pattern to extract session UUID from Anthropic metadata.user_id
 # Format: user_<hash>_account__session_<uuid>
@@ -38,6 +47,10 @@ def extract_session_id_from_anthropic_body(body: dict[str, Any]) -> str | None:
 
     user_id = metadata.get("user_id")
     if not isinstance(user_id, str):
+        return None
+
+    if len(user_id) > 8192:
+        logger.debug("metadata.user_id exceeds 8 KB (%d bytes) — skipping", len(user_id))
         return None
 
     # Try API key format: user_<hash>_account__session_<uuid>
@@ -75,8 +88,94 @@ def extract_session_id_from_headers(headers: dict[str, str]) -> str | None:
     return value if value else None
 
 
+_USER_ID_MAX_LENGTH = 256
+
+
+def _sanitize_user_id(value: str) -> str | None:
+    """Sanitize user ID by stripping control characters and truncating.
+
+    Args:
+        value: Raw user ID string
+
+    Returns:
+        Sanitized user ID (max 256 chars, no control chars), or None if empty
+    """
+    cleaned = "".join(ch for ch in value if ord(ch) >= 0x20 and ord(ch) != 0x7F).strip()
+    return cleaned[:_USER_ID_MAX_LENGTH] if cleaned else None
+
+
+def extract_user_id_from_headers(headers: dict[str, str], *, trust_header: bool) -> str | None:
+    """Extract user identity from the X-Luthien-User-Id request header.
+
+    Only consulted when ``trust_header`` is True (set via TRUST_USER_ID_HEADER config).
+    Values are trimmed, truncated to 256 chars, and stripped of control characters
+    to prevent log injection and storage overflow.
+
+    Args:
+        headers: Request headers (keys should be lowercase)
+        trust_header: When False, always returns None regardless of header value.
+            Controlled by TRUST_USER_ID_HEADER setting.
+
+    Returns:
+        Sanitized user ID string, or None if header absent, empty, or untrusted
+    """
+    if not trust_header:
+        return None
+    value = headers.get(USER_ID_HEADER)
+    if not value:
+        return None
+    return _sanitize_user_id(value)
+
+
+def extract_user_id_from_bearer_token(token: str | None) -> str | None:
+    """Extract user identity from the ``sub`` claim of a Bearer JWT token.
+
+    USER-ASSERTED, NOT AUTHENTICATED. Decodes the JWT payload without signature
+    verification — this is used for identity attribution only, not authentication.
+    Never use this value for access control or security decisions.
+
+    Malformed or opaque tokens (e.g. Anthropic API keys) return None gracefully.
+
+    Args:
+        token: Raw Bearer token string (without "Bearer " prefix), or None
+
+    Returns:
+        The ``sub`` claim string if present and valid, None otherwise
+    """
+    if not token:
+        return None
+
+    if len(token) > 8192:
+        return None
+
+    # JWTs have exactly three dot-separated parts
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+
+    payload_b64 = parts[1]
+    try:
+        # Add padding back — JWT base64url strips trailing '='
+        payload_b64 += "=" * ((-len(payload_b64)) % 4)
+        payload_bytes = base64.urlsafe_b64decode(payload_b64)
+        payload = json.loads(payload_bytes)
+    except (ValueError, binascii.Error, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    sub = payload.get("sub")
+    if not isinstance(sub, str) or not sub:
+        return None
+    return _sanitize_user_id(sub)
+
+
 __all__ = [
     "SESSION_ID_HEADER",
+    "USER_ID_HEADER",
     "extract_session_id_from_anthropic_body",
     "extract_session_id_from_headers",
+    "extract_user_id_from_bearer_token",
+    "extract_user_id_from_headers",
 ]

--- a/src/luthien_proxy/pipeline/session.py
+++ b/src/luthien_proxy/pipeline/session.py
@@ -92,13 +92,19 @@ _USER_ID_MAX_LENGTH = 256
 
 
 def _sanitize_user_id(value: str) -> str | None:
-    """Sanitize user ID by stripping control characters and truncating.
+    """Sanitize user ID by stripping ASCII C0 controls + DEL and truncating.
+
+    Strips bytes < 0x20 and 0x7F (sufficient to prevent log/CSV injection
+    via CR/LF/TAB/NUL). Does NOT strip Unicode Cf/Cc categories
+    (zero-width joiners, RTL overrides, U+0080-U+009F C1 controls) — those
+    matter only when the value is rendered in a UI, and the history UI
+    does not render user_id today. Tighten this if/when the UI lands.
 
     Args:
         value: Raw user ID string
 
     Returns:
-        Sanitized user ID (max 256 chars, no control chars), or None if empty
+        Sanitized user ID (max 256 chars, no ASCII C0/DEL), or None if empty
     """
     cleaned = "".join(ch for ch in value if ord(ch) >= 0x20 and ord(ch) != 0x7F).strip()
     return cleaned[:_USER_ID_MAX_LENGTH] if cleaned else None
@@ -134,6 +140,10 @@ def extract_user_id_from_authorization_header(header_value: str | None) -> str |
     :func:`extract_user_id_from_bearer_token`. Centralizes the prefix logic so
     callers don't reimplement it (case-insensitive scheme match, empty token
     rejection).
+
+    Pass the *value* directly — this function does not consult a header dict.
+    The scheme check is case-insensitive, so neither caller nor wrapper needs
+    to lowercase the input.
 
     Args:
         header_value: Raw value of the ``Authorization`` header, or None.

--- a/src/luthien_proxy/pipeline/session.py
+++ b/src/luthien_proxy/pipeline/session.py
@@ -127,12 +127,44 @@ def extract_user_id_from_headers(headers: dict[str, str], *, trust_header: bool)
     return _sanitize_user_id(value)
 
 
+def extract_user_id_from_authorization_header(header_value: str | None) -> str | None:
+    """Extract user identity from a raw ``Authorization`` header value.
+
+    Convenience wrapper that strips the ``Bearer `` scheme and delegates to
+    :func:`extract_user_id_from_bearer_token`. Centralizes the prefix logic so
+    callers don't reimplement it (case-insensitive scheme match, empty token
+    rejection).
+
+    Args:
+        header_value: Raw value of the ``Authorization`` header, or None.
+
+    Returns:
+        The JWT ``sub`` claim string if the header carries a decodable Bearer
+        JWT, None otherwise (including for non-Bearer schemes like Basic).
+    """
+    if not header_value:
+        return None
+    if not header_value.lower().startswith("bearer "):
+        return None
+    stripped = header_value[7:].strip()
+    return extract_user_id_from_bearer_token(stripped) if stripped else None
+
+
 def extract_user_id_from_bearer_token(token: str | None) -> str | None:
     """Extract user identity from the ``sub`` claim of a Bearer JWT token.
 
     USER-ASSERTED, NOT AUTHENTICATED. Decodes the JWT payload without signature
     verification — this is used for identity attribution only, not authentication.
     Never use this value for access control or security decisions.
+
+    The ``exp`` claim is intentionally ignored: rejecting expired JWTs creates
+    attribution gaps without adding any security guarantee (the signature is
+    not checked, so a forged-expiry token would pass anyway).
+
+    NOTE: this path only fires for OAuth-passthrough clients that send
+    ``Authorization: Bearer <jwt>``. Anthropic SDK clients using ``x-api-key``
+    do not carry a Bearer token — for those deployments, only the
+    ``X-Luthien-User-Id`` header path produces a user_id.
 
     Malformed or opaque tokens (e.g. Anthropic API keys) return None gracefully.
 
@@ -176,6 +208,7 @@ __all__ = [
     "USER_ID_HEADER",
     "extract_session_id_from_anthropic_body",
     "extract_session_id_from_headers",
+    "extract_user_id_from_authorization_header",
     "extract_user_id_from_bearer_token",
     "extract_user_id_from_headers",
 ]

--- a/src/luthien_proxy/pipeline/session.py
+++ b/src/luthien_proxy/pipeline/session.py
@@ -189,7 +189,11 @@ def extract_user_id_from_bearer_token(token: str | None) -> str | None:
     try:
         # Add padding back — JWT base64url strips trailing '='
         payload_b64 += "=" * ((-len(payload_b64)) % 4)
-        payload_bytes = base64.urlsafe_b64decode(payload_b64)
+        # Translate base64url alphabet to standard so we can use validate=True.
+        # validate=True surfaces malformed tokens early instead of silently
+        # discarding non-base64 chars and feeding garbage to json.loads.
+        standard_b64 = payload_b64.encode("ascii").translate(bytes.maketrans(b"-_", b"+/"))
+        payload_bytes = base64.b64decode(standard_b64, validate=True)
         payload = json.loads(payload_bytes)
     except (ValueError, binascii.Error, json.JSONDecodeError, UnicodeDecodeError):
         return None

--- a/src/luthien_proxy/policy_core/policy_context.py
+++ b/src/luthien_proxy/policy_core/policy_context.py
@@ -55,6 +55,7 @@ class PolicyContext:
         emitter: EventEmitterProtocol | None = None,
         raw_http_request: RawHttpRequest | None = None,
         session_id: str | None = None,
+        user_id: str | None = None,
         user_credential: Credential | None = None,
         credential_manager: "CredentialManager | None" = None,
         policy_cache_factory: "PolicyCacheFactory | None" = None,
@@ -69,6 +70,9 @@ class PolicyContext:
             raw_http_request: Optional raw HTTP request data before any processing.
                               Contains original headers, body, method, and path.
             session_id: Optional session identifier extracted from client request.
+            user_id: Optional user identity extracted from X-Luthien-User-Id header
+                     or JWT Bearer token sub claim. Used for attribution only —
+                     the value is user-asserted and NOT authenticated.
             user_credential: The credential extracted from the incoming request
                              (accounts for x-anthropic-api-key overrides).
             credential_manager: Shared credential manager for auth provider
@@ -80,6 +84,7 @@ class PolicyContext:
         self.request: Any | None = request
         self.raw_http_request: RawHttpRequest | None = raw_http_request
         self.session_id: str | None = session_id
+        self.user_id: str | None = user_id
         self.user_credential: Credential | None = user_credential
         self._credential_manager: "CredentialManager | None" = credential_manager
         self._policy_cache_factory: "PolicyCacheFactory | None" = policy_cache_factory
@@ -164,6 +169,8 @@ class PolicyContext:
         payload = dict(data)
         if self.session_id and "session_id" not in payload:
             payload["session_id"] = self.session_id
+        if self.user_id and "user_id" not in payload:
+            payload["user_id"] = self.user_id
         self._emitter.record(self.transaction_id, event_type, payload)
 
     @contextmanager
@@ -269,6 +276,7 @@ class PolicyContext:
         # Shared: non-copyable infrastructure and immutable request metadata
         new_ctx.transaction_id = self.transaction_id
         new_ctx.session_id = self.session_id
+        new_ctx.user_id = self.user_id
         new_ctx.raw_http_request = self.raw_http_request  # read-only after creation
         new_ctx.user_credential = self.user_credential  # frozen dataclass
         new_ctx._credential_manager = self._credential_manager  # holds db/cache pools
@@ -295,6 +303,7 @@ class PolicyContext:
         request: Any | None = None,
         raw_http_request: RawHttpRequest | None = None,
         session_id: str | None = None,
+        user_id: str | None = None,
         user_credential: Credential | None = None,
         credential_manager: "CredentialManager | None" = None,
         policy_cache_factory: "PolicyCacheFactory | None" = None,
@@ -308,6 +317,7 @@ class PolicyContext:
             request: Optional request object
             raw_http_request: Optional raw HTTP request data
             session_id: Optional session ID
+            user_id: Optional user identity for tests exercising user-aware behavior
             user_credential: Optional credential for tests exercising auth
             credential_manager: Optional manager for tests exercising auth providers
             policy_cache_factory: Optional cache factory for tests exercising caching
@@ -321,6 +331,7 @@ class PolicyContext:
             emitter=NullEventEmitter(),
             raw_http_request=raw_http_request,
             session_id=session_id,
+            user_id=user_id,
             user_credential=user_credential,
             credential_manager=credential_manager,
             policy_cache_factory=policy_cache_factory,

--- a/src/luthien_proxy/settings.py
+++ b/src/luthien_proxy/settings.py
@@ -45,6 +45,7 @@ class Settings(_SettingsBase):
     gateway_port: int = DEFAULT_GATEWAY_PORT
     log_level: str = "info"
     verbose_client_errors: bool = False
+    trust_user_id_header: bool = False
 
     # ── auth ────────────────────────────────────────────────────────
     client_api_key: str | None = None

--- a/src/luthien_proxy/utils/sqlite_migrations/018_add_user_id.sql
+++ b/src/luthien_proxy/utils/sqlite_migrations/018_add_user_id.sql
@@ -2,10 +2,12 @@
 -- ABOUTME: Enables tracking which user made each request for team deployments
 -- ABOUTME: Extracted from X-Luthien-User-Id header or JWT Bearer token sub claim
 
+-- user_id on conversation_calls is the column the history API filters/joins against.
 -- No IF NOT EXISTS on ALTER TABLE ADD COLUMN — migration runner guarantees
 -- each migration runs exactly once, so idempotency is handled by the tracker.
 ALTER TABLE conversation_calls ADD COLUMN user_id TEXT;
 CREATE INDEX IF NOT EXISTS idx_conversation_calls_user ON conversation_calls(user_id) WHERE user_id IS NOT NULL;
 
+-- user_id on conversation_events is denormalized for analytical queries; not indexed
+-- (every event row pays the write cost; current code joins through conversation_calls).
 ALTER TABLE conversation_events ADD COLUMN user_id TEXT;
-CREATE INDEX IF NOT EXISTS idx_conversation_events_user ON conversation_events(user_id) WHERE user_id IS NOT NULL;

--- a/src/luthien_proxy/utils/sqlite_migrations/018_add_user_id.sql
+++ b/src/luthien_proxy/utils/sqlite_migrations/018_add_user_id.sql
@@ -1,0 +1,11 @@
+-- ABOUTME: Adds user_id column to conversation_calls and conversation_events
+-- ABOUTME: Enables tracking which user made each request for team deployments
+-- ABOUTME: Extracted from X-Luthien-User-Id header or JWT Bearer token sub claim
+
+-- No IF NOT EXISTS on ALTER TABLE ADD COLUMN — migration runner guarantees
+-- each migration runs exactly once, so idempotency is handled by the tracker.
+ALTER TABLE conversation_calls ADD COLUMN user_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_conversation_calls_user ON conversation_calls(user_id) WHERE user_id IS NOT NULL;
+
+ALTER TABLE conversation_events ADD COLUMN user_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_conversation_events_user ON conversation_events(user_id) WHERE user_id IS NOT NULL;

--- a/tests/luthien_proxy/unit_tests/history/test_routes.py
+++ b/tests/luthien_proxy/unit_tests/history/test_routes.py
@@ -57,7 +57,7 @@ class TestListSessionsRoute:
             new_callable=AsyncMock,
             return_value=expected_response,
         ) as mock_fetch:
-            result = await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=50, offset=0)
+            result = await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=50, offset=0, user_id=None)
 
             assert isinstance(result, SessionListResponse)
             assert result.total == 100
@@ -65,7 +65,7 @@ class TestListSessionsRoute:
             assert result.has_more is True
             assert len(result.sessions) == 1
             assert result.sessions[0].session_id == "session-1"
-            mock_fetch.assert_called_once_with(50, mock_db_pool, 0)
+            mock_fetch.assert_called_once_with(50, mock_db_pool, 0, user_id=None)
 
     @pytest.mark.asyncio
     async def test_list_sessions_custom_limit(self):
@@ -77,8 +77,8 @@ class TestListSessionsRoute:
             new_callable=AsyncMock,
             return_value=SessionListResponse(sessions=[], total=0),
         ) as mock_fetch:
-            await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=100, offset=0)
-            mock_fetch.assert_called_once_with(100, mock_db_pool, 0)
+            await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=100, offset=0, user_id=None)
+            mock_fetch.assert_called_once_with(100, mock_db_pool, 0, user_id=None)
 
     @pytest.mark.asyncio
     async def test_list_sessions_with_offset(self):
@@ -96,11 +96,11 @@ class TestListSessionsRoute:
             new_callable=AsyncMock,
             return_value=expected_response,
         ) as mock_fetch:
-            result = await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=50, offset=50)
+            result = await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=50, offset=50, user_id=None)
 
             assert result.offset == 50
             assert result.has_more is True
-            mock_fetch.assert_called_once_with(50, mock_db_pool, 50)
+            mock_fetch.assert_called_once_with(50, mock_db_pool, 50, user_id=None)
 
     @pytest.mark.asyncio
     async def test_list_sessions_empty(self):
@@ -112,7 +112,7 @@ class TestListSessionsRoute:
             new_callable=AsyncMock,
             return_value=SessionListResponse(sessions=[], total=0),
         ):
-            result = await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=50, offset=0)
+            result = await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=50, offset=0, user_id=None)
 
             assert result.total == 0
             assert result.sessions == []

--- a/tests/luthien_proxy/unit_tests/history/test_service.py
+++ b/tests/luthien_proxy/unit_tests/history/test_service.py
@@ -988,6 +988,7 @@ class TestFetchSessionList:
                 "policy_interventions": 1,
                 "models": ["gpt-4", "claude-3"],
                 "request_payload": {"final_request": {"messages": [{"role": "user", "content": "Hello world"}]}},
+                "user_id": None,
             },
         ]
 
@@ -1010,6 +1011,7 @@ class TestFetchSessionList:
         assert result.sessions[0].policy_interventions == 1
         assert "gpt-4" in result.sessions[0].models_used
         assert result.sessions[0].preview_message == "Hello world"
+        assert result.sessions[0].user_id is None
 
     @pytest.mark.asyncio
     async def test_fetch_with_offset(self):
@@ -1024,6 +1026,7 @@ class TestFetchSessionList:
                 "policy_interventions": 0,
                 "models": ["gpt-4"],
                 "request_payload": None,  # Test with no first message
+                "user_id": None,
             },
         ]
 

--- a/tests/luthien_proxy/unit_tests/history/test_service.py
+++ b/tests/luthien_proxy/unit_tests/history/test_service.py
@@ -988,7 +988,7 @@ class TestFetchSessionList:
                 "policy_interventions": 1,
                 "models": ["gpt-4", "claude-3"],
                 "request_payload": {"final_request": {"messages": [{"role": "user", "content": "Hello world"}]}},
-                "user_id": None,
+                "user_ids": [],
             },
         ]
 
@@ -1011,7 +1011,7 @@ class TestFetchSessionList:
         assert result.sessions[0].policy_interventions == 1
         assert "gpt-4" in result.sessions[0].models_used
         assert result.sessions[0].preview_message == "Hello world"
-        assert result.sessions[0].user_id is None
+        assert result.sessions[0].user_ids == []
 
     @pytest.mark.asyncio
     async def test_fetch_with_offset(self):
@@ -1026,7 +1026,7 @@ class TestFetchSessionList:
                 "policy_interventions": 0,
                 "models": ["gpt-4"],
                 "request_payload": None,  # Test with no first message
-                "user_id": None,
+                "user_ids": [],
             },
         ]
 

--- a/tests/luthien_proxy/unit_tests/history/test_service.py
+++ b/tests/luthien_proxy/unit_tests/history/test_service.py
@@ -988,13 +988,13 @@ class TestFetchSessionList:
                 "policy_interventions": 1,
                 "models": ["gpt-4", "claude-3"],
                 "request_payload": {"final_request": {"messages": [{"role": "user", "content": "Hello world"}]}},
-                "user_ids": [],
             },
         ]
 
         mock_conn = AsyncMock()
         mock_conn.fetchval.return_value = 1  # Total count
-        mock_conn.fetch.return_value = mock_rows
+        # First fetch() = main session aggregation; second = user_ids lookup.
+        mock_conn.fetch.side_effect = [mock_rows, []]
 
         mock_pool = MagicMock()
         mock_pool.is_sqlite = False
@@ -1026,13 +1026,12 @@ class TestFetchSessionList:
                 "policy_interventions": 0,
                 "models": ["gpt-4"],
                 "request_payload": None,  # Test with no first message
-                "user_ids": [],
             },
         ]
 
         mock_conn = AsyncMock()
         mock_conn.fetchval.return_value = 100  # Total count
-        mock_conn.fetch.return_value = mock_rows
+        mock_conn.fetch.side_effect = [mock_rows, []]
 
         mock_pool = MagicMock()
         mock_pool.is_sqlite = False

--- a/tests/luthien_proxy/unit_tests/history/test_service_sqlite.py
+++ b/tests/luthien_proxy/unit_tests/history/test_service_sqlite.py
@@ -781,4 +781,83 @@ class TestFetchSessionListSqlite:
         assert result.sessions[0].session_id == "session-flag"
 
 
+class TestFetchSessionListUserFilter:
+    """Test the user_id filter on fetch_session_list."""
+
+    async def _seed_user_session(
+        self, pool: DatabasePool, *, call_id: str, session_id: str, user_id: str | None, created_at: str
+    ) -> None:
+        async with pool.connection() as conn:
+            await conn.execute(
+                """
+                INSERT INTO conversation_calls
+                (call_id, model_name, provider, status, session_id, user_id, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                call_id,
+                "gpt-4",
+                "openai",
+                "completed",
+                session_id,
+                user_id,
+                created_at,
+            )
+            await conn.execute(
+                """
+                INSERT INTO conversation_events
+                (id, call_id, event_type, payload, session_id, user_id, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                f"event-{call_id}",
+                call_id,
+                "transaction.request_recorded",
+                json.dumps(
+                    {
+                        "final_model": "gpt-4",
+                        "final_request": {"messages": [{"role": "user", "content": "hi"}]},
+                    }
+                ),
+                session_id,
+                user_id,
+                created_at,
+            )
+
+    @pytest.mark.asyncio
+    async def test_user_id_populated_on_summary(self, sqlite_pool: DatabasePool):
+        await self._seed_user_session(
+            sqlite_pool, call_id="c1", session_id="s1", user_id="alice", created_at="2025-01-15T10:00:00"
+        )
+        result = await fetch_session_list(limit=10, db_pool=sqlite_pool)
+        assert len(result.sessions) == 1
+        assert result.sessions[0].user_id == "alice"
+
+    @pytest.mark.asyncio
+    async def test_user_id_filter_returns_only_matching(self, sqlite_pool: DatabasePool):
+        await self._seed_user_session(
+            sqlite_pool, call_id="c1", session_id="s-alice", user_id="alice", created_at="2025-01-15T10:00:00"
+        )
+        await self._seed_user_session(
+            sqlite_pool, call_id="c2", session_id="s-bob", user_id="bob", created_at="2025-01-15T10:01:00"
+        )
+        result = await fetch_session_list(limit=10, db_pool=sqlite_pool, user_id="alice")
+        assert [s.session_id for s in result.sessions] == ["s-alice"]
+        assert result.total == 1
+
+    @pytest.mark.asyncio
+    async def test_user_id_filter_sql_injection_safe(self, sqlite_pool: DatabasePool):
+        """Bobby Tables: a value containing SQL is bound as a parameter, not interpolated."""
+        await self._seed_user_session(
+            sqlite_pool, call_id="c1", session_id="s1", user_id="alice", created_at="2025-01-15T10:00:00"
+        )
+        # If user_id were interpolated this would either error, drop the table,
+        # or return all rows. Bound as a parameter it simply matches nothing.
+        result = await fetch_session_list(
+            limit=10, db_pool=sqlite_pool, user_id="alice'; DROP TABLE conversation_calls;--"
+        )
+        assert result.sessions == []
+        # And the table is still queryable.
+        all_rows = await fetch_session_list(limit=10, db_pool=sqlite_pool)
+        assert len(all_rows.sessions) == 1
+
+
 __all__ = []

--- a/tests/luthien_proxy/unit_tests/history/test_service_sqlite.py
+++ b/tests/luthien_proxy/unit_tests/history/test_service_sqlite.py
@@ -829,7 +829,7 @@ class TestFetchSessionListUserFilter:
         )
         result = await fetch_session_list(limit=10, db_pool=sqlite_pool)
         assert len(result.sessions) == 1
-        assert result.sessions[0].user_id == "alice"
+        assert result.sessions[0].user_ids == ["alice"]
 
     @pytest.mark.asyncio
     async def test_user_id_filter_returns_only_matching(self, sqlite_pool: DatabasePool):
@@ -842,6 +842,75 @@ class TestFetchSessionListUserFilter:
         result = await fetch_session_list(limit=10, db_pool=sqlite_pool, user_id="alice")
         assert [s.session_id for s in result.sessions] == ["s-alice"]
         assert result.total == 1
+
+    @pytest.mark.asyncio
+    async def test_mixed_user_session_surfaces_all_ids(self, sqlite_pool: DatabasePool):
+        """A session reused across users surfaces every distinct user_id, never collapses."""
+        await self._seed_user_session(
+            sqlite_pool, call_id="c-alice", session_id="shared", user_id="alice", created_at="2025-01-15T10:00:00"
+        )
+        await self._seed_user_session(
+            sqlite_pool, call_id="c-bob", session_id="shared", user_id="bob", created_at="2025-01-15T10:01:00"
+        )
+        result = await fetch_session_list(limit=10, db_pool=sqlite_pool)
+        assert len(result.sessions) == 1
+        assert sorted(result.sessions[0].user_ids) == ["alice", "bob"]
+
+    @pytest.mark.asyncio
+    async def test_user_filter_does_not_leak_other_user_preview(self, sqlite_pool: DatabasePool):
+        """preview_message under ?user_id=alice must not surface bob's content from a shared session."""
+        async with sqlite_pool.connection() as conn:
+            # Bob's call lands first in the same session; his preview would otherwise
+            # become the session's preview_message.
+            await conn.execute(
+                """
+                INSERT INTO conversation_calls
+                (call_id, model_name, provider, status, session_id, user_id, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                "c-bob",
+                "gpt-4",
+                "openai",
+                "completed",
+                "shared",
+                "bob",
+                "2025-01-15T10:00:00",
+            )
+            await conn.execute(
+                """
+                INSERT INTO conversation_events
+                (id, call_id, event_type, payload, session_id, user_id, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                "e-bob",
+                "c-bob",
+                "transaction.request_recorded",
+                json.dumps(
+                    {
+                        "final_model": "gpt-4-secret",
+                        "final_request": {"messages": [{"role": "user", "content": "BOBS PRIVATE MESSAGE"}]},
+                    }
+                ),
+                "shared",
+                "bob",
+                "2025-01-15T10:00:00",
+            )
+
+        await self._seed_user_session(
+            sqlite_pool,
+            call_id="c-alice",
+            session_id="shared",
+            user_id="alice",
+            created_at="2025-01-15T10:01:00",
+        )
+
+        # Filtered query must not surface bob's content.
+        filtered = await fetch_session_list(limit=10, db_pool=sqlite_pool, user_id="alice")
+        assert [s.session_id for s in filtered.sessions] == ["shared"]
+        summary = filtered.sessions[0]
+        assert summary.user_ids == ["alice"], "filter must scope user_ids to alice only"
+        assert summary.preview_message != "BOBS PRIVATE MESSAGE", "preview_message leaked content from a different user"
+        assert "gpt-4-secret" not in summary.models_used, "models_used leaked a model from a different user's call"
 
     @pytest.mark.asyncio
     async def test_user_id_filter_sql_injection_safe(self, sqlite_pool: DatabasePool):

--- a/tests/luthien_proxy/unit_tests/observability/test_emitter.py
+++ b/tests/luthien_proxy/unit_tests/observability/test_emitter.py
@@ -254,9 +254,9 @@ class TestEventEmitter:
 
         emitter = EventEmitter(db_pool=mock_pool, stdout_enabled=False)
 
-        before = EventEmitter.dropped_db_writes
+        before = emitter.dropped_db_writes
         await emitter.emit("tx-123", "test.event", {"key": "value"})
-        assert EventEmitter.dropped_db_writes == before + 1
+        assert emitter.dropped_db_writes == before + 1
 
     @pytest.mark.asyncio
     async def test_write_db_increments_dropped_counter_on_os_error(self) -> None:
@@ -273,9 +273,9 @@ class TestEventEmitter:
 
         emitter = EventEmitter(db_pool=mock_pool, stdout_enabled=False)
 
-        before = EventEmitter.dropped_db_writes
+        before = emitter.dropped_db_writes
         await emitter.emit("tx-123", "test.event", {"key": "value"})
-        assert EventEmitter.dropped_db_writes == before + 1
+        assert emitter.dropped_db_writes == before + 1
 
     @pytest.mark.asyncio
     async def test_write_db_does_not_catch_unrelated_exceptions(self) -> None:

--- a/tests/luthien_proxy/unit_tests/observability/test_emitter.py
+++ b/tests/luthien_proxy/unit_tests/observability/test_emitter.py
@@ -254,9 +254,9 @@ class TestEventEmitter:
 
         emitter = EventEmitter(db_pool=mock_pool, stdout_enabled=False)
 
-        before = emitter.dropped_db_writes
+        before = EventEmitter.dropped_db_writes
         await emitter.emit("tx-123", "test.event", {"key": "value"})
-        assert emitter.dropped_db_writes == before + 1
+        assert EventEmitter.dropped_db_writes == before + 1
 
     @pytest.mark.asyncio
     async def test_write_db_increments_dropped_counter_on_os_error(self) -> None:
@@ -273,9 +273,9 @@ class TestEventEmitter:
 
         emitter = EventEmitter(db_pool=mock_pool, stdout_enabled=False)
 
-        before = emitter.dropped_db_writes
+        before = EventEmitter.dropped_db_writes
         await emitter.emit("tx-123", "test.event", {"key": "value"})
-        assert emitter.dropped_db_writes == before + 1
+        assert EventEmitter.dropped_db_writes == before + 1
 
     @pytest.mark.asyncio
     async def test_write_db_does_not_catch_unrelated_exceptions(self) -> None:

--- a/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
@@ -173,7 +173,7 @@ class TestProcessRequest:
             mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
             mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
 
-            anthropic_request, raw_http_request, session_id = await _process_request(
+            anthropic_request, raw_http_request, session_id, _user_id = await _process_request(
                 request=mock_request,
                 call_id="test-call-id",
                 emitter=mock_emitter,
@@ -204,7 +204,7 @@ class TestProcessRequest:
             mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
             mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
 
-            _anthropic_request, _raw_http_request, session_id = await _process_request(
+            _anthropic_request, _raw_http_request, session_id, _user_id = await _process_request(
                 request=mock_request,
                 call_id="test-call-id",
                 emitter=mock_emitter,
@@ -226,7 +226,7 @@ class TestProcessRequest:
             mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
             mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
 
-            _anthropic_request, _raw_http_request, session_id = await _process_request(
+            _anthropic_request, _raw_http_request, session_id, _user_id = await _process_request(
                 request=mock_request,
                 call_id="test-call-id",
                 emitter=mock_emitter,
@@ -2021,6 +2021,7 @@ class TestAnthropicPolicyIOBuffering:
             emitter=MagicMock(),
             call_id="test-call",
             session_id=None,
+            user_id=None,
             request_log_recorder=MagicMock(),
             is_streaming=is_streaming,
         )

--- a/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
@@ -234,6 +234,64 @@ class TestProcessRequest:
 
         assert session_id == "oauth-session-abc123"
 
+    @staticmethod
+    def _make_jwt(sub: str) -> str:
+        import base64
+        import json
+
+        payload_bytes = json.dumps({"sub": sub}).encode()
+        payload = base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode()
+        return f"eyJhbGciOiJSUzI1NiJ9.{payload}.fakesig"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "headers,trust,expected",
+        [
+            # Header-only path: trusted header set, no Bearer.
+            ({"x-luthien-user-id": "alice"}, True, "alice"),
+            # JWT-only path: only the Bearer Authorization is set.
+            ({"authorization": "Bearer JWT_PLACEHOLDER"}, True, "bob"),
+            ({"authorization": "Bearer JWT_PLACEHOLDER"}, False, "bob"),
+            # Both present + header trusted: header WINS (load-bearing precedence).
+            ({"x-luthien-user-id": "alice", "authorization": "Bearer JWT_PLACEHOLDER"}, True, "alice"),
+            # Both present but header NOT trusted: header is ignored, JWT wins.
+            ({"x-luthien-user-id": "alice", "authorization": "Bearer JWT_PLACEHOLDER"}, False, "bob"),
+            # Header trusted but blank, JWT present: header drops to None, JWT wins.
+            ({"x-luthien-user-id": "", "authorization": "Bearer JWT_PLACEHOLDER"}, True, "bob"),
+            # Neither: None.
+            ({}, True, None),
+            ({}, False, None),
+        ],
+    )
+    async def test_user_id_extraction_precedence(self, mock_request, mock_emitter, mock_span, headers, trust, expected):
+        """Header (when trusted) wins over JWT sub. Untrusted header drops to JWT."""
+        if "authorization" in headers and headers["authorization"] == "Bearer JWT_PLACEHOLDER":
+            headers = {**headers, "authorization": f"Bearer {self._make_jwt('bob')}"}
+
+        anthropic_body = {
+            "model": DEFAULT_TEST_MODEL,
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 16,
+        }
+        mock_request.json = AsyncMock(return_value=anthropic_body)
+        mock_request.headers = headers
+
+        with (
+            patch("luthien_proxy.pipeline.anthropic_processor.tracer") as mock_tracer,
+            patch("luthien_proxy.pipeline.anthropic_processor.get_settings") as mock_get_settings,
+        ):
+            mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
+            mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
+            mock_get_settings.return_value.trust_user_id_header = trust
+
+            _request, _raw, _session, user_id = await _process_request(
+                request=mock_request,
+                call_id="test-call-id",
+                emitter=mock_emitter,
+            )
+
+        assert user_id == expected
+
     @pytest.mark.asyncio
     async def test_request_size_limit_exceeded(self, mock_request, mock_emitter, mock_span):
         """Test that oversized requests raise HTTPException."""

--- a/tests/luthien_proxy/unit_tests/pipeline/test_session.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_session.py
@@ -2,8 +2,11 @@
 
 from luthien_proxy.pipeline.session import (
     SESSION_ID_HEADER,
+    USER_ID_HEADER,
     extract_session_id_from_anthropic_body,
     extract_session_id_from_headers,
+    extract_user_id_from_bearer_token,
+    extract_user_id_from_headers,
 )
 
 
@@ -157,3 +160,167 @@ class TestExtractSessionIdFromHeaders:
     def test_header_name_constant(self):
         """Test the header name constant is correct."""
         assert SESSION_ID_HEADER == "x-session-id"
+
+
+class TestExtractUserIdFromHeaders:
+    """Tests for extract_user_id_from_headers function."""
+
+    def test_extracts_user_id_from_header(self):
+        """Test extraction from X-Luthien-User-Id header."""
+        headers = {
+            "content-type": "application/json",
+            USER_ID_HEADER: "alice@example.com",
+        }
+        user_id = extract_user_id_from_headers(headers, trust_header=True)
+        assert user_id == "alice@example.com"
+
+    def test_returns_none_when_header_missing(self):
+        """Test returns None when X-Luthien-User-Id header is missing."""
+        headers = {
+            "content-type": "application/json",
+            "authorization": "Bearer token",
+        }
+        user_id = extract_user_id_from_headers(headers, trust_header=True)
+        assert user_id is None
+
+    def test_returns_none_if_header_empty(self):
+        """Test returns None if header value is empty."""
+        headers = {USER_ID_HEADER: ""}
+        user_id = extract_user_id_from_headers(headers, trust_header=True)
+        assert user_id is None
+
+    def test_preserves_arbitrary_user_id_format(self):
+        """Test arbitrary user ID formats are preserved."""
+        for uid in ["user-123", "alice", "alice@corp.example.com", "sub:abc123"]:
+            headers = {USER_ID_HEADER: uid}
+            assert extract_user_id_from_headers(headers, trust_header=True) == uid
+
+    def test_header_name_constant(self):
+        """Test the header name constant is correct."""
+        assert USER_ID_HEADER == "x-luthien-user-id"
+
+    def test_returns_none_when_trust_header_false(self):
+        """Gating: returns None even when header is present if trust_header=False."""
+        headers = {USER_ID_HEADER: "alice@example.com"}
+        assert extract_user_id_from_headers(headers, trust_header=False) is None
+
+    def test_strips_control_characters(self):
+        """Sanitization: control characters are stripped from the value."""
+        headers = {USER_ID_HEADER: "alice\x00\x1f\x7f@example.com"}
+        result = extract_user_id_from_headers(headers, trust_header=True)
+        assert result == "alice@example.com"
+
+    def test_truncates_to_max_length(self):
+        """Sanitization: values longer than 256 chars are truncated."""
+        long_id = "a" * 300
+        headers = {USER_ID_HEADER: long_id}
+        result = extract_user_id_from_headers(headers, trust_header=True)
+        assert result == "a" * 256
+
+    def test_returns_none_if_only_control_chars(self):
+        """Sanitization: returns None if header contains only control characters."""
+        headers = {USER_ID_HEADER: "\x00\x1f\x7f"}
+        assert extract_user_id_from_headers(headers, trust_header=True) is None
+
+
+class TestExtractUserIdFromBearerToken:
+    """Tests for extract_user_id_from_bearer_token function."""
+
+    def test_extracts_sub_from_valid_jwt(self):
+        """Test extraction of sub claim from a valid JWT."""
+        import base64
+        import json
+
+        # Build a minimal JWT: header.payload.signature (signature not verified)
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256", "typ": "JWT"}).encode()).rstrip(b"=").decode()
+        payload = (
+            base64.urlsafe_b64encode(json.dumps({"sub": "user-abc-123", "email": "alice@example.com"}).encode())
+            .rstrip(b"=")
+            .decode()
+        )
+        token = f"{header}.{payload}.fakesignature"
+
+        user_id = extract_user_id_from_bearer_token(token)
+        assert user_id == "user-abc-123"
+
+    def test_returns_none_when_no_sub_claim(self):
+        """Test returns None when JWT has no sub claim."""
+        import base64
+        import json
+
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).rstrip(b"=").decode()
+        payload = base64.urlsafe_b64encode(json.dumps({"email": "alice@example.com"}).encode()).rstrip(b"=").decode()
+        token = f"{header}.{payload}.fakesig"
+
+        user_id = extract_user_id_from_bearer_token(token)
+        assert user_id is None
+
+    def test_returns_none_for_non_jwt_token(self):
+        """Test returns None for opaque (non-JWT) tokens."""
+        user_id = extract_user_id_from_bearer_token("sk-ant-api03-someapikey")
+        assert user_id is None
+
+    def test_returns_none_for_empty_token(self):
+        """Test returns None for empty token string."""
+        user_id = extract_user_id_from_bearer_token("")
+        assert user_id is None
+
+    def test_returns_none_for_malformed_jwt_payload(self):
+        """Test returns None when JWT payload is not valid base64 JSON."""
+        token = "header.notvalidbase64!!.signature"
+        user_id = extract_user_id_from_bearer_token(token)
+        assert user_id is None
+
+    def test_returns_none_when_sub_is_not_string(self):
+        """Test returns None when sub claim is not a string."""
+        import base64
+        import json
+
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).rstrip(b"=").decode()
+        payload = base64.urlsafe_b64encode(json.dumps({"sub": 12345}).encode()).rstrip(b"=").decode()
+        token = f"{header}.{payload}.fakesig"
+
+        user_id = extract_user_id_from_bearer_token(token)
+        assert user_id is None
+
+    def test_returns_none_for_none_token(self):
+        """Test returns None when token is None."""
+        user_id = extract_user_id_from_bearer_token(None)
+        assert user_id is None
+
+    def test_handles_jwt_without_padding(self):
+        """Test handles JWT base64 without padding (standard JWT format)."""
+        import base64
+        import json
+
+        # JWT payloads often lack = padding
+        payload_data = {"sub": "user-xyz", "iss": "https://auth.example.com"}
+        payload_bytes = json.dumps(payload_data).encode()
+        # Deliberately strip padding as real JWTs do
+        payload = base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode()
+        token = f"eyJhbGciOiJSUzI1NiJ9.{payload}.fakesig"
+
+        user_id = extract_user_id_from_bearer_token(token)
+        assert user_id == "user-xyz"
+
+    def _make_jwt(self, sub: str) -> str:
+        import base64
+        import json
+
+        payload_bytes = json.dumps({"sub": sub}).encode()
+        payload = base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode()
+        return f"eyJhbGciOiJSUzI1NiJ9.{payload}.fakesig"
+
+    def test_strips_control_characters_from_sub(self):
+        token = self._make_jwt("user\r\nX-Injected: evil")
+        assert extract_user_id_from_bearer_token(token) == "userX-Injected: evil"
+
+    def test_truncates_sub_to_max_length(self):
+        token = self._make_jwt("a" * 300)
+        result = extract_user_id_from_bearer_token(token)
+        assert result is not None
+        assert len(result) == 256
+
+    def test_returns_none_for_sub_of_only_control_chars(self):
+        token = self._make_jwt("\x00\x01\x1f\x7f")
+        assert extract_user_id_from_bearer_token(token) is None

--- a/tests/luthien_proxy/unit_tests/pipeline/test_session.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_session.py
@@ -5,6 +5,7 @@ from luthien_proxy.pipeline.session import (
     USER_ID_HEADER,
     extract_session_id_from_anthropic_body,
     extract_session_id_from_headers,
+    extract_user_id_from_authorization_header,
     extract_user_id_from_bearer_token,
     extract_user_id_from_headers,
 )
@@ -324,3 +325,58 @@ class TestExtractUserIdFromBearerToken:
     def test_returns_none_for_sub_of_only_control_chars(self):
         token = self._make_jwt("\x00\x01\x1f\x7f")
         assert extract_user_id_from_bearer_token(token) is None
+
+
+class TestExtractUserIdFromAuthorizationHeader:
+    """Tests for the Authorization-header convenience wrapper."""
+
+    @staticmethod
+    def _make_jwt(sub: str) -> str:
+        import base64
+        import json
+
+        payload_bytes = json.dumps({"sub": sub}).encode()
+        payload = base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode()
+        return f"eyJhbGciOiJSUzI1NiJ9.{payload}.fakesig"
+
+    def test_returns_none_for_none_header(self):
+        assert extract_user_id_from_authorization_header(None) is None
+
+    def test_returns_none_for_empty_header(self):
+        assert extract_user_id_from_authorization_header("") is None
+
+    def test_extracts_with_canonical_bearer_prefix(self):
+        assert extract_user_id_from_authorization_header(f"Bearer {self._make_jwt('alice')}") == "alice"
+
+    def test_case_insensitive_scheme_match(self):
+        # RFC 7235 says auth-scheme is case-insensitive.
+        assert extract_user_id_from_authorization_header(f"bearer {self._make_jwt('alice')}") == "alice"
+        assert extract_user_id_from_authorization_header(f"BEARER {self._make_jwt('alice')}") == "alice"
+
+    def test_returns_none_for_basic_auth(self):
+        # Don't try to decode credentials from non-Bearer schemes.
+        assert extract_user_id_from_authorization_header("Basic dXNlcjpwYXNz") is None
+
+    def test_returns_none_for_bearer_with_no_token(self):
+        assert extract_user_id_from_authorization_header("Bearer ") is None
+        assert extract_user_id_from_authorization_header("Bearer    ") is None
+
+    def test_strips_surrounding_whitespace_from_token(self):
+        assert extract_user_id_from_authorization_header(f"Bearer  {self._make_jwt('alice')}  ") == "alice"
+
+    def test_returns_none_for_opaque_anthropic_api_key(self):
+        # `Authorization: Bearer sk-ant-...` is malformed as a JWT — should not raise.
+        assert extract_user_id_from_authorization_header("Bearer sk-ant-api01-abcdef") is None
+
+
+class TestExtractUserIdHeaderEdgeCases:
+    """Edge cases pinned for regressions."""
+
+    def test_whitespace_only_header_returns_none(self):
+        # `_sanitize_user_id` strips whitespace; a header containing only spaces
+        # must reduce to None rather than the empty string.
+        assert extract_user_id_from_headers({USER_ID_HEADER: "   \t  "}, trust_header=True) is None
+
+    def test_header_ignored_when_trust_disabled(self):
+        # Even a valid value is dropped when TRUST_USER_ID_HEADER=false.
+        assert extract_user_id_from_headers({USER_ID_HEADER: "alice"}, trust_header=False) is None


### PR DESCRIPTION
## Summary

Closes #554. Commandeers @sjawhar's [PR #577](https://github.com/LuthienResearch/luthien-proxy/pull/577) onto a branch we control, plus the in-scope follow-on hardening work that landed in the abandoned tracking PR #595.

The proxy now records a `user_id` (or list of `user_ids` for sessions reused across users) against each conversation call so operators can attribute traffic to individual users via `GET /api/history/sessions?user_id=...`. The history UI itself does not render `user_ids` yet — that is a follow-up.

## What's in scope

- `X-Luthien-User-Id` request header — gated behind `TRUST_USER_ID_HEADER` (default **off**; intended for use behind an authenticated reverse proxy).
- Bearer JWT `sub` claim, decoded **without signature verification**. This is user-asserted attribution, never authentication.
- `_sanitize_user_id` helper applied to both sources: strip C0/DEL control chars (Unicode `Cf`/`Cc` not yet stripped — see Out-of-scope), truncate to 256 chars, bail on Authorization tokens > 8 KB.
- Precedence (load-bearing, pinned by parametrized test): trusted header wins over JWT sub when both are set; untrusted header drops to JWT.
- New `user_id` columns on `conversation_calls` and `conversation_events` (migration 018; renumbered from the abandoned bundle's 014, which collides on main).
- `SessionSummary.user_ids: list[str]` always populated from the joined `conversation_calls`. Multi-element when a session is reused across users — never collapsed via MIN/MAX.
- `?user_id=...` filter on `GET /api/history/sessions` — bound as a query parameter (SQL-injection regression test included). The filter scopes every content surface (preview_message, models_used, user_ids) to the requested user; cross-user leak regression test included.

## Provenance

- Original PR: https://github.com/LuthienResearch/luthien-proxy/pull/577 (Sami Jawhar)
- Tracker PR: https://github.com/LuthienResearch/luthien-proxy/pull/595 (Paolo Calvi — kept open as a draft board)
- Notable follow-ups folded in (originally in #595):
  - 1864a9c — TRUST_USER_ID_HEADER gate
  - b2cd58a — JWT sub sanitization
  - a9a1a84 — extracted _sanitize_user_id, narrowed JWT decode exception clause
  - 4902e37 — JWT user_id documented as user-asserted (F5)
  - caa9876, 1ac16e0, 3256dad — history filter on user_id column + always populate
  - a35a860 — SQL injection regression test
  - Misc session.py hardening: 2e42e00, c0a412b, 086e5a0, 120fb8b
- Adversarial-review fixes in commit 6604d01 (cross-user leakage in CTEs, MIN→array_agg, first-event NULL).

## Out of scope (deliberately excluded)

- The rest of #595's bundle (webhook export, retention, session search FTS, role-based auth, upstream-headers, OTEL endpoint defaults, StringReplacementPolicy work). Those land — or have already landed — as their own PRs per One PR = One Concern.
- History UI rendering of `user_ids` and a `?user_id=` filter input — follow-up.
- Unicode `Cf`/`Cc` stripping in `_sanitize_user_id` — follow-up; matters only when the UI lands. Logs are unaffected (CR/LF already stripped).
- `request_log` table user_id plumbing — separate audit subsystem, follow-up.

## Test plan

- [x] scripts/dev_checks.sh (ruff, pyright, full unit suite — 2355 passing)
- [x] MOCK_ANTHROPIC_PORT=18889 scripts/run_e2e.sh sqlite (47 e2e tests passing)
- [x] CI green
- [x] /devil review for adversarial sweep (3 findings fixed in 6604d01)
- [x] /pr-watch active

🤖 Generated with [Claude Code](https://claude.com/claude-code)