### PR TITLE
test(e2e): remove tests that send sk-ant- API keys as Authorization: Bearer

### DIFF
--- a/changelog.d/e2e-remove-oauth-direct-tests.md
+++ b/changelog.d/e2e-remove-oauth-direct-tests.md
@@ -1,0 +1,6 @@
+---
+category: Chores & Docs
+pr: 747
+---
+
+**Remove e2e tests that misuse Bearer auth with API keys**: Deleted three passthrough-auth tests and one streaming-chunk test that sent `Authorization: Bearer <sk-ant-...>`. Anthropic only accepts API keys via `x-api-key`; Bearer is reserved for OAuth, whose automated use Anthropic forbids. Replaced the broken probe fixture with `gateway_passthrough_mode`, which reads `auth_mode` from the admin API. The buffered tool-call streaming behavior remains covered by `mock_e2e` tests.

--- a/tests/luthien_proxy/e2e_tests/test_anthropic_passthrough_auth.py
+++ b/tests/luthien_proxy/e2e_tests/test_anthropic_passthrough_auth.py
@@ -1,25 +1,24 @@
 """E2E tests for Anthropic passthrough authentication.
 
-Tests the passthrough authentication feature in three modes:
+Covers two passthrough paths:
 
 1. **x-anthropic-api-key header** (works in any auth_mode):
-   Client passes their Anthropic key via x-anthropic-api-key header while
-   authenticating to the proxy with CLIENT_API_KEY via Authorization header.
+   Client authenticates to the proxy with CLIENT_API_KEY via Authorization,
+   and forwards an Anthropic API key for upstream calls via x-anthropic-api-key.
 
-2. **Auth mode passthrough** (requires AUTH_MODE=both or AUTH_MODE=passthrough):
-   Client authenticates directly with their Anthropic key as the Bearer token.
-   The proxy validates it via the free count_tokens endpoint and uses it for
-   upstream API calls.
+2. **OAuth passthrough via Claude Code** (requires AUTH_MODE=both or passthrough):
+   Claude Code uses its OAuth credentials as the Bearer token. The proxy
+   validates them and uses them for upstream Anthropic calls.
 
-3. **OAuth passthrough via Claude Code** (requires AUTH_MODE=both):
-   Claude Code uses its OAuth credentials to authenticate through the proxy
-   without ANTHROPIC_API_KEY being set. The proxy validates the OAuth token
-   and uses it for upstream Anthropic calls.
+Direct API-key-as-Bearer tests are deliberately *not* covered here: Anthropic
+only accepts API keys via x-api-key, and Bearer tokens are reserved for OAuth
+credentials whose automated use Anthropic forbids. The OAuth path is therefore
+exercised only via Claude Code, never via raw HTTP calls from this suite.
 
 Prerequisites:
 - Gateway must be running (docker compose up)
 - ANTHROPIC_API_KEY env var for header passthrough tests
-- AUTH_MODE=both for passthrough mode and OAuth tests
+- AUTH_MODE=both (or passthrough) on the gateway for the Claude Code OAuth test
 - Claude CLI installed + logged in via OAuth for Claude Code tests
 """
 
@@ -62,11 +61,17 @@ async def gateway_passthrough_mode(http_client, gateway_healthy, gateway_url, ad
         f"{gateway_url}/api/admin/auth/config",
         headers={"Authorization": f"Bearer {admin_api_key}"},
     )
-    if response.status_code != 200:
-        pytest.skip(f"Could not read auth config from admin API: {response.status_code}")
+    # Surface server-side regressions; only treat genuine auth/availability
+    # responses as skip-worthy prereq misses.
+    if response.status_code >= 500:
+        response.raise_for_status()
+    if response.status_code in (401, 403, 404):
+        pytest.skip(f"Admin auth config not accessible: HTTP {response.status_code}")
+    assert response.status_code == 200, f"Unexpected status reading admin auth config: {response.status_code}"
     mode = response.json().get("auth_mode")
     if mode not in ("both", "passthrough"):
         pytest.skip(f"Gateway auth_mode={mode!r}; passthrough tests require 'both' or 'passthrough'")
+    yield
 
 
 # === x-anthropic-api-key header passthrough (works in any auth_mode) ===

--- a/tests/luthien_proxy/e2e_tests/test_anthropic_passthrough_auth.py
+++ b/tests/luthien_proxy/e2e_tests/test_anthropic_passthrough_auth.py
@@ -50,28 +50,23 @@ def anthropic_key():
 
 
 @pytest.fixture
-async def passthrough_mode(http_client, gateway_healthy, gateway_url, api_key):
-    """Verify gateway supports passthrough auth mode.
+async def gateway_passthrough_mode(http_client, gateway_healthy, gateway_url, admin_api_key):
+    """Confirm the gateway is in an auth_mode that accepts passthrough (both or passthrough).
 
-    Sends a real Anthropic key as the Bearer token (not via x-anthropic-api-key).
-    This only succeeds when AUTH_MODE is 'both' or 'passthrough'.
+    Reads auth_config from the admin API instead of probing /v1/messages with a
+    bearer token — Anthropic forbids automated use of OAuth credentials, so we
+    must not exercise OAuth via direct API tests. Tests that need a real bearer
+    flow run Claude Code instead (see ``test_claude_code_oauth_passthrough``).
     """
-    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not anthropic_key:
-        pytest.skip("ANTHROPIC_API_KEY not set (needed for passthrough mode tests)")
-
-    response = await http_client.post(
-        f"{gateway_url}/v1/messages",
-        json={
-            "model": ANTHROPIC_MODEL,
-            "messages": [{"role": "user", "content": "hi"}],
-            "max_tokens": 5,
-        },
-        headers={"Authorization": f"Bearer {anthropic_key}"},
+    response = await http_client.get(
+        f"{gateway_url}/api/admin/auth/config",
+        headers={"Authorization": f"Bearer {admin_api_key}"},
     )
-    if response.status_code == 401:
-        pytest.skip("Gateway not in passthrough/both auth mode (set AUTH_MODE=both to enable these tests)")
-    return anthropic_key
+    if response.status_code != 200:
+        pytest.skip(f"Could not read auth config from admin API: {response.status_code}")
+    mode = response.json().get("auth_mode")
+    if mode not in ("both", "passthrough"):
+        pytest.skip(f"Gateway auth_mode={mode!r}; passthrough tests require 'both' or 'passthrough'")
 
 
 # === x-anthropic-api-key header passthrough (works in any auth_mode) ===
@@ -216,78 +211,12 @@ async def test_proxy_auth_still_required_with_client_key(gateway_healthy, http_c
     assert response.status_code == 401
 
 
-# === Passthrough auth mode (requires AUTH_MODE=both or AUTH_MODE=passthrough) ===
-
-
-@pytest.mark.e2e
-@pytest.mark.asyncio
-async def test_passthrough_mode_direct_auth(http_client, passthrough_mode, gateway_url):
-    """In passthrough/both mode, client's Anthropic key works as the Bearer token."""
-    response = await http_client.post(
-        f"{gateway_url}/v1/messages",
-        json={
-            "model": ANTHROPIC_MODEL,
-            "messages": [{"role": "user", "content": "Say 'hello'"}],
-            "max_tokens": 10,
-        },
-        headers={"Authorization": f"Bearer {passthrough_mode}"},
-    )
-
-    assert response.status_code == 200
-    data = response.json()
-    assert data["type"] == "message"
-    assert len(data["content"]) > 0
-
-
-@pytest.mark.e2e
-@pytest.mark.asyncio
-async def test_passthrough_mode_invalid_key_rejected(http_client, passthrough_mode, gateway_url):
-    """In passthrough/both mode, invalid Anthropic key is rejected."""
-    response = await http_client.post(
-        f"{gateway_url}/v1/messages",
-        json={
-            "model": ANTHROPIC_MODEL,
-            "messages": [{"role": "user", "content": "Say 'hello'"}],
-            "max_tokens": 10,
-        },
-        headers={"Authorization": "Bearer sk-ant-invalid-key-00000"},
-    )
-
-    assert response.status_code == 401
-
-
-@pytest.mark.e2e
-@pytest.mark.asyncio
-async def test_passthrough_mode_streaming(passthrough_mode, gateway_url):
-    """In passthrough/both mode, streaming works with client's key as Bearer token."""
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        async with client.stream(
-            "POST",
-            f"{gateway_url}/v1/messages",
-            json={
-                "model": ANTHROPIC_MODEL,
-                "messages": [{"role": "user", "content": "Say 'hello'"}],
-                "max_tokens": 10,
-                "stream": True,
-            },
-            headers={"Authorization": f"Bearer {passthrough_mode}"},
-        ) as response:
-            assert response.status_code == 200
-
-            raw_events = []
-            async for line in response.aiter_lines():
-                if line.startswith("data: "):
-                    raw_events.append(line[6:])
-
-    assert len(raw_events) > 0
-    event_types = []
-    for raw in raw_events:
-        try:
-            event_types.append(json.loads(raw).get("type"))
-        except json.JSONDecodeError:
-            continue
-    assert "message_start" in event_types
-    assert "message_stop" in event_types
+# === Passthrough auth mode ===
+#
+# Note: Bearer-token passthrough only legitimately exercises OAuth credentials
+# (sk-ant- API keys must use x-api-key per Anthropic's API). Anthropic forbids
+# automated use of OAuth tokens, so OAuth flows are tested through Claude Code
+# below — never by direct API calls from this suite.
 
 
 # === OAuth passthrough via Claude Code ===
@@ -362,7 +291,7 @@ async def run_claude_code_oauth(
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_claude_code_oauth_passthrough(claude_available, passthrough_mode, gateway_url):
+async def test_claude_code_oauth_passthrough(claude_available, gateway_passthrough_mode, gateway_url):
     """Claude Code authenticates through the proxy using OAuth credentials.
 
     Requires:

--- a/tests/luthien_proxy/e2e_tests/test_streaming_chunk_structure.py
+++ b/tests/luthien_proxy/e2e_tests/test_streaming_chunk_structure.py
@@ -340,46 +340,6 @@ async def test_anthropic_streaming_sse_format_compliance(http_client):
 # === Tool Call Tests ===
 
 
-@pytest.fixture(scope="module")
-async def tool_call_judge_policy_active():
-    """Ensure ToolCallJudgePolicy is active for testing buffered tool call emission.
-
-    This policy buffers tool calls and re-emits them using create_tool_call_chunk,
-    which tests the policy-generated streaming format (not passthrough from LiteLLM).
-    """
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        admin_headers = {"Authorization": f"Bearer {ADMIN_API_KEY}"}
-
-        # Set ToolCallJudgePolicy using the /api/admin/policy/set endpoint
-        set_response = await client.post(
-            f"{GATEWAY_URL}/api/admin/policy/set",
-            headers=admin_headers,
-            json={
-                "policy_class_ref": "luthien_proxy.policies.tool_call_judge_policy:ToolCallJudgePolicy",
-                "config": {
-                    "model": DEFAULT_TEST_MODEL,
-                    "probability_threshold": 0.99,  # High threshold = allow most tool calls
-                    "temperature": 0.0,
-                    "max_tokens": 256,
-                    "auth_provider": "user_credentials",
-                },
-                "enabled_by": "e2e-streaming-tests",
-            },
-        )
-
-        if set_response.status_code != 200:
-            raise RuntimeError(f"Failed to set ToolCallJudgePolicy: {set_response.text}")
-
-        result = set_response.json()
-        if not result.get("success"):
-            raise RuntimeError(f"Failed to set ToolCallJudgePolicy: {result.get('error')}")
-
-        # Give the policy a moment to activate
-        await asyncio.sleep(0.1)
-
-        yield "ToolCallJudgePolicy"
-
-
 @pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_anthropic_streaming_tool_use_structure(http_client, noop_policy_active):
@@ -499,111 +459,12 @@ async def test_anthropic_streaming_tool_use_structure(http_client, noop_policy_a
         )
 
 
-@pytest.mark.e2e
-@pytest.mark.asyncio
-async def test_anthropic_buffered_tool_call_emits_message_delta(http_client, tool_call_judge_policy_active):
-    """Test that policy-buffered tool calls emit proper message_delta with stop_reason.
-
-    ToolCallJudgePolicy buffers tool_use events, judges the complete call, then
-    re-emits the full event sequence (start, delta, stop) if allowed.
-    Uses the real Anthropic API key for ToolCallJudgePolicy evaluation.
-    """
-    anthropic_key = os.getenv("ANTHROPIC_API_KEY", "")
-    if not anthropic_key:
-        pytest.skip("ANTHROPIC_API_KEY required for ToolCallJudgePolicy tests")
-
-    async with http_client.stream(
-        "POST",
-        f"{GATEWAY_URL}/v1/messages",
-        json={
-            "model": DEFAULT_TEST_MODEL,
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "Call the get_weather tool with location set to 'San Francisco'. Do not respond with text, only use the tool.",
-                }
-            ],
-            "tools": [
-                {
-                    "name": "get_weather",
-                    "description": "Get current weather for a location",
-                    "input_schema": {
-                        "type": "object",
-                        "properties": {
-                            "location": {"type": "string", "description": "City name"},
-                        },
-                        "required": ["location"],
-                    },
-                }
-            ],
-            "tool_choice": {"type": "tool", "name": "get_weather"},
-            "max_tokens": 150,
-            "stream": True,
-        },
-        headers={"Authorization": f"Bearer {anthropic_key}"},
-    ) as response:
-        assert response.status_code == 200
-
-        lines = []
-        async for line in response.aiter_lines():
-            lines.append(line)
-
-        events = parse_anthropic_sse_stream(lines)
-        assert len(events) > 0, "Should have events"
-
-        event_types = [event_type for event_type, _ in events]
-
-        # Should have standard message lifecycle
-        assert event_types[0] == "message_start", "Must start with message_start"
-        assert event_types[-1] == "message_stop", "Must end with message_stop"
-
-        # Find tool_use content_block_start
-        tool_start_events = [
-            (event_type, data)
-            for event_type, data in events
-            if event_type == "content_block_start" and data.get("content_block", {}).get("type") == "tool_use"
-        ]
-
-        assert len(tool_start_events) >= 1, "Should have at least one tool_use content_block_start"
-
-        # Validate tool call structure
-        event_type, tool_start = tool_start_events[0]
-        content_block = tool_start["content_block"]
-        assert content_block["type"] == "tool_use"
-        assert "id" in content_block, "Tool use must have id"
-        assert "name" in content_block, "Tool use must have name"
-        assert content_block["name"] == "get_weather"
-
-        # Find input_json_delta events
-        tool_delta_events = [
-            (event_type, data)
-            for event_type, data in events
-            if event_type == "content_block_delta" and data.get("delta", {}).get("type") == "input_json_delta"
-        ]
-
-        assert len(tool_delta_events) > 0, "Should have input_json_delta events"
-
-        # Accumulate and validate JSON
-        all_json = "".join(data["delta"]["partial_json"] for event_type, data in tool_delta_events)
-        assert len(all_json) > 0, "Tool input JSON must not be empty"
-        tool_input = json.loads(all_json)
-        assert "location" in tool_input, "Tool input must have location parameter"
-
-        # CRITICAL: Find message_delta with stop_reason=tool_use
-        # This is the specific bug we fixed - without this, Claude Code doesn't recognize the tool call
-        message_delta_events = [(event_type, data) for event_type, data in events if event_type == "message_delta"]
-
-        assert len(message_delta_events) >= 1, (
-            "Must have message_delta event - this was the bug! "
-            "Policy-buffered tool calls were not emitting message_delta with stop_reason"
-        )
-
-        # Validate the message_delta has proper stop_reason
-        last_message_delta = message_delta_events[-1][1]
-        assert "delta" in last_message_delta, "message_delta must have delta field"
-        assert "stop_reason" in last_message_delta["delta"], (
-            "message_delta must have stop_reason - clients like Claude Code require this"
-        )
-        assert last_message_delta["delta"]["stop_reason"] == "tool_use", (
-            f"stop_reason must be 'tool_use', got: {last_message_delta['delta'].get('stop_reason')}"
-        )
+# Removed: test_anthropic_buffered_tool_call_emits_message_delta.
+#
+# The previous version sent `Authorization: Bearer $ANTHROPIC_API_KEY` so the
+# ToolCallJudgePolicy (configured with auth_provider=user_credentials) could
+# pull the user's credential for its judge LLM call. Anthropic only accepts
+# API keys via x-api-key — Bearer-token auth means OAuth, and Anthropic
+# forbids automated use of OAuth credentials. The same buffered-tool-call
+# behavior is exercised deterministically by mock_e2e tests in
+# tests/luthien_proxy/e2e_tests/test_mock_*.py without hitting Anthropic.


### PR DESCRIPTION
## Summary

Anthropic only accepts API keys via `x-api-key`. `Authorization: Bearer` is reserved for OAuth credentials — and Anthropic forbids automated/programmatic use of OAuth (those credentials belong to Claude Code and similar Anthropic products). Several e2e tests sent the user's `sk-ant-` key as `Authorization: Bearer`, which means they either:
- skipped because Anthropic rejected the bearer (the visible symptom), or
- would have violated Anthropic's terms if OAuth credentials had been substituted to make them pass.

This PR deletes those tests and refactors the lone surviving bearer-passthrough test (`test_claude_code_oauth_passthrough`) so it asserts its prereq the right way.

**Removed**
- `test_passthrough_mode_direct_auth`
- `test_passthrough_mode_invalid_key_rejected`
- `test_passthrough_mode_streaming`
- `test_anthropic_buffered_tool_call_emits_message_delta` (in `test_streaming_chunk_structure.py`)
- The now-orphan `tool_call_judge_policy_active` fixture

**Refactored**
- Replaced the `passthrough_mode` probe fixture (which sent the user's `sk-ant-` key as Bearer to `/v1/messages` and skipped on 401) with `gateway_passthrough_mode`, which reads the gateway's `auth_mode` from the admin API. The surviving `test_claude_code_oauth_passthrough` uses Claude Code (correct shape — Anthropic permits OAuth via the official client) and now depends on the new fixture.

The deleted streaming-chunk test's intent (policy-buffered tool-call emission shape) is covered deterministically by `mock_e2e` tests in `test_mock_*.py`.

## Test plan

- [x] `./scripts/run_e2e.sh --fresh` — all three tiers green, no flaky skips related to OAuth handling
- [x] `./scripts/dev_checks.sh` clean

---
*Posted by Claude Code (claude-opus-4-7[1m])*