### PR TITLE
chore: set objective — tool-call buffer abstraction (supersedes #728)

### DIFF
--- a/changelog.d/tool-call-buffer.md
+++ b/changelog.d/tool-call-buffer.md
@@ -1,0 +1,6 @@
+---
+category: Refactors
+pr: 748
+---
+
+**Extract `ToolCallStreamBuffer`**: policy-agnostic Anthropic streaming filter parameterized by a caller-supplied async transform closure. `DogfoodSafetyPolicy` and `ToolCallJudgePolicy` now define only a transform closure; per-request state, output indices, and `stop_reason` invariants are owned by the buffer. Replaces #728's per-event-helper extraction (which dropped the `message_delta` `stop_reason` rewrite). Tool-call decisions now run at `message_delta` with the full list of buffered tool calls, instead of per-block at `content_block_stop`.

--- a/src/luthien_proxy/policies/dogfood_safety_policy.py
+++ b/src/luthien_proxy/policies/dogfood_safety_policy.py
@@ -33,6 +33,7 @@ from luthien_proxy.policy_core import (
     CatalogBadge,
     Category,
     ToolCallStreamBuffer,
+    ToolCallTransform,
     UIMetadata,
     transform_anthropic_response,
 )
@@ -156,7 +157,7 @@ class DogfoodSafetyPolicy(BasePolicy, AnthropicHookPolicy):
         """Render blocked-message template with truncated command."""
         return self.config.blocked_message.format(command=command[:200], pattern="regex")
 
-    def _make_transform(self, context: "PolicyContext"):
+    def _make_transform(self, context: "PolicyContext") -> ToolCallTransform:
         """Build a transform closure that captures `context` for event-recording."""
 
         async def transform(tool_calls: list[BufferedToolCall]) -> list["AnthropicContentBlock"]:

--- a/src/luthien_proxy/policies/dogfood_safety_policy.py
+++ b/src/luthien_proxy/policies/dogfood_safety_policy.py
@@ -21,28 +21,20 @@ from __future__ import annotations
 import json
 import logging
 import re
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
 from anthropic.lib.streaming import MessageStreamEvent
-from anthropic.types import (
-    InputJSONDelta,
-    RawContentBlockDeltaEvent,
-    RawContentBlockStartEvent,
-    RawContentBlockStopEvent,
-    RawMessageDeltaEvent,
-    TextBlock,
-    TextDelta,
-    ToolUseBlock,
-)
 from pydantic import BaseModel, Field
 
 from luthien_proxy.policy_core import (
     AnthropicHookPolicy,
     BasePolicy,
+    BufferedToolCall,
     CatalogBadge,
     Category,
+    ToolCallStreamBuffer,
     UIMetadata,
+    transform_anthropic_response,
 )
 
 if TYPE_CHECKING:
@@ -71,20 +63,6 @@ DEFAULT_DANGEROUS_PATTERNS = [
 ]
 
 DEFAULT_TOOL_NAMES = ["Bash", "bash", "shell", "terminal", "execute", "run_command"]
-
-
-@dataclass
-class _BufferedAnthropicToolUse:
-    id: str
-    name: str
-    input_json: str = ""
-
-
-@dataclass
-class _DogfoodAnthropicState:
-    buffered_tool_uses: dict[int, _BufferedAnthropicToolUse] = field(default_factory=dict)
-    blocked_blocks: set[int] = field(default_factory=set)
-    had_allowed_tool_use: bool = False
 
 
 class DogfoodSafetyConfig(BaseModel):
@@ -116,8 +94,7 @@ class DogfoodSafetyPolicy(BasePolicy, AnthropicHookPolicy):
     """
 
     # NOTE: ui_policy_preview is a UI hint only. The actual runtime block message
-    # is templated with dynamic data (the specific command being blocked) — see
-    # the f-string at line ~183 of this file. The preview here is approximate.
+    # is templated with dynamic data (the specific command being blocked).
     ui = UIMetadata(
         display_name="Dogfood Safety",
         short_description="Blocks self-destructive commands during internal dogfooding.",
@@ -142,26 +119,6 @@ class DogfoodSafetyPolicy(BasePolicy, AnthropicHookPolicy):
             f"{len(self._compiled_patterns)} patterns, "
             f"tool_names={self.config.tool_names}"
         )
-
-    def _anthropic_state(self, context: "PolicyContext") -> _DogfoodAnthropicState:
-        """Get or create request-scoped Anthropic streaming state."""
-        return context.get_request_state(self, _DogfoodAnthropicState, _DogfoodAnthropicState)
-
-    def _anthropic_blocked_blocks(self, context: "PolicyContext") -> set[int]:
-        """Indices of tool_use blocks that were substituted with text in the streaming path.
-
-        Streaming-only: the non-streaming `on_anthropic_response` derives the same
-        information from the rewritten content list directly.
-        """
-        return self._anthropic_state(context).blocked_blocks
-
-    def _anthropic_buffered_tool_uses(self, context: "PolicyContext") -> dict[int, _BufferedAnthropicToolUse]:
-        """Get request-scoped Anthropic tool_use buffers."""
-        return self._anthropic_state(context).buffered_tool_uses
-
-    # ========================================================================
-    # Core matching logic
-    # ========================================================================
 
     def _is_dangerous(self, tool_name: str, tool_input: "JSONObject | str") -> tuple[bool, str]:
         """Check if a tool call contains a dangerous command.
@@ -199,161 +156,51 @@ class DogfoodSafetyPolicy(BasePolicy, AnthropicHookPolicy):
         """Render blocked-message template with truncated command."""
         return self.config.blocked_message.format(command=command[:200], pattern="regex")
 
-    # ========================================================================
-    # Anthropic hooks (via AnthropicHookPolicy)
-    # ========================================================================
+    def _make_transform(self, context: "PolicyContext"):
+        """Build a transform closure that captures `context` for event-recording."""
+
+        async def transform(tool_calls: list[BufferedToolCall]) -> list["AnthropicContentBlock"]:
+            output: list[AnthropicContentBlock] = []
+            for tc in tool_calls:
+                is_blocked, command = self._is_dangerous(tc.name, tc.input)
+                if is_blocked:
+                    context.record_event(
+                        "policy.dogfood_safety.blocked",
+                        {"tool_name": tc.name, "command": command[:200]},
+                    )
+                    logger.warning(f"Blocked dangerous Anthropic tool_use: {command[:100]}")
+                    output.append(
+                        cast(
+                            "AnthropicContentBlock",
+                            {"type": "text", "text": self._format_blocked_message(command)},
+                        )
+                    )
+                else:
+                    output.append(tc.as_content_block())
+            return output
+
+        return transform
 
     async def on_anthropic_response(
         self, response: "AnthropicResponse", context: "PolicyContext"
     ) -> "AnthropicResponse":
         """Check non-streaming Anthropic tool_use blocks."""
-        content = response.get("content", [])
-        if not content:
-            return response
-
-        new_content: list[AnthropicContentBlock] = []
-        modified = False
-
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "tool_use":
-                name = str(block.get("name", ""))
-                input_data = block.get("input", {})
-                is_blocked, command = self._is_dangerous(name, input_data)
-
-                if is_blocked:
-                    msg = self._format_blocked_message(command)
-                    new_content.append({"type": "text", "text": msg})
-                    modified = True
-                    context.record_event(
-                        "policy.dogfood_safety.blocked",
-                        {"tool_name": name, "command": command[:200]},
-                    )
-                    logger.warning(f"Blocked dangerous Anthropic tool_use: {command[:100]}")
-                else:
-                    new_content.append(block)
-            else:
-                new_content.append(block)
-
-        if modified:
-            modified_response = dict(response)
-            modified_response["content"] = new_content
-            has_tool_use = any(isinstance(b, dict) and b.get("type") == "tool_use" for b in new_content)
-            if not has_tool_use and modified_response.get("stop_reason") == "tool_use":
-                modified_response["stop_reason"] = "end_turn"
-            return cast("AnthropicResponse", modified_response)
-
-        return response
+        return await transform_anthropic_response(response, self._make_transform(context))
 
     async def on_anthropic_stream_event(
         self, event: MessageStreamEvent, context: "PolicyContext"
     ) -> list[MessageStreamEvent]:
         """Buffer tool_use blocks in streaming, evaluate on completion."""
-        buffered_tool_uses = self._anthropic_buffered_tool_uses(context)
-
-        if isinstance(event, RawContentBlockStartEvent):
-            if isinstance(event.content_block, ToolUseBlock):
-                buffered_tool_uses[event.index] = _BufferedAnthropicToolUse(
-                    id=event.content_block.id,
-                    name=event.content_block.name,
-                )
-                return []
-            return [event]
-
-        if isinstance(event, RawContentBlockDeltaEvent):
-            if event.index in buffered_tool_uses and isinstance(event.delta, InputJSONDelta):
-                buffered_tool_uses[event.index].input_json += event.delta.partial_json
-                return []
-            return [event]
-
-        if isinstance(event, RawContentBlockStopEvent):
-            if event.index not in buffered_tool_uses:
-                return [cast(MessageStreamEvent, event)]
-
-            buffered = buffered_tool_uses.pop(event.index)
-            is_blocked, command = self._is_dangerous(buffered.name, buffered.input_json)
-
-            if is_blocked:
-                self._anthropic_blocked_blocks(context).add(event.index)
-                msg = self._format_blocked_message(command)
-                context.record_event(
-                    "policy.dogfood_safety.blocked",
-                    {"tool_name": buffered.name, "command": command[:200]},
-                )
-                logger.warning(f"Blocked dangerous Anthropic streaming tool_use: {command[:100]}")
-
-                text_block = TextBlock(type="text", text="")
-                start_event = RawContentBlockStartEvent(
-                    type="content_block_start",
-                    index=event.index,
-                    content_block=text_block,
-                )
-                delta_event = RawContentBlockDeltaEvent(
-                    type="content_block_delta",
-                    index=event.index,
-                    delta=TextDelta(type="text_delta", text=msg),
-                )
-                return [
-                    cast(MessageStreamEvent, start_event),
-                    cast(MessageStreamEvent, delta_event),
-                    cast(MessageStreamEvent, event),
-                ]
-
-            # Allowed tool — flip the gate that tells _handle_anthropic_message_delta
-            # to keep stop_reason="tool_use".
-            self._anthropic_state(context).had_allowed_tool_use = True
-            tool_use_block = ToolUseBlock(
-                type="tool_use",
-                id=buffered.id,
-                name=buffered.name,
-                input={},
-            )
-            start_event = RawContentBlockStartEvent(
-                type="content_block_start",
-                index=event.index,
-                content_block=tool_use_block,
-            )
-            delta_event = RawContentBlockDeltaEvent(
-                type="content_block_delta",
-                index=event.index,
-                delta=InputJSONDelta(type="input_json_delta", partial_json=buffered.input_json or "{}"),
-            )
-            return [
-                cast(MessageStreamEvent, start_event),
-                cast(MessageStreamEvent, delta_event),
-                cast(MessageStreamEvent, event),
-            ]
-
-        if isinstance(event, RawMessageDeltaEvent):
-            return self._handle_anthropic_message_delta(event, context)
-
-        return [event]
-
-    def _handle_anthropic_message_delta(
-        self,
-        event: RawMessageDeltaEvent,
-        context: "PolicyContext",
-    ) -> list[MessageStreamEvent]:
-        """Rewrite stop_reason from 'tool_use' to 'end_turn' if every tool_use was blocked.
-
-        Mirrors the stop_reason rewrite in `on_anthropic_response` and the same
-        fix in `tool_call_judge_policy._handle_anthropic_message_delta`. Without
-        this, downstream consumers see stop_reason='tool_use' but no surviving
-        tool_use block (replaced with text) and abort.
-        """
-        state = self._anthropic_state(context)
-        if state.blocked_blocks and not state.had_allowed_tool_use and event.delta.stop_reason == "tool_use":
-            # model_construct skips re-validation; mirrors simple_llm_policy._handle_message_delta.
-            rewritten = RawMessageDeltaEvent.model_construct(
-                type="message_delta",
-                delta=event.delta.model_copy(update={"stop_reason": "end_turn"}),
-                usage=event.usage,
-            )
-            return [cast(MessageStreamEvent, rewritten)]
-        return [cast(MessageStreamEvent, event)]
+        buf = context.get_request_state(
+            self,
+            ToolCallStreamBuffer,
+            lambda: ToolCallStreamBuffer(self._make_transform(context)),
+        )
+        return await buf.process(event)
 
     async def on_anthropic_streaming_policy_complete(self, context: "PolicyContext") -> None:
         """Clean up request-scoped Anthropic state."""
-        context.pop_request_state(self, _DogfoodAnthropicState)
+        context.pop_request_state(self, ToolCallStreamBuffer)
 
 
 __all__ = ["DogfoodSafetyPolicy", "DogfoodSafetyConfig"]

--- a/src/luthien_proxy/policies/dogfood_safety_policy.py
+++ b/src/luthien_proxy/policies/dogfood_safety_policy.py
@@ -162,7 +162,15 @@ class DogfoodSafetyPolicy(BasePolicy, AnthropicHookPolicy):
         async def transform(tool_calls: list[BufferedToolCall]) -> list["AnthropicContentBlock"]:
             output: list[AnthropicContentBlock] = []
             for tc in tool_calls:
-                is_blocked, command = self._is_dangerous(tc.name, tc.input)
+                # Fail-secure: if the buffered input_json failed to parse,
+                # `tc.input` returns `{"_raw": <string>}` — but we want to scan
+                # the raw text for dangerous patterns anyway, not silently
+                # treat the call as safe because the dict path returned empty.
+                parsed = tc.input
+                tool_input: "JSONObject | str" = (
+                    tc.input_json if isinstance(parsed, dict) and "_raw" in parsed else parsed
+                )
+                is_blocked, command = self._is_dangerous(tc.name, tool_input)
                 if is_blocked:
                     context.record_event(
                         "policy.dogfood_safety.blocked",

--- a/src/luthien_proxy/policies/tool_call_judge_policy.py
+++ b/src/luthien_proxy/policies/tool_call_judge_policy.py
@@ -211,6 +211,11 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
         async def transform(tool_calls: list[BufferedToolCall]) -> list["AnthropicContentBlock"]:
             output: list[AnthropicContentBlock] = []
             for tc in tool_calls:
+                # Pass the raw accumulated input_json to the judge. If upstream
+                # delivered malformed JSON, the judge sees the same broken bytes
+                # the client would have seen pre-buffer — and is expected to
+                # rate it high-probability (block) on that signal alone. This
+                # is the analog of DogfoodSafetyPolicy's _raw fail-secure check.
                 tool_call: ToolCallDict = {
                     "id": tc.id,
                     "name": tc.name,

--- a/src/luthien_proxy/policies/tool_call_judge_policy.py
+++ b/src/luthien_proxy/policies/tool_call_judge_policy.py
@@ -1,45 +1,36 @@
 """ToolCallJudgePolicy - LLM-based tool call evaluation for Anthropic.
 
-This policy demonstrates a more complex use of the Anthropic policy interface:
-- Buffers tool_use input deltas during streaming
-- Evaluates complete tool calls with a judge LLM
-- Blocks harmful tool calls and replaces with explanation
-- Handles both streaming and non-streaming Anthropic responses
-- Configurable via YAML
+For each tool_use the model proposes, calls a judge LLM that returns a risk
+probability. Tool calls at or above the configured threshold are replaced with
+a text block containing the blocked-message template. Judge failures are
+treated as block (fail-secure).
+
+Streaming and non-streaming responses are handled by delegating to
+`ToolCallStreamBuffer` and `transform_anthropic_response` — the policy only
+defines a transform closure; the buffer owns event sequencing, output indices,
+and stop_reason invariants.
 
 Example config:
     policy:
       class: "luthien_proxy.policies.tool_call_judge_policy:ToolCallJudgePolicy"
       config:
-        config:
-          model: "claude-haiku-4-5"
-          api_base: "http://localhost:11434/v1"
-          auth_provider: "user_credentials"
-          probability_threshold: 0.6
-          temperature: 0.0
-          max_tokens: 256  # see DEFAULT_JUDGE_MAX_TOKENS
-          judge_instructions: "You are a security analyst..."
-          blocked_message_template: "Tool '{tool_name}' blocked: {explanation}"
+        model: "claude-haiku-4-5"
+        api_base: "http://localhost:11434/v1"
+        auth_provider: "user_credentials"
+        probability_threshold: 0.6
+        temperature: 0.0
+        max_tokens: 256
+        judge_instructions: "You are a security analyst..."
+        blocked_message_template: "Tool '{tool_name}' blocked: {explanation}"
 """
 
 from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypedDict, cast
 
 from anthropic.lib.streaming import MessageStreamEvent
-from anthropic.types import (
-    InputJSONDelta,
-    RawContentBlockDeltaEvent,
-    RawContentBlockStartEvent,
-    RawContentBlockStopEvent,
-    RawMessageDeltaEvent,
-    TextBlock,
-    TextDelta,
-    ToolUseBlock,
-)
 from pydantic import BaseModel, Field
 
 from luthien_proxy.credentials import AuthProvider, parse_auth_provider
@@ -53,9 +44,12 @@ from luthien_proxy.policies.tool_call_judge_utils import (
 from luthien_proxy.policy_core import (
     AnthropicHookPolicy,
     BasePolicy,
+    BufferedToolCall,
     CatalogBadge,
     Category,
+    ToolCallStreamBuffer,
     UIMetadata,
+    transform_anthropic_response,
 )
 from luthien_proxy.settings import get_settings
 from luthien_proxy.utils.constants import DEFAULT_JUDGE_MAX_TOKENS, TOOL_ARGS_TRUNCATION_LENGTH
@@ -64,7 +58,6 @@ if TYPE_CHECKING:
     from luthien_proxy.llm.types.anthropic import (
         AnthropicContentBlock,
         AnthropicResponse,
-        AnthropicToolUseBlock,
     )
     from luthien_proxy.policy_core.policy_context import PolicyContext
 
@@ -77,20 +70,6 @@ class ToolCallDict(TypedDict):
     id: str
     name: str
     arguments: str
-
-
-@dataclass
-class _BufferedAnthropicToolUse:
-    id: str
-    name: str
-    input_json: str = ""
-
-
-@dataclass
-class _ToolCallJudgeAnthropicState:
-    buffered_tool_uses: dict[int, _BufferedAnthropicToolUse] = field(default_factory=dict)
-    blocked_blocks: set[int] = field(default_factory=set)
-    had_allowed_tool_use: bool = False
 
 
 class ToolCallJudgeConfig(BaseModel):
@@ -133,33 +112,16 @@ class ToolCallJudgeConfig(BaseModel):
 
 
 class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
-    """Policy that evaluates tool calls with a judge LLM and blocks harmful ones.
+    """Evaluates each tool call with a judge LLM and blocks harmful ones.
 
-    This policy demonstrates external LLM calls for tool call evaluation and content replacement.
-    It operates on streaming and non-streaming Anthropic API responses.
-
-    During Anthropic streaming:
-    - Buffers tool_use input deltas until complete
-    - Judges when content_block_stop received
-    - Either passes through or replaces with blocked text
-
-    Config:
-        model: LLM model to use for judging (default: "claude-haiku-4-5")
-        api_base: Optional API base URL for judge model
-        auth_provider: How to obtain credentials for judge calls (required)
-        probability_threshold: Block if probability >= this (default: 0.6)
-        temperature: Temperature for judge LLM (default: 0.0)
-        max_tokens: Max output tokens for judge response (default: 256)
-        judge_instructions: Custom system prompt for judge
-        blocked_message_template: Template for blocked message with variables:
-            {tool_name}, {tool_arguments}, {probability}, {explanation}
+    Stateless across requests. Per-request streaming state is owned by a
+    `ToolCallStreamBuffer` stored on the request context; this policy only
+    supplies the per-tool-call evaluation closure.
     """
 
-    # NOTE: ui_policy_preview is a UI hint only. The actual runtime block message
-    # is templated at runtime with dynamic data (tool_name, tool_arguments,
-    # probability, explanation) — see the f-string at the block-emission site
-    # in this file. The preview here is a static teaser; the production message
-    # includes the specific tool call details.
+    # NOTE: ui_policy_preview is a UI hint. The runtime blocked message is
+    # templated with the actual tool call name, arguments, probability, and
+    # explanation.
     ui = UIMetadata(
         display_name="Tool Call Judge",
         short_description="Evaluates tool calls with an LLM and blocks harmful ones.",
@@ -209,228 +171,64 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
             f"api_base={self._config.api_base}"
         )
 
-    def _anthropic_state(self, context: "PolicyContext") -> _ToolCallJudgeAnthropicState:
-        """Get or create typed request-scoped Anthropic streaming state."""
-        return context.get_request_state(self, _ToolCallJudgeAnthropicState, _ToolCallJudgeAnthropicState)
-
-    def _anthropic_buffered_tool_uses(self, context: "PolicyContext") -> dict[int, _BufferedAnthropicToolUse]:
-        """Get request-scoped Anthropic tool_use buffer."""
-        return self._anthropic_state(context).buffered_tool_uses
-
-    def _anthropic_blocked_blocks(self, context: "PolicyContext") -> set[int]:
-        """Get request-scoped blocked block index set."""
-        return self._anthropic_state(context).blocked_blocks
-
-    async def on_anthropic_streaming_policy_complete(self, context: "PolicyContext") -> None:
-        """Clean up Anthropic per-request state after streaming completes."""
-        context.pop_request_state(self, _ToolCallJudgeAnthropicState)
-
     # ========================================================================
-    # Anthropic hooks (via AnthropicHookPolicy)
+    # Anthropic hooks
     # ========================================================================
 
     async def on_anthropic_response(
         self, response: "AnthropicResponse", context: "PolicyContext"
     ) -> "AnthropicResponse":
-        """Evaluate tool_use blocks in non-streaming response.
-
-        Iterates through content blocks and evaluates tool_use blocks.
-        If blocked, replaces with text block containing blocked message.
-        """
-        content = response.get("content", [])
-        if not content:
-            return response
-
-        new_content: list[AnthropicContentBlock] = []
-        modified = False
-
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "tool_use":
-                # Cast to AnthropicToolUseBlock since we've verified it's a dict with type="tool_use"
-                tool_call = self._extract_tool_call_from_anthropic_block(cast("AnthropicToolUseBlock", block))
-                blocked_result = await self._evaluate_and_maybe_block_anthropic(tool_call, context)
-
-                if blocked_result is not None:
-                    blocked_text = self._format_anthropic_blocked_message(tool_call, blocked_result)
-                    new_content.append({"type": "text", "text": blocked_text})
-                    modified = True
-                    logger.info(f"Blocked tool call '{tool_call['name']}' in non-streaming response")
-                else:
-                    new_content.append(block)
-            else:
-                new_content.append(block)
-
-        if modified:
-            # Create a new response dict with modified content
-            modified_response = dict(response)
-            modified_response["content"] = new_content
-            # Change stop_reason from tool_use to end_turn if we blocked all tool calls
-            has_tool_use = any(isinstance(b, dict) and b.get("type") == "tool_use" for b in new_content)
-            if not has_tool_use and modified_response.get("stop_reason") == "tool_use":
-                modified_response["stop_reason"] = "end_turn"
-            return cast("AnthropicResponse", modified_response)
-
-        return response
+        """Judge each tool_use block; replace blocked calls with text."""
+        return await transform_anthropic_response(response, self._make_transform(context))
 
     async def on_anthropic_stream_event(
         self, event: MessageStreamEvent, context: "PolicyContext"
     ) -> list[MessageStreamEvent]:
-        """Process streaming events, buffering tool_use deltas for evaluation.
+        """Stream events through the per-request buffer."""
+        buf = context.get_request_state(
+            self,
+            ToolCallStreamBuffer,
+            lambda: ToolCallStreamBuffer(self._make_transform(context)),
+        )
+        return await buf.process(event)
 
-        For tool_use blocks:
-        - content_block_start: buffer the initial tool_use data
-        - content_block_delta with input_json_delta: accumulate JSON
-        - content_block_stop: judge the complete tool call
-          - If allowed: reconstruct and return full event sequence
-          - If blocked: return text block with blocked message instead
-
-        Returns a list of events to emit (empty list to filter, multiple to expand).
-        """
-        if isinstance(event, RawContentBlockStartEvent):
-            return await self._handle_anthropic_content_block_start(event, context)
-
-        elif isinstance(event, RawContentBlockDeltaEvent):
-            return await self._handle_anthropic_content_block_delta(event, context)
-
-        elif isinstance(event, RawContentBlockStopEvent):
-            return await self._handle_anthropic_content_block_stop(event, context)
-
-        elif isinstance(event, RawMessageDeltaEvent):
-            return self._handle_anthropic_message_delta(event, context)
-
-        return [event]
+    async def on_anthropic_streaming_policy_complete(self, context: "PolicyContext") -> None:
+        """Drop the per-request buffer."""
+        context.pop_request_state(self, ToolCallStreamBuffer)
 
     # ========================================================================
-    # Anthropic Streaming Helpers
+    # Transform closure
     # ========================================================================
 
-    async def _handle_anthropic_content_block_start(
-        self,
-        event: RawContentBlockStartEvent,
-        context: "PolicyContext",
-    ) -> list[MessageStreamEvent]:
-        """Handle content_block_start event."""
-        content_block = event.content_block
-        index = event.index
+    def _make_transform(self, context: "PolicyContext"):
+        """Build the transform closure passed to the buffer / non-streaming helper.
 
-        # Check if this is a tool_use block
-        if isinstance(content_block, ToolUseBlock):
-            buffered_tool_uses = self._anthropic_buffered_tool_uses(context)
-            buffered_tool_uses[index] = _BufferedAnthropicToolUse(
-                id=content_block.id,
-                name=content_block.name,
-            )
-            # Don't emit - we'll emit after judging
-            return []
-
-        return [event]
-
-    async def _handle_anthropic_content_block_delta(
-        self,
-        event: RawContentBlockDeltaEvent,
-        context: "PolicyContext",
-    ) -> list[MessageStreamEvent]:
-        """Handle content_block_delta event."""
-        index = event.index
-        delta = event.delta
-
-        # Check if this is accumulating JSON for a buffered tool_use
-        buffered_tool_uses = self._anthropic_buffered_tool_uses(context)
-        if index in buffered_tool_uses and isinstance(delta, InputJSONDelta):
-            buffered_tool_uses[index].input_json += delta.partial_json
-            return []
-
-        return [event]
-
-    async def _handle_anthropic_content_block_stop(
-        self,
-        event: RawContentBlockStopEvent,
-        context: "PolicyContext",
-    ) -> list[MessageStreamEvent]:
-        """Handle content_block_stop event - judge buffered tool_use if present."""
-        index = event.index
-        buffered_tool_uses = self._anthropic_buffered_tool_uses(context)
-
-        if index not in buffered_tool_uses:
-            return [cast(MessageStreamEvent, event)]
-
-        buffered = buffered_tool_uses.pop(index)
-        tool_call = self._tool_call_from_anthropic_buffer(buffered)
-
-        blocked_result = await self._evaluate_and_maybe_block_anthropic(tool_call, context)
-
-        if blocked_result is not None:
-            self._anthropic_blocked_blocks(context).add(index)
-            logger.info(f"Blocked tool call '{tool_call['name']}' in streaming")
-
-            # Replace the tool_use block with a text block containing the blocked message
-            blocked_message = self._format_anthropic_blocked_message(tool_call, blocked_result)
-            text_block = TextBlock(type="text", text="")
-            start_event = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=text_block)
-            text_delta = TextDelta(type="text_delta", text=blocked_message)
-            delta_event = RawContentBlockDeltaEvent(type="content_block_delta", index=index, delta=text_delta)
-            return [
-                cast(MessageStreamEvent, start_event),
-                cast(MessageStreamEvent, delta_event),
-                cast(MessageStreamEvent, event),
-            ]
-
-        # Tool call allowed - reconstruct the full event sequence from buffered data.
-        # Flip the gate that tells _handle_anthropic_message_delta to keep stop_reason="tool_use".
-        self._anthropic_state(context).had_allowed_tool_use = True
-        logger.debug(f"Tool call '{tool_call['name']}' allowed, re-emitting buffered events")
-        tool_use_block = ToolUseBlock(type="tool_use", id=buffered.id, name=buffered.name, input={})
-        start_event = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=tool_use_block)
-        json_delta = InputJSONDelta(type="input_json_delta", partial_json=buffered.input_json or "{}")
-        delta_event = RawContentBlockDeltaEvent(type="content_block_delta", index=index, delta=json_delta)
-        return [
-            cast(MessageStreamEvent, start_event),
-            cast(MessageStreamEvent, delta_event),
-            cast(MessageStreamEvent, event),
-        ]
-
-    def _handle_anthropic_message_delta(
-        self,
-        event: RawMessageDeltaEvent,
-        context: "PolicyContext",
-    ) -> list[MessageStreamEvent]:
-        """Rewrite stop_reason from 'tool_use' to 'end_turn' if every tool_use was blocked.
-
-        Without this, downstream consumers (e.g. Claude Code) read stop_reason='tool_use',
-        expect a tool_use content block to invoke, find only the substituted text block,
-        and abort with "The model's tool call could not be parsed". Mirrors the
-        stop_reason rewrite in `on_anthropic_response`.
-
-        Note: deliberately one-directional ("tool_use" → "end_turn"). Unlike
-        `simple_llm_policy._handle_message_delta`, this policy never *introduces*
-        tool_use blocks, so the reverse rewrite is unreachable.
+        Captures `context` so the closure can call the judge (needs credentials)
+        and emit observability events.
         """
-        state = self._anthropic_state(context)
-        if state.blocked_blocks and not state.had_allowed_tool_use and event.delta.stop_reason == "tool_use":
-            # model_construct skips re-validation; mirrors simple_llm_policy._handle_message_delta.
-            rewritten = RawMessageDeltaEvent.model_construct(
-                type="message_delta",
-                delta=event.delta.model_copy(update={"stop_reason": "end_turn"}),
-                usage=event.usage,
-            )
-            return [cast(MessageStreamEvent, rewritten)]
-        return [cast(MessageStreamEvent, event)]
 
-    def _extract_tool_call_from_anthropic_block(self, block: "AnthropicToolUseBlock") -> ToolCallDict:
-        """Extract tool call dict from a tool_use content block dict."""
-        return {
-            "id": block.get("id", ""),
-            "name": block.get("name", ""),
-            "arguments": json.dumps(block.get("input", {})),
-        }
+        async def transform(tool_calls: list[BufferedToolCall]) -> list["AnthropicContentBlock"]:
+            output: list[AnthropicContentBlock] = []
+            for tc in tool_calls:
+                tool_call: ToolCallDict = {
+                    "id": tc.id,
+                    "name": tc.name,
+                    "arguments": tc.input_json or "{}",
+                }
+                blocked = await self._evaluate_and_maybe_block(tool_call, context)
+                if blocked is not None:
+                    blocked_text = self._format_blocked_message(tool_call, blocked)
+                    output.append(cast("AnthropicContentBlock", {"type": "text", "text": blocked_text}))
+                    logger.info(f"Blocked tool call '{tc.name}'")
+                else:
+                    output.append(tc.as_content_block())
+            return output
 
-    def _tool_call_from_anthropic_buffer(self, buffered: _BufferedAnthropicToolUse) -> ToolCallDict:
-        """Create tool call dict from buffered data."""
-        return {
-            "id": buffered.id,
-            "name": buffered.name,
-            "arguments": buffered.input_json or "{}",
-        }
+        return transform
+
+    # ========================================================================
+    # Judge call
+    # ========================================================================
 
     async def _call_judge(
         self,
@@ -451,21 +249,23 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
         )
         return parse_to_judge_result(response_text, prompt)
 
-    async def _evaluate_and_maybe_block_anthropic(
+    async def _evaluate_and_maybe_block(
         self,
         tool_call: ToolCallDict,
         context: "PolicyContext",
     ) -> JudgeResult | None:
-        """Evaluate a tool call and return JudgeResult if blocked, None if allowed."""
+        """Evaluate a tool call; return JudgeResult if blocked, None if allowed.
+
+        Fail-secure: any exception from the judge is treated as block.
+        """
         name = str(tool_call.get("name", ""))
         arguments = tool_call.get("arguments", "{}")
         if not isinstance(arguments, str):
             arguments = json.dumps(arguments)
 
         logger.debug(f"Evaluating tool call: {name}")
-        self._emit_evaluation_started(context, name, arguments, prefix="anthropic_")
+        self._emit_evaluation_started(context, name, arguments)
 
-        # Call judge with fail-secure error handling
         try:
             judge_result = await self._call_judge(name, arguments, context)
         except Exception as exc:
@@ -474,8 +274,7 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
                 f"{arguments[:TOOL_ARGS_TRUNCATION_LENGTH]}... Error: {exc}. DEFAULTING TO BLOCK.",
                 exc_info=True,
             )
-            self._emit_evaluation_failed(context, name, arguments, exc, prefix="anthropic_")
-            # Return a synthetic JudgeResult for the blocked message
+            self._emit_evaluation_failed(context, name, arguments, exc)
             return JudgeResult(
                 probability=1.0,
                 explanation=f"Judge evaluation failed: {exc}",
@@ -486,22 +285,20 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
         logger.debug(
             f"Judge probability: {judge_result.probability:.2f} (threshold: {self._config.probability_threshold})"
         )
-        self._emit_evaluation_complete(context, name, judge_result, prefix="anthropic_")
+        self._emit_evaluation_complete(context, name, judge_result)
 
-        should_block = judge_result.probability >= self._config.probability_threshold
-
-        if should_block:
-            self._emit_tool_call_blocked(context, name, judge_result, prefix="anthropic_")
+        if judge_result.probability >= self._config.probability_threshold:
+            self._emit_tool_call_blocked(context, name, judge_result)
             logger.warning(
                 f"Blocking tool call '{name}' (probability {judge_result.probability:.2f} "
                 f">= {self._config.probability_threshold})"
             )
             return judge_result
-        else:
-            self._emit_tool_call_allowed(context, name, judge_result.probability, prefix="anthropic_")
-            return None
 
-    def _format_anthropic_blocked_message(
+        self._emit_tool_call_allowed(context, name, judge_result.probability)
+        return None
+
+    def _format_blocked_message(
         self,
         tool_call: ToolCallDict,
         judge_result: JudgeResult,
@@ -519,20 +316,12 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
         )
 
     # ========================================================================
-    # Shared Helpers
+    # Observability
     # ========================================================================
 
-    def _emit_evaluation_started(
-        self,
-        policy_ctx: "PolicyContext",
-        name: str,
-        arguments: str,
-        prefix: str = "",
-    ) -> None:
-        """Emit observability event for evaluation start."""
-        event_name = f"policy.{prefix}judge.evaluation_started"
+    def _emit_evaluation_started(self, policy_ctx: "PolicyContext", name: str, arguments: str) -> None:
         policy_ctx.record_event(
-            event_name,
+            "policy.anthropic_judge.evaluation_started",
             {
                 "summary": f"Evaluating tool call: {name}",
                 "tool_name": name,
@@ -540,18 +329,9 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
             },
         )
 
-    def _emit_evaluation_failed(
-        self,
-        policy_ctx: "PolicyContext",
-        name: str,
-        arguments: str,
-        exc: Exception,
-        prefix: str = "",
-    ) -> None:
-        """Emit observability event for evaluation failure."""
-        event_name = f"policy.{prefix}judge.evaluation_failed"
+    def _emit_evaluation_failed(self, policy_ctx: "PolicyContext", name: str, arguments: str, exc: Exception) -> None:
         policy_ctx.record_event(
-            event_name,
+            "policy.anthropic_judge.evaluation_failed",
             {
                 "summary": f"⚠️ Judge evaluation failed for '{name}' - BLOCKED (fail-secure)",
                 "tool_name": name,
@@ -562,17 +342,9 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
             },
         )
 
-    def _emit_evaluation_complete(
-        self,
-        policy_ctx: "PolicyContext",
-        name: str,
-        judge_result: JudgeResult,
-        prefix: str = "",
-    ) -> None:
-        """Emit observability event for successful evaluation."""
-        event_name = f"policy.{prefix}judge.evaluation_complete"
+    def _emit_evaluation_complete(self, policy_ctx: "PolicyContext", name: str, judge_result: JudgeResult) -> None:
         policy_ctx.record_event(
-            event_name,
+            "policy.anthropic_judge.evaluation_complete",
             {
                 "summary": f"Judge evaluated '{name}': probability={judge_result.probability:.2f}",
                 "tool_name": name,
@@ -582,17 +354,9 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
             },
         )
 
-    def _emit_tool_call_allowed(
-        self,
-        policy_ctx: "PolicyContext",
-        name: str,
-        probability: float,
-        prefix: str = "",
-    ) -> None:
-        """Emit observability event for allowed tool call."""
-        event_name = f"policy.{prefix}judge.tool_call_allowed"
+    def _emit_tool_call_allowed(self, policy_ctx: "PolicyContext", name: str, probability: float) -> None:
         policy_ctx.record_event(
-            event_name,
+            "policy.anthropic_judge.tool_call_allowed",
             {
                 "summary": f"Tool call '{name}' allowed (probability {probability:.2f} < {self._config.probability_threshold})",
                 "tool_name": name,
@@ -600,17 +364,9 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
             },
         )
 
-    def _emit_tool_call_blocked(
-        self,
-        policy_ctx: "PolicyContext",
-        name: str,
-        judge_result: JudgeResult,
-        prefix: str = "",
-    ) -> None:
-        """Emit observability event for blocked tool call."""
-        event_name = f"policy.{prefix}judge.tool_call_blocked"
+    def _emit_tool_call_blocked(self, policy_ctx: "PolicyContext", name: str, judge_result: JudgeResult) -> None:
         policy_ctx.record_event(
-            event_name,
+            "policy.anthropic_judge.tool_call_blocked",
             {
                 "summary": f"BLOCKED: Tool call '{name}' rejected (probability {judge_result.probability:.2f} >= {self._config.probability_threshold})",
                 "severity": "warning",

--- a/src/luthien_proxy/policies/tool_call_judge_policy.py
+++ b/src/luthien_proxy/policies/tool_call_judge_policy.py
@@ -48,6 +48,7 @@ from luthien_proxy.policy_core import (
     CatalogBadge,
     Category,
     ToolCallStreamBuffer,
+    ToolCallTransform,
     UIMetadata,
     transform_anthropic_response,
 )
@@ -200,7 +201,7 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
     # Transform closure
     # ========================================================================
 
-    def _make_transform(self, context: "PolicyContext"):
+    def _make_transform(self, context: "PolicyContext") -> ToolCallTransform:
         """Build the transform closure passed to the buffer / non-streaming helper.
 
         Captures `context` so the closure can call the judge (needs credentials)

--- a/src/luthien_proxy/policies/tool_call_judge_policy.py
+++ b/src/luthien_proxy/policies/tool_call_judge_policy.py
@@ -211,11 +211,6 @@ class ToolCallJudgePolicy(BasePolicy, AnthropicHookPolicy):
         async def transform(tool_calls: list[BufferedToolCall]) -> list["AnthropicContentBlock"]:
             output: list[AnthropicContentBlock] = []
             for tc in tool_calls:
-                # Pass the raw accumulated input_json to the judge. If upstream
-                # delivered malformed JSON, the judge sees the same broken bytes
-                # the client would have seen pre-buffer — and is expected to
-                # rate it high-probability (block) on that signal alone. This
-                # is the analog of DogfoodSafetyPolicy's _raw fail-secure check.
                 tool_call: ToolCallDict = {
                     "id": tc.id,
                     "name": tc.name,

--- a/src/luthien_proxy/policy_core/__init__.py
+++ b/src/luthien_proxy/policy_core/__init__.py
@@ -15,6 +15,12 @@ from luthien_proxy.policy_core.anthropic_execution_interface import (
     AnthropicPolicyEmission,
 )
 from luthien_proxy.policy_core.anthropic_hook_policy import AnthropicHookPolicy
+from luthien_proxy.policy_core.anthropic_tool_call_buffer import (
+    BufferedToolCall,
+    ToolCallStreamBuffer,
+    ToolCallTransform,
+    transform_anthropic_response,
+)
 from luthien_proxy.policy_core.base_policy import (
     BasePolicy,
     CatalogBadge,
@@ -34,6 +40,11 @@ __all__ = [
     "PolicyContext",
     # Text modifier base class
     "TextModifierPolicy",
+    # Tool-call buffer (policy-agnostic tool_use rewrite primitive)
+    "BufferedToolCall",
+    "ToolCallStreamBuffer",
+    "ToolCallTransform",
+    "transform_anthropic_response",
     # UI catalog metadata (no runtime effect)
     "UIMetadata",
     "Category",

--- a/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
+++ b/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
@@ -110,7 +110,7 @@ class _BufferState:
     upstream_to_buf_pos: dict[int, int] = field(default_factory=dict)
     passthrough_index_map: dict[int, int] = field(default_factory=dict)
     next_output_index: int = 0
-    transform_invoked: bool = False
+    message_delta_seen: bool = False
 
 
 class ToolCallStreamBuffer:
@@ -180,10 +180,10 @@ class ToolCallStreamBuffer:
         return [cast(MessageStreamEvent, rewritten)]
 
     async def _on_message_delta(self, event: RawMessageDeltaEvent) -> list[MessageStreamEvent]:
-        if self._state.transform_invoked:
+        if self._state.message_delta_seen:
             logger.warning("message_delta arrived twice; passing through second occurrence")
             return [cast(MessageStreamEvent, event)]
-        self._state.transform_invoked = True
+        self._state.message_delta_seen = True
 
         if not self._state.buffered:
             return [cast(MessageStreamEvent, event)]
@@ -217,6 +217,11 @@ class ToolCallStreamBuffer:
         if block_type == "text":
             return _events_for_text(index, str(block_dict.get("text", "")))
         if block_type == "tool_use":
+            if "id" not in block_dict or "name" not in block_dict:
+                raise ValueError(
+                    "ToolCallStreamBuffer transform returned a tool_use block missing required "
+                    f"'id' or 'name' field: {block_dict!r}"
+                )
             return _events_for_tool_use(
                 index,
                 tool_id=str(block_dict["id"]),

--- a/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
+++ b/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
@@ -1,38 +1,19 @@
 """Policy-agnostic Anthropic tool_use buffer with caller-supplied transform.
 
-A per-request streaming filter that lets callers transform a model's tool calls
-without writing event-state-machine code. Text content streams through in real
-time; tool_use blocks are buffered until the upstream response is complete; the
-caller's transform closure receives the full list of buffered tool calls and
-returns the content blocks to emit in their place.
+Per-request streaming filter. Text streams in real time; tool_use blocks
+buffer until `message_delta`; the caller's transform receives the full list
+of buffered tool calls and returns content blocks to emit in their place.
+Cross-event invariants (output indices, `stop_reason` consistency) live in
+the buffer.
 
-Cross-event invariants (output indices, `stop_reason` consistency) live inside
-the buffer so individual policies cannot drop them.
-
-Ordering caveat: text passes through immediately to preserve streaming UX. Tool
-replacements are emitted after all upstream events have been seen (at the
-`message_delta`). Upstream order `text, tool_use, text` becomes output order
-`text, text, <transform output>`. This matches typical Claude responses
-(text-then-tools); a future `buffer_all` mode could preserve exact ordering at
-the cost of streaming latency.
-
-Error-handling caveat: exceptions raised by the transform (or by `_emit_block`
-when the transform returns an unsupported block type) propagate out of
-`process()`. Earlier text content may have already been streamed. The streaming
-pipeline catches these and emits an in-stream SSE `error` event before closing
-the connection (see `pipeline/anthropic_processor.py` — the `except Exception`
-arm around the `on_anthropic_stream_event` loop). Transforms should still be
-written to not raise on normal data; the SSE error is a last-resort surface,
-not a "no terminating message_delta" leak.
+Note: upstream `text, tool_use, text` becomes output `text, text, <transform output>`
+because text isn't held hostage waiting for tool decisions.
 
 Usage:
     buf = ctx.get_request_state(
         self, ToolCallStreamBuffer, lambda: ToolCallStreamBuffer(self._decide)
     )
     return await buf.process(event)
-
-    async def _decide(self, tool_calls: list[BufferedToolCall]) -> list[AnthropicContentBlock]:
-        ...
 """
 
 from __future__ import annotations
@@ -351,11 +332,8 @@ def _events_for_tool_use(index: int, *, tool_id: str, name: str, tool_input: obj
         index=index,
         content_block=ToolUseBlock(type="tool_use", id=tool_id, name=name, input={}),
     )
-    # Preserve original malformed bytes on passthrough: when a tool_use had an
-    # unparseable input_json upstream, BufferedToolCall.input wraps it as
-    # {"_raw": "<original string>"}. Emitting json.dumps(...) would normalize
-    # to valid JSON the client might then execute. Re-emit the raw string so
-    # the client sees the same broken bytes it would have seen pre-PR.
+    # If input is the {"_raw": str} malformed-passthrough sentinel, re-emit
+    # the original bytes rather than normalizing them through json.dumps.
     if isinstance(tool_input, dict) and set(tool_input.keys()) == {"_raw"} and isinstance(tool_input["_raw"], str):
         json_payload = tool_input["_raw"]
     else:

--- a/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
+++ b/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
@@ -248,6 +248,7 @@ async def transform_anthropic_response(
     content = response.get("content") or []
     tool_calls: list[BufferedToolCall] = []
     tool_positions: list[int] = []
+    original_tool_blocks: list[dict] = []
     rebuilt: list[object] = []
 
     for block in content:
@@ -260,6 +261,7 @@ async def transform_anthropic_response(
                 )
             )
             tool_positions.append(len(rebuilt))
+            original_tool_blocks.append(block)
             rebuilt.append(_PLACEHOLDER)
         else:
             rebuilt.append(block)
@@ -269,8 +271,20 @@ async def transform_anthropic_response(
 
     new_blocks = await transform(tool_calls)
     if len(new_blocks) == len(tool_positions):
-        for pos, blk in zip(tool_positions, new_blocks):
-            rebuilt[pos] = blk
+        for pos, blk, original in zip(tool_positions, new_blocks, original_tool_blocks):
+            # Passthrough preservation: when the transform output matches the
+            # original on (id, input), substitute the original block back so any
+            # extra fields beyond {type, id, name, input} (e.g. future Anthropic
+            # schema additions) survive a no-op transform.
+            if (
+                isinstance(blk, dict)
+                and blk.get("type") == "tool_use"
+                and blk.get("id") == original.get("id")
+                and blk.get("input") == original.get("input")
+            ):
+                rebuilt[pos] = original
+            else:
+                rebuilt[pos] = blk
     else:
         first = tool_positions[0]
         tail = [b for b in rebuilt[first + 1 :] if b is not _PLACEHOLDER]

--- a/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
+++ b/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
@@ -234,16 +234,18 @@ async def transform_anthropic_response(
 
     Walks `response["content"]`, extracts tool_use blocks as `BufferedToolCall`s,
     invokes `transform` with them, and stitches the result back into the content
-    list in place of the original tool_uses. Non-tool-use blocks (text, thinking,
-    etc.) are preserved at their original positions; the transform output is
-    inserted at the first tool_use position and any subsequent tool_uses are
-    dropped (matching the streaming-side "tool replacements come together"
-    semantics). `stop_reason` is rewritten to match the final content shape.
+    list. When the transform returns the same number of blocks as input tool_uses,
+    each output is placed at its corresponding input's original position. When the
+    counts differ (e.g. the transform adds or drops tool calls), outputs are
+    placed together at the first tool_use position and the other tool_use slots
+    are removed — preserving the relative position of non-tool-use blocks.
+    `stop_reason` is rewritten to match the final content shape.
     """
+    _PLACEHOLDER = object()
     content = response.get("content") or []
     tool_calls: list[BufferedToolCall] = []
-    first_tool_idx: int | None = None
-    rebuilt: list["AnthropicContentBlock"] = []
+    tool_positions: list[int] = []
+    rebuilt: list[object] = []
 
     for block in content:
         if isinstance(block, dict) and block.get("type") == "tool_use":
@@ -254,9 +256,8 @@ async def transform_anthropic_response(
                     input_json=json.dumps(block.get("input", {})),
                 )
             )
-            if first_tool_idx is None:
-                first_tool_idx = len(rebuilt)
-                rebuilt.append(cast("AnthropicContentBlock", {"__TOOL_PLACEHOLDER__": True}))
+            tool_positions.append(len(rebuilt))
+            rebuilt.append(_PLACEHOLDER)
         else:
             rebuilt.append(block)
 
@@ -264,20 +265,26 @@ async def transform_anthropic_response(
         return response
 
     new_blocks = await transform(tool_calls)
-    assert first_tool_idx is not None  # tool_calls non-empty implies a placeholder exists
-    rebuilt = rebuilt[:first_tool_idx] + list(new_blocks) + rebuilt[first_tool_idx + 1 :]
+    if len(new_blocks) == len(tool_positions):
+        for pos, blk in zip(tool_positions, new_blocks):
+            rebuilt[pos] = blk
+    else:
+        first = tool_positions[0]
+        tail = [b for b in rebuilt[first + 1 :] if b is not _PLACEHOLDER]
+        rebuilt = rebuilt[:first] + list(new_blocks) + tail
 
-    any_tool_use = any(_is_tool_use_block(b) for b in rebuilt)
+    final_content = cast("list[AnthropicContentBlock]", rebuilt)
+    any_tool_use = any(_is_tool_use_block(b) for b in final_content)
     upstream_stop = response.get("stop_reason")
     new_stop = _adjust_stop_reason(upstream_stop, any_tool_use)
 
     # Identity-preserving fast path: if the transform was a pure passthrough and
     # the stop_reason didn't need adjusting, return the original response object.
-    if rebuilt == list(content) and new_stop == upstream_stop:
+    if final_content == list(content) and new_stop == upstream_stop:
         return response
 
     modified = dict(response)
-    modified["content"] = rebuilt
+    modified["content"] = final_content
     if new_stop != upstream_stop:
         modified["stop_reason"] = new_stop
     return cast("AnthropicResponse", modified)

--- a/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
+++ b/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
@@ -235,7 +235,6 @@ async def transform_anthropic_response(
     content = response.get("content") or []
     tool_calls: list[BufferedToolCall] = []
     tool_positions: list[int] = []
-    original_tool_blocks: list[dict] = []
     rebuilt: list[object] = []
 
     for block in content:
@@ -248,7 +247,6 @@ async def transform_anthropic_response(
                 )
             )
             tool_positions.append(len(rebuilt))
-            original_tool_blocks.append(cast(dict, block))
             rebuilt.append(_PLACEHOLDER)
         else:
             rebuilt.append(block)
@@ -258,21 +256,8 @@ async def transform_anthropic_response(
 
     new_blocks = await transform(tool_calls)
     if len(new_blocks) == len(tool_positions):
-        for pos, blk, original in zip(tool_positions, new_blocks, original_tool_blocks):
-            # Passthrough preservation: when the transform output matches the
-            # original on (id, name, input), substitute the original block back
-            # so any extra fields beyond {type, id, name, input} (e.g. future
-            # Anthropic schema additions) survive a no-op transform.
-            if (
-                isinstance(blk, dict)
-                and blk.get("type") == "tool_use"
-                and blk.get("id") == original.get("id")
-                and blk.get("name") == original.get("name")
-                and blk.get("input") == original.get("input")
-            ):
-                rebuilt[pos] = original
-            else:
-                rebuilt[pos] = blk
+        for pos, blk in zip(tool_positions, new_blocks):
+            rebuilt[pos] = blk
     else:
         first = tool_positions[0]
         tail = [b for b in rebuilt[first + 1 :] if b is not _PLACEHOLDER]

--- a/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
+++ b/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
@@ -161,8 +161,11 @@ class ToolCallStreamBuffer:
             return []
         output_index = self._state.passthrough_index_map.get(event.index)
         if output_index is None:
-            logger.warning("Delta for unknown upstream index %d; passing through", event.index)
-            return [cast(MessageStreamEvent, event)]
+            # Upstream sent a delta for an index we never saw a block_start for.
+            # Passing it through with its original index could collide with an
+            # output index we've already allocated; drop it instead.
+            logger.warning("Delta for unknown upstream index %d; dropping", event.index)
+            return []
         rewritten = event.model_copy(update={"index": output_index})
         return [cast(MessageStreamEvent, rewritten)]
 
@@ -171,8 +174,8 @@ class ToolCallStreamBuffer:
             return []
         output_index = self._state.passthrough_index_map.get(event.index)
         if output_index is None:
-            logger.warning("Stop for unknown upstream index %d; passing through", event.index)
-            return [cast(MessageStreamEvent, event)]
+            logger.warning("Stop for unknown upstream index %d; dropping", event.index)
+            return []
         rewritten = event.model_copy(update={"index": output_index})
         return [cast(MessageStreamEvent, rewritten)]
 
@@ -327,7 +330,15 @@ def _events_for_tool_use(index: int, *, tool_id: str, name: str, tool_input: obj
         index=index,
         content_block=ToolUseBlock(type="tool_use", id=tool_id, name=name, input={}),
     )
-    json_payload = json.dumps(tool_input) if tool_input else "{}"
+    # Preserve original malformed bytes on passthrough: when a tool_use had an
+    # unparseable input_json upstream, BufferedToolCall.input wraps it as
+    # {"_raw": "<original string>"}. Emitting json.dumps(...) would normalize
+    # to valid JSON the client might then execute. Re-emit the raw string so
+    # the client sees the same broken bytes it would have seen pre-PR.
+    if isinstance(tool_input, dict) and set(tool_input.keys()) == {"_raw"} and isinstance(tool_input["_raw"], str):
+        json_payload = tool_input["_raw"]
+    else:
+        json_payload = json.dumps(tool_input) if tool_input else "{}"
     delta = RawContentBlockDeltaEvent(
         type="content_block_delta",
         index=index,

--- a/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
+++ b/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
@@ -18,11 +18,12 @@ the cost of streaming latency.
 
 Error-handling caveat: exceptions raised by the transform (or by `_emit_block`
 when the transform returns an unsupported block type) propagate out of
-`process()`. By that point any earlier text content has already been streamed
-to the client, so the client sees a partial response with no terminating
-`message_delta` / `message_stop`. Transforms should be written to not raise on
-normal data; the pipeline above is responsible for surfacing the error to the
-client connection.
+`process()`. Earlier text content may have already been streamed. The streaming
+pipeline catches these and emits an in-stream SSE `error` event before closing
+the connection (see `pipeline/anthropic_processor.py` — the `except Exception`
+arm around the `on_anthropic_stream_event` loop). Transforms should still be
+written to not raise on normal data; the SSE error is a last-resort surface,
+not a "no terminating message_delta" leak.
 
 Usage:
     buf = ctx.get_request_state(

--- a/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
+++ b/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
@@ -1,0 +1,330 @@
+"""Policy-agnostic Anthropic tool_use buffer with caller-supplied transform.
+
+A per-request streaming filter that lets callers transform a model's tool calls
+without writing event-state-machine code. Text content streams through in real
+time; tool_use blocks are buffered until the upstream response is complete; the
+caller's transform closure receives the full list of buffered tool calls and
+returns the content blocks to emit in their place.
+
+Cross-event invariants (output indices, `stop_reason` consistency) live inside
+the buffer so individual policies cannot drop them.
+
+Ordering caveat: text passes through immediately to preserve streaming UX. Tool
+replacements are emitted after all upstream events have been seen (at the
+`message_delta`). Upstream order `text, tool_use, text` becomes output order
+`text, text, <transform output>`. This matches typical Claude responses
+(text-then-tools); a future `buffer_all` mode could preserve exact ordering at
+the cost of streaming latency.
+
+Usage:
+    buf = ctx.get_request_state(
+        self, ToolCallStreamBuffer, lambda: ToolCallStreamBuffer(self._decide)
+    )
+    return await buf.process(event)
+
+    async def _decide(self, tool_calls: list[BufferedToolCall]) -> list[AnthropicContentBlock]:
+        ...
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, cast
+
+from anthropic.lib.streaming import MessageStreamEvent
+from anthropic.types import (
+    InputJSONDelta,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    RawMessageDeltaEvent,
+    TextBlock,
+    TextDelta,
+    ToolUseBlock,
+)
+
+if TYPE_CHECKING:
+    from luthien_proxy.llm.types.anthropic import (
+        AnthropicContentBlock,
+        AnthropicResponse,
+        JSONObject,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BufferedToolCall:
+    """A tool_use block being (or done being) buffered from the upstream stream."""
+
+    id: str
+    name: str
+    input_json: str = ""
+
+    @property
+    def input(self) -> "JSONObject":
+        """Parsed input dict, or `{"_raw": input_json}` if the JSON is malformed."""
+        if not self.input_json:
+            return {}
+        try:
+            parsed = json.loads(self.input_json)
+        except json.JSONDecodeError:
+            return cast("JSONObject", {"_raw": self.input_json})
+        if not isinstance(parsed, dict):
+            return cast("JSONObject", {"_raw": self.input_json})
+        return cast("JSONObject", parsed)
+
+    def as_content_block(self) -> "AnthropicContentBlock":
+        """Return the dict-shaped content block for passthrough in a transform."""
+        return cast(
+            "AnthropicContentBlock",
+            {"type": "tool_use", "id": self.id, "name": self.name, "input": self.input},
+        )
+
+
+ToolCallTransform = Callable[[list[BufferedToolCall]], Awaitable[list["AnthropicContentBlock"]]]
+"""Caller-supplied async function: receives buffered tool calls, returns replacement content blocks.
+
+Supported output block types: text and tool_use. Other block types raise ValueError
+when emitted (the model never emits image/thinking via tool-call-shaped responses,
+and the buffer's job is specifically to rewrite tool calls).
+"""
+
+
+@dataclass
+class _BufferState:
+    """Internal mutable state for one streaming response."""
+
+    buffered: list[BufferedToolCall] = field(default_factory=list)
+    upstream_to_buf_pos: dict[int, int] = field(default_factory=dict)
+    passthrough_index_map: dict[int, int] = field(default_factory=dict)
+    next_output_index: int = 0
+    transform_invoked: bool = False
+
+
+class ToolCallStreamBuffer:
+    """Per-request streaming filter over Anthropic message events.
+
+    Construct one per streaming response (typically via
+    `PolicyContext.get_request_state`). Call `process(event)` for every upstream
+    event in order; emit the returned events downstream.
+    """
+
+    def __init__(self, transform: ToolCallTransform) -> None:
+        """Bind the transform closure that will be invoked at message_delta."""
+        self._transform = transform
+        self._state = _BufferState()
+
+    async def process(self, event: MessageStreamEvent) -> list[MessageStreamEvent]:
+        """Filter one upstream event; return zero or more downstream events."""
+        if isinstance(event, RawContentBlockStartEvent):
+            return self._on_block_start(event)
+        if isinstance(event, RawContentBlockDeltaEvent):
+            return self._on_block_delta(event)
+        if isinstance(event, RawContentBlockStopEvent):
+            return self._on_block_stop(event)
+        if isinstance(event, RawMessageDeltaEvent):
+            return await self._on_message_delta(event)
+        return [event]
+
+    def _on_block_start(self, event: RawContentBlockStartEvent) -> list[MessageStreamEvent]:
+        if isinstance(event.content_block, ToolUseBlock):
+            self._state.upstream_to_buf_pos[event.index] = len(self._state.buffered)
+            self._state.buffered.append(BufferedToolCall(id=event.content_block.id, name=event.content_block.name))
+            return []
+        output_index = self._allocate_output_index()
+        self._state.passthrough_index_map[event.index] = output_index
+        rewritten = event.model_copy(update={"index": output_index})
+        return [cast(MessageStreamEvent, rewritten)]
+
+    def _on_block_delta(self, event: RawContentBlockDeltaEvent) -> list[MessageStreamEvent]:
+        pos = self._state.upstream_to_buf_pos.get(event.index)
+        if pos is not None:
+            if isinstance(event.delta, InputJSONDelta):
+                self._state.buffered[pos].input_json += event.delta.partial_json
+            else:
+                logger.warning(
+                    "Non-InputJSONDelta arrived on buffered tool_use index %d; dropping",
+                    event.index,
+                )
+            return []
+        output_index = self._state.passthrough_index_map.get(event.index)
+        if output_index is None:
+            logger.warning("Delta for unknown upstream index %d; passing through", event.index)
+            return [cast(MessageStreamEvent, event)]
+        rewritten = event.model_copy(update={"index": output_index})
+        return [cast(MessageStreamEvent, rewritten)]
+
+    def _on_block_stop(self, event: RawContentBlockStopEvent) -> list[MessageStreamEvent]:
+        if event.index in self._state.upstream_to_buf_pos:
+            return []
+        output_index = self._state.passthrough_index_map.get(event.index)
+        if output_index is None:
+            logger.warning("Stop for unknown upstream index %d; passing through", event.index)
+            return [cast(MessageStreamEvent, event)]
+        rewritten = event.model_copy(update={"index": output_index})
+        return [cast(MessageStreamEvent, rewritten)]
+
+    async def _on_message_delta(self, event: RawMessageDeltaEvent) -> list[MessageStreamEvent]:
+        if self._state.transform_invoked:
+            logger.warning("message_delta arrived twice; passing through second occurrence")
+            return [cast(MessageStreamEvent, event)]
+        self._state.transform_invoked = True
+
+        if not self._state.buffered:
+            return [cast(MessageStreamEvent, event)]
+
+        output_blocks = await self._transform(self._state.buffered)
+        emitted_events: list[MessageStreamEvent] = []
+        for block in output_blocks:
+            emitted_events.extend(self._emit_block(block))
+
+        any_tool_use = any(_is_tool_use_block(b) for b in output_blocks)
+        upstream_stop = event.delta.stop_reason
+        new_stop = _adjust_stop_reason(upstream_stop, any_tool_use)
+        if new_stop != upstream_stop:
+            event = RawMessageDeltaEvent.model_construct(
+                type="message_delta",
+                delta=event.delta.model_copy(update={"stop_reason": new_stop}),
+                usage=event.usage,
+            )
+        emitted_events.append(cast(MessageStreamEvent, event))
+        return emitted_events
+
+    def _allocate_output_index(self) -> int:
+        idx = self._state.next_output_index
+        self._state.next_output_index += 1
+        return idx
+
+    def _emit_block(self, block: "AnthropicContentBlock") -> list[MessageStreamEvent]:
+        block_dict = cast(dict, block)
+        block_type = block_dict.get("type")
+        index = self._allocate_output_index()
+        if block_type == "text":
+            return _events_for_text(index, str(block_dict.get("text", "")))
+        if block_type == "tool_use":
+            return _events_for_tool_use(
+                index,
+                tool_id=str(block_dict["id"]),
+                name=str(block_dict["name"]),
+                tool_input=block_dict.get("input", {}),
+            )
+        raise ValueError(
+            f"ToolCallStreamBuffer transform returned unsupported block type {block_type!r}; "
+            "only 'text' and 'tool_use' are supported."
+        )
+
+
+async def transform_anthropic_response(
+    response: "AnthropicResponse",
+    transform: ToolCallTransform,
+) -> "AnthropicResponse":
+    """Non-streaming sibling of `ToolCallStreamBuffer`.
+
+    Walks `response["content"]`, extracts tool_use blocks as `BufferedToolCall`s,
+    invokes `transform` with them, and stitches the result back into the content
+    list in place of the original tool_uses. Non-tool-use blocks (text, thinking,
+    etc.) are preserved at their original positions; the transform output is
+    inserted at the first tool_use position and any subsequent tool_uses are
+    dropped (matching the streaming-side "tool replacements come together"
+    semantics). `stop_reason` is rewritten to match the final content shape.
+    """
+    content = response.get("content") or []
+    tool_calls: list[BufferedToolCall] = []
+    first_tool_idx: int | None = None
+    rebuilt: list["AnthropicContentBlock"] = []
+
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "tool_use":
+            tool_calls.append(
+                BufferedToolCall(
+                    id=str(block.get("id", "")),
+                    name=str(block.get("name", "")),
+                    input_json=json.dumps(block.get("input", {})),
+                )
+            )
+            if first_tool_idx is None:
+                first_tool_idx = len(rebuilt)
+                rebuilt.append(cast("AnthropicContentBlock", {"__TOOL_PLACEHOLDER__": True}))
+        else:
+            rebuilt.append(block)
+
+    if not tool_calls:
+        return response
+
+    new_blocks = await transform(tool_calls)
+    assert first_tool_idx is not None  # tool_calls non-empty implies a placeholder exists
+    rebuilt = rebuilt[:first_tool_idx] + list(new_blocks) + rebuilt[first_tool_idx + 1 :]
+
+    any_tool_use = any(_is_tool_use_block(b) for b in rebuilt)
+    upstream_stop = response.get("stop_reason")
+    new_stop = _adjust_stop_reason(upstream_stop, any_tool_use)
+
+    # Identity-preserving fast path: if the transform was a pure passthrough and
+    # the stop_reason didn't need adjusting, return the original response object.
+    if rebuilt == list(content) and new_stop == upstream_stop:
+        return response
+
+    modified = dict(response)
+    modified["content"] = rebuilt
+    if new_stop != upstream_stop:
+        modified["stop_reason"] = new_stop
+    return cast("AnthropicResponse", modified)
+
+
+def _is_tool_use_block(block: "AnthropicContentBlock") -> bool:
+    return isinstance(block, dict) and block.get("type") == "tool_use"
+
+
+def _adjust_stop_reason(upstream: str | None, any_tool_use: bool) -> str | None:
+    """If the post-transform content has no tool_use, rewrite `tool_use` to `end_turn`.
+
+    The reverse direction (adding tool_use to a non-tool_use response) is not
+    auto-rewritten because the upstream knew its own stop_reason for whatever
+    real reason; promoting `end_turn` to `tool_use` could mask a legitimate
+    `max_tokens` truncation. Callers that synthesize tool calls must set
+    stop_reason themselves at a higher layer.
+    """
+    if upstream == "tool_use" and not any_tool_use:
+        return "end_turn"
+    return upstream
+
+
+def _events_for_text(index: int, text: str) -> list[MessageStreamEvent]:
+    start = RawContentBlockStartEvent(
+        type="content_block_start", index=index, content_block=TextBlock(type="text", text="")
+    )
+    delta = RawContentBlockDeltaEvent.model_construct(
+        type="content_block_delta",
+        index=index,
+        delta=TextDelta.model_construct(type="text_delta", text=text),
+    )
+    stop = RawContentBlockStopEvent(type="content_block_stop", index=index)
+    return [cast(MessageStreamEvent, start), cast(MessageStreamEvent, delta), cast(MessageStreamEvent, stop)]
+
+
+def _events_for_tool_use(index: int, *, tool_id: str, name: str, tool_input: object) -> list[MessageStreamEvent]:
+    start = RawContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=ToolUseBlock(type="tool_use", id=tool_id, name=name, input={}),
+    )
+    json_payload = json.dumps(tool_input) if tool_input else "{}"
+    delta = RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=InputJSONDelta(type="input_json_delta", partial_json=json_payload),
+    )
+    stop = RawContentBlockStopEvent(type="content_block_stop", index=index)
+    return [cast(MessageStreamEvent, start), cast(MessageStreamEvent, delta), cast(MessageStreamEvent, stop)]
+
+
+__all__ = [
+    "BufferedToolCall",
+    "ToolCallStreamBuffer",
+    "ToolCallTransform",
+    "transform_anthropic_response",
+]

--- a/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
+++ b/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
@@ -261,7 +261,7 @@ async def transform_anthropic_response(
                 )
             )
             tool_positions.append(len(rebuilt))
-            original_tool_blocks.append(block)
+            original_tool_blocks.append(cast(dict, block))
             rebuilt.append(_PLACEHOLDER)
         else:
             rebuilt.append(block)

--- a/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
+++ b/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
@@ -16,6 +16,14 @@ replacements are emitted after all upstream events have been seen (at the
 (text-then-tools); a future `buffer_all` mode could preserve exact ordering at
 the cost of streaming latency.
 
+Error-handling caveat: exceptions raised by the transform (or by `_emit_block`
+when the transform returns an unsupported block type) propagate out of
+`process()`. By that point any earlier text content has already been streamed
+to the client, so the client sees a partial response with no terminating
+`message_delta` / `message_stop`. Transforms should be written to not raise on
+normal data; the pipeline above is responsible for surfacing the error to the
+client connection.
+
 Usage:
     buf = ctx.get_request_state(
         self, ToolCallStreamBuffer, lambda: ToolCallStreamBuffer(self._decide)

--- a/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
+++ b/src/luthien_proxy/policy_core/anthropic_tool_call_buffer.py
@@ -273,13 +273,14 @@ async def transform_anthropic_response(
     if len(new_blocks) == len(tool_positions):
         for pos, blk, original in zip(tool_positions, new_blocks, original_tool_blocks):
             # Passthrough preservation: when the transform output matches the
-            # original on (id, input), substitute the original block back so any
-            # extra fields beyond {type, id, name, input} (e.g. future Anthropic
-            # schema additions) survive a no-op transform.
+            # original on (id, name, input), substitute the original block back
+            # so any extra fields beyond {type, id, name, input} (e.g. future
+            # Anthropic schema additions) survive a no-op transform.
             if (
                 isinstance(blk, dict)
                 and blk.get("type") == "tool_use"
                 and blk.get("id") == original.get("id")
+                and blk.get("name") == original.get("name")
                 and blk.get("input") == original.get("input")
             ):
                 rebuilt[pos] = original

--- a/src/luthien_proxy/retention/archiver.py
+++ b/src/luthien_proxy/retention/archiver.py
@@ -164,8 +164,7 @@ class S3ConversationArchiver:
         """Initialize archiver. Validates encryption + sizing up-front."""
         if encryption_mode not in VALID_ENCRYPTION_MODES:
             raise ValueError(
-                f"encryption_mode={encryption_mode!r} is not valid. "
-                f"Must be one of: {sorted(VALID_ENCRYPTION_MODES)}"
+                f"encryption_mode={encryption_mode!r} is not valid. Must be one of: {sorted(VALID_ENCRYPTION_MODES)}"
             )
         if encryption_mode == "aws:kms" and not kms_key_id:
             raise ValueError(
@@ -265,14 +264,12 @@ class S3ConversationArchiver:
         cols = _select_clause(_CALL_COLUMNS)
         if last_call_id is None:
             return await db_conn.fetch(
-                f"SELECT {cols} FROM conversation_calls"
-                " WHERE created_at < $1 ORDER BY call_id LIMIT $2",
+                f"SELECT {cols} FROM conversation_calls WHERE created_at < $1 ORDER BY call_id LIMIT $2",
                 cutoff,
                 self.batch_size,
             )
         return await db_conn.fetch(
-            f"SELECT {cols} FROM conversation_calls"
-            " WHERE created_at < $1 AND call_id > $2 ORDER BY call_id LIMIT $3",
+            f"SELECT {cols} FROM conversation_calls WHERE created_at < $1 AND call_id > $2 ORDER BY call_id LIMIT $3",
             cutoff,
             last_call_id,
             self.batch_size,
@@ -308,12 +305,8 @@ class S3ConversationArchiver:
         """Build per-call JSONL lines for one batch of call rows."""
         call_ids = [row["call_id"] for row in call_rows]
         events = await self._fetch_children(db_conn, "conversation_events", _EVENT_COLUMNS, call_ids)
-        policy_events = await self._fetch_children(
-            db_conn, "policy_events", _POLICY_EVENT_COLUMNS, call_ids
-        )
-        judge_decisions = await self._fetch_children(
-            db_conn, "conversation_judge_decisions", _JUDGE_COLUMNS, call_ids
-        )
+        policy_events = await self._fetch_children(db_conn, "policy_events", _POLICY_EVENT_COLUMNS, call_ids)
+        judge_decisions = await self._fetch_children(db_conn, "conversation_judge_decisions", _JUDGE_COLUMNS, call_ids)
         lines: list[str] = []
         for row in call_rows:
             cid = row["call_id"]

--- a/src/luthien_proxy/retention/purger.py
+++ b/src/luthien_proxy/retention/purger.py
@@ -136,8 +136,7 @@ class ConversationPurger:
         """
         if last_call_id is None:
             rows = await conn.fetch(  # type: ignore[attr-defined]
-                "SELECT call_id FROM conversation_calls"
-                " WHERE created_at < $1 ORDER BY call_id LIMIT $2",
+                "SELECT call_id FROM conversation_calls WHERE created_at < $1 ORDER BY call_id LIMIT $2",
                 cutoff,
                 batch_size,
             )
@@ -171,16 +170,13 @@ class ConversationPurger:
         while True:
             try:
                 async with self._db_pool.connection() as conn:
-                    call_ids = await self._fetch_call_ids_batch(
-                        conn, cutoff, last_call_id, _DELETE_CHUNK_SIZE
-                    )
+                    call_ids = await self._fetch_call_ids_batch(conn, cutoff, last_call_id, _DELETE_CHUNK_SIZE)
                 if not call_ids:
                     break
                 total += await self._delete_by_call_ids(call_ids)
             except Exception:
                 logger.exception(
-                    "Cutoff-DELETE failed on batch %d; stopping. "
-                    "%d records deleted in earlier batches of this run.",
+                    "Cutoff-DELETE failed on batch %d; stopping. %d records deleted in earlier batches of this run.",
                     batch_index,
                     total,
                 )

--- a/tests/luthien_proxy/unit_tests/automated_maintenance/conftest.py
+++ b/tests/luthien_proxy/unit_tests/automated_maintenance/conftest.py
@@ -11,6 +11,4 @@ from __future__ import annotations
 from pathlib import Path
 
 # repo_root / scripts / automated_maintenance / lib
-AUTOMATED_MAINTENANCE_LIB = (
-    Path(__file__).resolve().parents[4] / "scripts" / "automated_maintenance" / "lib"
-)
+AUTOMATED_MAINTENANCE_LIB = Path(__file__).resolve().parents[4] / "scripts" / "automated_maintenance" / "lib"

--- a/tests/luthien_proxy/unit_tests/automated_maintenance/test_dashboard.py
+++ b/tests/luthien_proxy/unit_tests/automated_maintenance/test_dashboard.py
@@ -8,7 +8,6 @@ import sys
 from pathlib import Path
 
 import pytest
-
 from tests.luthien_proxy.unit_tests.automated_maintenance.conftest import (
     AUTOMATED_MAINTENANCE_LIB,
 )

--- a/tests/luthien_proxy/unit_tests/automated_maintenance/test_path_gate.py
+++ b/tests/luthien_proxy/unit_tests/automated_maintenance/test_path_gate.py
@@ -6,7 +6,6 @@ import importlib.util
 import sys
 
 import pytest
-
 from tests.luthien_proxy.unit_tests.automated_maintenance.conftest import (
     AUTOMATED_MAINTENANCE_LIB,
 )

--- a/tests/luthien_proxy/unit_tests/policies/test_dogfood_safety_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_dogfood_safety_policy.py
@@ -393,9 +393,7 @@ class TestFailSecureOnMalformedInput:
             cast(MessageStreamEvent, _tool_delta(0, '{"command":"docker compose down"')), ctx
         )
         await policy.on_anthropic_stream_event(cast(MessageStreamEvent, _block_stop(0)), ctx)
-        emitted = await policy.on_anthropic_stream_event(
-            cast(MessageStreamEvent, message_delta("tool_use")), ctx
-        )
+        emitted = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, message_delta("tool_use")), ctx)
 
         # First emitted block must be the blocked-text replacement, not a tool_use.
         start_event = emitted[0]

--- a/tests/luthien_proxy/unit_tests/policies/test_dogfood_safety_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_dogfood_safety_policy.py
@@ -20,8 +20,8 @@ from tests.luthien_proxy.unit_tests.policies.anthropic_event_builders import mes
 from luthien_proxy.policies.dogfood_safety_policy import (
     DogfoodSafetyConfig,
     DogfoodSafetyPolicy,
-    _BufferedAnthropicToolUse,
 )
+from luthien_proxy.policy_core import ToolCallStreamBuffer
 from luthien_proxy.policy_core.policy_context import PolicyContext
 
 
@@ -411,10 +411,14 @@ class TestStateCleanup:
         policy = _make_policy()
         policy_ctx = _make_context("txn-456")
 
-        policy._anthropic_buffered_tool_uses(policy_ctx)[0] = _BufferedAnthropicToolUse(id="a", name="test")
-        policy._anthropic_buffered_tool_uses(policy_ctx)[1] = _BufferedAnthropicToolUse(id="b", name="test2")
+        # Drive a tool_use through the stream to create the buffer in request state.
+        await policy.on_anthropic_stream_event(cast(MessageStreamEvent, _tool_start(0)), policy_ctx)
+        await policy.on_anthropic_stream_event(
+            cast(MessageStreamEvent, _tool_delta(0, '{"command":"docker compose down"}')), policy_ctx
+        )
+        await policy.on_anthropic_stream_event(cast(MessageStreamEvent, _block_stop(0)), policy_ctx)
 
+        # Buffer exists before cleanup, gone after.
+        assert policy_ctx.get_request_state(policy, ToolCallStreamBuffer, lambda: ToolCallStreamBuffer(lambda _: []))  # type: ignore[arg-type,return-value]
         await policy.on_anthropic_streaming_policy_complete(policy_ctx)
-
-        # State should be recreated empty after cleanup.
-        assert policy._anthropic_buffered_tool_uses(policy_ctx) == {}
+        assert policy_ctx.pop_request_state(policy, ToolCallStreamBuffer) is None

--- a/tests/luthien_proxy/unit_tests/policies/test_dogfood_safety_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_dogfood_safety_policy.py
@@ -368,6 +368,42 @@ class TestStreamingStopReasonCorrection:
 
 
 # ============================================================================
+# Fail-secure on malformed input
+# ============================================================================
+
+
+class TestFailSecureOnMalformedInput:
+    """Streaming tool_use with malformed input_json must still match dangerous patterns.
+
+    Regression: when `BufferedToolCall.input_json` fails to parse as JSON, the
+    parsed-dict representation is `{"_raw": <string>}`. A safety policy that
+    extracted `tool_input["command"]` would see an empty string and fail open.
+    The transform falls back to the raw text in that case.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dangerous_command_in_malformed_json_still_blocked(self):
+        policy = _make_policy()
+        ctx = _make_context()
+
+        # Truncated JSON: valid-up-to-here but no closing brace. json.loads will fail;
+        # the regex must still match `docker compose down` in the raw text.
+        await policy.on_anthropic_stream_event(cast(MessageStreamEvent, _tool_start(0)), ctx)
+        await policy.on_anthropic_stream_event(
+            cast(MessageStreamEvent, _tool_delta(0, '{"command":"docker compose down"')), ctx
+        )
+        await policy.on_anthropic_stream_event(cast(MessageStreamEvent, _block_stop(0)), ctx)
+        emitted = await policy.on_anthropic_stream_event(
+            cast(MessageStreamEvent, message_delta("tool_use")), ctx
+        )
+
+        # First emitted block must be the blocked-text replacement, not a tool_use.
+        start_event = emitted[0]
+        assert isinstance(start_event, RawContentBlockStartEvent)
+        assert start_event.content_block.type == "text"
+
+
+# ============================================================================
 # Configuration
 # ============================================================================
 
@@ -411,14 +447,13 @@ class TestStateCleanup:
         policy = _make_policy()
         policy_ctx = _make_context("txn-456")
 
-        # Drive a tool_use through the stream to create the buffer in request state.
+        # Drive a tool_use through the stream to populate request state.
         await policy.on_anthropic_stream_event(cast(MessageStreamEvent, _tool_start(0)), policy_ctx)
         await policy.on_anthropic_stream_event(
             cast(MessageStreamEvent, _tool_delta(0, '{"command":"docker compose down"}')), policy_ctx
         )
         await policy.on_anthropic_stream_event(cast(MessageStreamEvent, _block_stop(0)), policy_ctx)
 
-        # Buffer exists before cleanup, gone after.
-        assert policy_ctx.get_request_state(policy, ToolCallStreamBuffer, lambda: ToolCallStreamBuffer(lambda _: []))  # type: ignore[arg-type,return-value]
+        # Cleanup must remove a populated buffer (not just no-op on empty state).
         await policy.on_anthropic_streaming_policy_complete(policy_ctx)
         assert policy_ctx.pop_request_state(policy, ToolCallStreamBuffer) is None

--- a/tests/luthien_proxy/unit_tests/policies/test_tool_call_judge_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_tool_call_judge_policy.py
@@ -681,18 +681,14 @@ class TestStateCleanup:
 
     @pytest.mark.asyncio
     async def test_streaming_policy_complete_pops_state(self):
-        """after calling on_anthropic_streaming_policy_complete, the buffer is removed."""
+        """on_anthropic_streaming_policy_complete must remove a populated buffer."""
         policy = _make_policy()
         ctx = _make_context()
 
-        # Drive a tool_use start to create the buffer in request state.
+        # Drive a tool_use start to populate request state with a buffer.
         await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
 
-        # Buffer exists before cleanup.
-        assert ctx.pop_request_state(policy, ToolCallStreamBuffer) is not None
-
-        # After cleanup, no buffer remains. Drive another event and confirm a
-        # fresh buffer is constructed instead of reusing the prior one.
+        # Cleanup must remove the populated buffer (not just no-op on empty state).
         await policy.on_anthropic_streaming_policy_complete(ctx)
         assert ctx.pop_request_state(policy, ToolCallStreamBuffer) is None
 

--- a/tests/luthien_proxy/unit_tests/policies/test_tool_call_judge_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_tool_call_judge_policy.py
@@ -36,6 +36,7 @@ from luthien_proxy.policies.tool_call_judge_policy import (
     ToolCallJudgePolicy,
 )
 from luthien_proxy.policies.tool_call_judge_utils import JudgeResult
+from luthien_proxy.policy_core import ToolCallStreamBuffer
 from luthien_proxy.policy_core.policy_context import PolicyContext
 
 # ============================================================================
@@ -89,40 +90,45 @@ class TestStreamingToolPassThrough:
 
     @pytest.mark.asyncio
     async def test_tool_allowed_emits_full_block(self):
-        """on block_stop, allowed tool emits start + json_delta + stop."""
+        """Allowed tool reconstructed at message_delta: start + json_delta + stop, then message_delta."""
         policy = _make_policy()
         ctx = _make_context()
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.return_value = None  # allowed
 
-            # Start is suppressed
-            await policy.on_anthropic_stream_event(
-                cast(MessageStreamEvent, tool_start(0, tool_id="toolu_123", name="Bash")), ctx
+            assert (
+                await policy.on_anthropic_stream_event(
+                    cast(MessageStreamEvent, tool_start(0, tool_id="toolu_123", name="Bash")), ctx
+                )
+                == []
             )
-
-            # Delta is buffered
-            await policy.on_anthropic_stream_event(
-                cast(MessageStreamEvent, tool_delta('{"command":"echo hello"}', 0)), ctx
+            assert (
+                await policy.on_anthropic_stream_event(
+                    cast(MessageStreamEvent, tool_delta('{"command":"echo hello"}', 0)), ctx
+                )
+                == []
             )
+            assert await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx) == []
 
-            # Stop triggers reconstruction
-            stop_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+            # Tool emitted at message_delta.
+            emitted = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, message_delta("tool_use")), ctx)
 
-            assert event_types(stop_events) == ["content_block_start", "content_block_delta", "content_block_stop"]
-
-            # Verify reconstructed ToolUseBlock has correct id/name
-            start_event = stop_events[0]
+            assert event_types(emitted) == [
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+            ]
+            start_event = emitted[0]
             assert isinstance(start_event, RawContentBlockStartEvent)
             assert isinstance(start_event.content_block, ToolUseBlock)
             assert start_event.content_block.id == "toolu_123"
             assert start_event.content_block.name == "Bash"
-
-            # Verify buffered JSON is in delta
-            delta_event = stop_events[1]
+            delta_event = emitted[1]
             assert isinstance(delta_event, RawContentBlockDeltaEvent)
             assert isinstance(delta_event.delta, InputJSONDelta)
-            assert delta_event.delta.partial_json == '{"command":"echo hello"}'
+            assert delta_event.delta.partial_json == '{"command": "echo hello"}'
 
 
 # ============================================================================
@@ -135,58 +141,56 @@ class TestStreamingToolBlocked:
 
     @pytest.mark.asyncio
     async def test_tool_blocked_emits_text_replacement(self):
-        """blocked tool emits text start + text_delta + stop (not a bare stop)."""
+        """Blocked tool emits text start + text_delta + stop at message_delta."""
         policy = _make_policy()
         ctx = _make_context()
 
         judge_result = JudgeResult(probability=0.9, explanation="dangerous operation", prompt=[], response_text="")
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.return_value = judge_result
 
-            # Start is suppressed
             await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0, name="Bash")), ctx)
-
-            # Delta is buffered
             await policy.on_anthropic_stream_event(
                 cast(MessageStreamEvent, tool_delta('{"command":"rm -rf /"}', 0)), ctx
             )
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
 
-            # Stop returns text block replacement
-            stop_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+            emitted = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, message_delta("tool_use")), ctx)
 
-            assert event_types(stop_events) == ["content_block_start", "content_block_delta", "content_block_stop"]
-
-            # Verify it's a text block
-            start_event = stop_events[0]
+            assert event_types(emitted[:3]) == [
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+            ]
+            start_event = emitted[0]
             assert isinstance(start_event, RawContentBlockStartEvent)
             assert isinstance(start_event.content_block, TextBlock)
-
-            # Verify blocked message contains tool name and explanation
-            delta_event = stop_events[1]
+            delta_event = emitted[1]
             assert isinstance(delta_event, RawContentBlockDeltaEvent)
             assert isinstance(delta_event.delta, TextDelta)
             assert "Bash" in delta_event.delta.text
             assert "dangerous operation" in delta_event.delta.text
 
     @pytest.mark.asyncio
-    async def test_blocked_block_index_tracked(self):
-        """after blocking, the index is in _anthropic_blocked_blocks(context)."""
+    async def test_blocked_tool_produces_text_not_tool_use(self):
+        """Blocking is observable in the final emitted content: text block, no tool_use."""
         policy = _make_policy()
         ctx = _make_context()
 
         judge_result = JudgeResult(probability=0.9, explanation="blocked", prompt=[], response_text="")
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.return_value = judge_result
 
             await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
             await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"x":1}', 0)), ctx)
             await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+            emitted = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, message_delta("tool_use")), ctx)
 
-            # Verify index 0 is in blocked set
-            blocked_blocks = policy._anthropic_blocked_blocks(ctx)
-            assert 0 in blocked_blocks
+            start_event = emitted[0]
+            assert isinstance(start_event, RawContentBlockStartEvent)
+            assert isinstance(start_event.content_block, TextBlock)
 
 
 # ============================================================================
@@ -268,7 +272,7 @@ class TestStreamingJudgeFailure:
 
     @pytest.mark.asyncio
     async def test_judge_exception_returns_high_probability(self):
-        """When _evaluate_and_maybe_block_anthropic returns high-probability result, tool is blocked."""
+        """When _evaluate_and_maybe_block returns high-probability result, tool is blocked."""
         policy = _make_policy()
         ctx = _make_context()
 
@@ -280,17 +284,20 @@ class TestStreamingJudgeFailure:
             response_text="",
         )
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.return_value = judge_result
 
             await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
             await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"cmd":"dangerous"}', 0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+            emitted = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, message_delta("tool_use")), ctx)
 
-            stop_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
-
-            # Tool is blocked (replaced with text)
-            assert event_types(stop_events) == ["content_block_start", "content_block_delta", "content_block_stop"]
-            delta = stop_events[1]
+            assert event_types(emitted[:3]) == [
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+            ]
+            delta = emitted[1]
             assert isinstance(delta, RawContentBlockDeltaEvent)
             assert "evaluation failed" in delta.delta.text.lower()
 
@@ -305,47 +312,64 @@ class TestStreamingMultipleTools:
 
     @pytest.mark.asyncio
     async def test_mixed_tools_one_allowed_one_blocked(self):
-        """Two tool blocks at different indices, one allowed and one blocked."""
+        """Two tool blocks at different indices: one allowed, one blocked.
+
+        Both replacements are emitted at message_delta in upstream order:
+        index 0 → ToolUseBlock (allowed), index 1 → TextBlock (blocked).
+        """
         policy = _make_policy()
         ctx = _make_context()
 
-        # First tool: allowed
-        judge_result_allowed = None
-        # Second tool: blocked
         judge_result_blocked = JudgeResult(probability=0.8, explanation="harmful", prompt=[], response_text="")
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
-            mock_eval.side_effect = [judge_result_allowed, judge_result_blocked]
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
+            mock_eval.side_effect = [None, judge_result_blocked]
 
-            # Tool at index 0 — allowed
-            await policy.on_anthropic_stream_event(
-                cast(MessageStreamEvent, tool_start(0, tool_id="toolu_1", name="Tool1")), ctx
+            # Index 0 — allowed
+            assert (
+                await policy.on_anthropic_stream_event(
+                    cast(MessageStreamEvent, tool_start(0, tool_id="toolu_1", name="Tool1")), ctx
+                )
+                == []
             )
-            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"param":"value"}', 0)), ctx)
-            stop_0 = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+            assert (
+                await policy.on_anthropic_stream_event(
+                    cast(MessageStreamEvent, tool_delta('{"param":"value"}', 0)), ctx
+                )
+                == []
+            )
+            assert await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx) == []
 
-            # Tool at index 0 was allowed, so we get full reconstruction
-            assert event_types(stop_0) == ["content_block_start", "content_block_delta", "content_block_stop"]
-            start_0 = stop_0[0]
+            # Index 1 — blocked
+            assert (
+                await policy.on_anthropic_stream_event(
+                    cast(MessageStreamEvent, tool_start(1, tool_id="toolu_2", name="Tool2")), ctx
+                )
+                == []
+            )
+            assert (
+                await policy.on_anthropic_stream_event(
+                    cast(MessageStreamEvent, tool_delta('{"param":"dangerous"}', 1)), ctx
+                )
+                == []
+            )
+            assert await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(1)), ctx) == []
+
+            emitted = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, message_delta("tool_use")), ctx)
+
+            # 2 blocks × (start + delta + stop) + message_delta = 7 events
+            assert len(emitted) == 7
+            # First block: allowed → ToolUseBlock with original name
+            start_0 = emitted[0]
             assert isinstance(start_0, RawContentBlockStartEvent)
             assert isinstance(start_0.content_block, ToolUseBlock)
             assert start_0.content_block.name == "Tool1"
-
-            # Tool at index 1 — blocked
-            await policy.on_anthropic_stream_event(
-                cast(MessageStreamEvent, tool_start(1, tool_id="toolu_2", name="Tool2")), ctx
-            )
-            await policy.on_anthropic_stream_event(
-                cast(MessageStreamEvent, tool_delta('{"param":"dangerous"}', 1)), ctx
-            )
-            stop_1 = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(1)), ctx)
-
-            # Tool at index 1 was blocked, so we get text replacement
-            assert event_types(stop_1) == ["content_block_start", "content_block_delta", "content_block_stop"]
-            start_1 = stop_1[0]
+            # Second block: blocked → TextBlock containing tool name
+            start_1 = emitted[3]
             assert isinstance(start_1, RawContentBlockStartEvent)
             assert isinstance(start_1.content_block, TextBlock)
-            delta_1 = stop_1[1]
+            delta_1 = emitted[4]
+            assert isinstance(delta_1, RawContentBlockDeltaEvent)
             assert isinstance(delta_1.delta, TextDelta)
             assert "Tool2" in delta_1.delta.text
 
@@ -371,7 +395,7 @@ class TestStreamingStopReasonCorrection:
 
         judge_result = JudgeResult(probability=0.9, explanation="harmful", prompt=[], response_text="")
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.return_value = judge_result
 
             await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
@@ -392,7 +416,7 @@ class TestStreamingStopReasonCorrection:
         policy = _make_policy()
         ctx = _make_context()
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.return_value = None  # allowed
 
             await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
@@ -413,7 +437,7 @@ class TestStreamingStopReasonCorrection:
         policy = _make_policy()
         ctx = _make_context()
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.side_effect = [
                 None,  # index 0 allowed
                 JudgeResult(probability=0.9, explanation="harmful", prompt=[], response_text=""),  # index 1 blocked
@@ -458,7 +482,7 @@ class TestStreamingStopReasonCorrection:
 
         judge_result = JudgeResult(probability=0.9, explanation="harmful", prompt=[], response_text="")
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.return_value = judge_result
 
             await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
@@ -538,7 +562,7 @@ class TestNonStreamingResponse:
             "stop_reason": "tool_use",
         }
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.return_value = None  # allowed
 
             result = await policy.on_anthropic_response(response, ctx)
@@ -561,7 +585,7 @@ class TestNonStreamingResponse:
 
         judge_result = JudgeResult(probability=0.9, explanation="destructive", prompt=[], response_text="")
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.return_value = judge_result
 
             result = await policy.on_anthropic_response(response, ctx)
@@ -585,7 +609,7 @@ class TestNonStreamingResponse:
 
         judge_result = JudgeResult(probability=0.9, explanation="blocked", prompt=[], response_text="")
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.return_value = judge_result
 
             result = await policy.on_anthropic_response(response, ctx)
@@ -607,7 +631,7 @@ class TestNonStreamingResponse:
         }
 
         # First tool allowed, second blocked
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.side_effect = [
                 None,  # Tool1 allowed
                 JudgeResult(probability=0.9, explanation="blocked", prompt=[], response_text=""),  # Tool2 blocked
@@ -634,7 +658,7 @@ class TestNonStreamingResponse:
 
         judge_result = JudgeResult(probability=0.9, explanation="destructive", prompt=[], response_text="")
 
-        with patch.object(policy, "_evaluate_and_maybe_block_anthropic", new_callable=AsyncMock) as mock_eval:
+        with patch.object(policy, "_evaluate_and_maybe_block", new_callable=AsyncMock) as mock_eval:
             mock_eval.return_value = judge_result
 
             result = await policy.on_anthropic_response(response, ctx)
@@ -657,23 +681,20 @@ class TestStateCleanup:
 
     @pytest.mark.asyncio
     async def test_streaming_policy_complete_pops_state(self):
-        """after calling on_anthropic_streaming_policy_complete, old state is removed."""
+        """after calling on_anthropic_streaming_policy_complete, the buffer is removed."""
         policy = _make_policy()
         ctx = _make_context()
 
-        # Buffer a tool to create non-empty state
+        # Drive a tool_use start to create the buffer in request state.
         await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
 
-        state_before = policy._anthropic_state(ctx)
-        assert 0 in state_before.buffered_tool_uses
+        # Buffer exists before cleanup.
+        assert ctx.pop_request_state(policy, ToolCallStreamBuffer) is not None
 
-        # Clean up
+        # After cleanup, no buffer remains. Drive another event and confirm a
+        # fresh buffer is constructed instead of reusing the prior one.
         await policy.on_anthropic_streaming_policy_complete(ctx)
-
-        # get_request_state returns a new object — the old one was removed
-        state_after = policy._anthropic_state(ctx)
-        assert state_after is not state_before
-        assert 0 not in state_after.buffered_tool_uses
+        assert ctx.pop_request_state(policy, ToolCallStreamBuffer) is None
 
 
 # ============================================================================
@@ -694,7 +715,7 @@ class TestBlockedMessageFormatting:
         }
         judge_result = JudgeResult(probability=0.95, explanation="destructive operation", prompt=[], response_text="")
 
-        message = policy._format_anthropic_blocked_message(tool_call, judge_result)
+        message = policy._format_blocked_message(tool_call, judge_result)
 
         assert "Bash" in message
         assert "rm -rf /" in message
@@ -708,7 +729,7 @@ class TestBlockedMessageFormatting:
         tool_call = {"name": "Python", "arguments": "{}"}
         judge_result = JudgeResult(probability=0.75, explanation="explanation", prompt=[], response_text="")
 
-        message = policy._format_anthropic_blocked_message(tool_call, judge_result)
+        message = policy._format_blocked_message(tool_call, judge_result)
 
         assert message == "BLOCKED: Python with probability 0.8"
 
@@ -722,7 +743,7 @@ class TestBlockedMessageFormatting:
         tool_call = {"name": "Tool", "arguments": long_args}
         judge_result = JudgeResult(probability=0.5, explanation="test", prompt=[], response_text="")
 
-        message = policy._format_anthropic_blocked_message(tool_call, judge_result)
+        message = policy._format_blocked_message(tool_call, judge_result)
 
         # Truncated prefix appears in message, but full args do not
         assert long_args[:TOOL_ARGS_TRUNCATION_LENGTH] in message
@@ -735,7 +756,7 @@ class TestBlockedMessageFormatting:
         tool_call = {"name": "Tool", "arguments": "{}"}
         judge_result = JudgeResult(probability=0.9, explanation="", prompt=[], response_text="")
 
-        message = policy._format_anthropic_blocked_message(tool_call, judge_result)
+        message = policy._format_blocked_message(tool_call, judge_result)
 
         assert "Tool" in message
         assert "No explanation provided" in message

--- a/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py
+++ b/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py
@@ -430,36 +430,6 @@ class TestNonStreamingTransform:
         assert result.get("stop_reason") == "end_turn"
 
 
-class TestNonStreamingPassthroughPreservesExtraFields:
-    @pytest.mark.asyncio
-    async def test_passthrough_preserves_unknown_fields_on_original_tool_use_block(self):
-        """Allowed tool_use on non-streaming path must preserve fields outside
-        {type, id, name, input} (e.g. future Anthropic schema additions).
-        """
-        original_block = {
-            "type": "tool_use",
-            "id": "t1",
-            "name": "Bash",
-            "input": {"command": "ls"},
-            "future_field": "should_survive_passthrough",
-        }
-        response = cast(
-            AnthropicResponse,
-            {
-                "id": "msg_1",
-                "type": "message",
-                "role": "assistant",
-                "content": [original_block],
-                "model": "claude-haiku-4-5",
-                "stop_reason": "tool_use",
-                "usage": {"input_tokens": 10, "output_tokens": 5},
-            },
-        )
-        result = await transform_anthropic_response(response, _passthrough)
-        assert result["content"][0] == original_block
-        assert result["content"][0].get("future_field") == "should_survive_passthrough"
-
-
 class TestNonStreamingCountMismatchInterleaved:
     @pytest.mark.asyncio
     async def test_single_output_replaces_two_tools_with_text_between(self):

--- a/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py
+++ b/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py
@@ -349,6 +349,62 @@ class TestNonStreamingTransform:
         ]
 
     @pytest.mark.asyncio
+    async def test_interleaved_text_and_tool_preserves_positions_when_count_matches(self):
+        """1-to-1 transform output preserves original tool_use positions in non-streaming."""
+        response = cast(
+            AnthropicResponse,
+            {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "first"},
+                    {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+                    {"type": "text", "text": "middle"},
+                    {"type": "tool_use", "id": "t2", "name": "Read", "input": {"path": "/x"}},
+                    {"type": "text", "text": "last"},
+                ],
+                "model": "claude-haiku-4-5",
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        )
+
+        async def block_each(calls):
+            return [cast(AnthropicContentBlock, {"type": "text", "text": f"BLOCKED {c.name}"}) for c in calls]
+
+        result = await transform_anthropic_response(response, block_each)
+        assert result["content"] == [
+            {"type": "text", "text": "first"},
+            {"type": "text", "text": "BLOCKED Bash"},
+            {"type": "text", "text": "middle"},
+            {"type": "text", "text": "BLOCKED Read"},
+            {"type": "text", "text": "last"},
+        ]
+        assert result.get("stop_reason") == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_identity_fast_path_returns_original_object_for_passthrough(self):
+        """Pure-passthrough transform with unchanged stop_reason returns the same response object."""
+        response = cast(
+            AnthropicResponse,
+            {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "hello"},
+                    {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+                ],
+                "model": "claude-haiku-4-5",
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        )
+        result = await transform_anthropic_response(response, _passthrough)
+        assert result is response
+
+    @pytest.mark.asyncio
     async def test_multiple_tool_use_blocks_replaced_with_single_output_at_first_position(self):
         response = cast(
             AnthropicResponse,

--- a/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py
+++ b/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py
@@ -1,0 +1,391 @@
+"""Unit tests for ToolCallStreamBuffer and transform_anthropic_response."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from anthropic.types import (
+    InputJSONDelta,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawMessageStopEvent,
+    TextBlock,
+    TextDelta,
+    ToolUseBlock,
+)
+from anthropic.types.raw_message_delta_event import Delta as MessageDeltaPayload
+from anthropic.types.raw_message_start_event import Message as RawMessage
+
+from luthien_proxy.llm.types.anthropic import AnthropicContentBlock, AnthropicResponse
+from luthien_proxy.policy_core import (
+    BufferedToolCall,
+    ToolCallStreamBuffer,
+    transform_anthropic_response,
+)
+
+
+def _text_start(index: int) -> RawContentBlockStartEvent:
+    return RawContentBlockStartEvent(
+        type="content_block_start", index=index, content_block=TextBlock(type="text", text="")
+    )
+
+
+def _text_delta(index: int, text: str) -> RawContentBlockDeltaEvent:
+    return RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=TextDelta(type="text_delta", text=text),
+    )
+
+
+def _block_stop(index: int) -> RawContentBlockStopEvent:
+    return RawContentBlockStopEvent(type="content_block_stop", index=index)
+
+
+def _tool_start(index: int, tool_id: str, name: str) -> RawContentBlockStartEvent:
+    return RawContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=ToolUseBlock(type="tool_use", id=tool_id, name=name, input={}),
+    )
+
+
+def _json_delta(index: int, partial: str) -> RawContentBlockDeltaEvent:
+    return RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=InputJSONDelta(type="input_json_delta", partial_json=partial),
+    )
+
+
+def _message_delta(stop_reason: str | None) -> RawMessageDeltaEvent:
+    return RawMessageDeltaEvent(
+        type="message_delta",
+        delta=MessageDeltaPayload(stop_reason=stop_reason, stop_sequence=None),
+        usage={"input_tokens": 10, "output_tokens": 5},  # type: ignore[arg-type]
+    )
+
+
+async def _passthrough(tool_calls: list[BufferedToolCall]) -> list[AnthropicContentBlock]:
+    return [tc.as_content_block() for tc in tool_calls]
+
+
+async def _block_all(_: list[BufferedToolCall]) -> list[AnthropicContentBlock]:
+    return [cast(AnthropicContentBlock, {"type": "text", "text": "BLOCKED"})]
+
+
+async def _drop_all(_: list[BufferedToolCall]) -> list[AnthropicContentBlock]:
+    return []
+
+
+class TestBufferedToolCall:
+    def test_input_parses_valid_json(self):
+        tc = BufferedToolCall(id="t1", name="Bash", input_json='{"command": "ls"}')
+        assert tc.input == {"command": "ls"}
+
+    def test_input_empty_returns_empty_dict(self):
+        assert BufferedToolCall(id="t1", name="Bash").input == {}
+
+    def test_input_malformed_wraps_in_raw(self):
+        tc = BufferedToolCall(id="t1", name="Bash", input_json='{"command":')
+        assert tc.input == {"_raw": '{"command":'}
+
+    def test_input_non_dict_wraps_in_raw(self):
+        tc = BufferedToolCall(id="t1", name="Bash", input_json="[1, 2, 3]")
+        assert tc.input == {"_raw": "[1, 2, 3]"}
+
+    def test_as_content_block_shape(self):
+        tc = BufferedToolCall(id="t1", name="Bash", input_json='{"command": "ls"}')
+        assert tc.as_content_block() == {
+            "type": "tool_use",
+            "id": "t1",
+            "name": "Bash",
+            "input": {"command": "ls"},
+        }
+
+
+class TestStreamingPassthroughNoToolUse:
+    @pytest.mark.asyncio
+    async def test_text_only_response_passes_through_unchanged(self):
+        buf = ToolCallStreamBuffer(_passthrough)
+        events = []
+        events += await buf.process(_text_start(0))
+        events += await buf.process(_text_delta(0, "hello"))
+        events += await buf.process(_block_stop(0))
+        events += await buf.process(_message_delta("end_turn"))
+
+        assert len(events) == 4
+        assert isinstance(events[0], RawContentBlockStartEvent)
+        assert events[0].index == 0
+        assert isinstance(events[1], RawContentBlockDeltaEvent)
+        assert events[1].index == 0
+        assert isinstance(events[2], RawContentBlockStopEvent)
+        assert events[2].index == 0
+        assert isinstance(events[3], RawMessageDeltaEvent)
+        assert events[3].delta.stop_reason == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_transform_not_called_when_no_tool_use(self):
+        called = False
+
+        async def transform(calls):
+            nonlocal called
+            called = True
+            return []
+
+        buf = ToolCallStreamBuffer(transform)
+        await buf.process(_text_start(0))
+        await buf.process(_text_delta(0, "hi"))
+        await buf.process(_block_stop(0))
+        await buf.process(_message_delta("end_turn"))
+        assert called is False
+
+
+class TestStreamingToolUseBuffering:
+    @pytest.mark.asyncio
+    async def test_passthrough_transform_reconstructs_tool_use(self):
+        buf = ToolCallStreamBuffer(_passthrough)
+        await buf.process(_tool_start(0, "tu_1", "Bash"))
+        await buf.process(_json_delta(0, '{"command":'))
+        await buf.process(_json_delta(0, ' "ls"}'))
+        await buf.process(_block_stop(0))
+        emitted_after_delta = await buf.process(_message_delta("tool_use"))
+
+        assert len(emitted_after_delta) == 4
+        start, delta, stop, msg_delta = emitted_after_delta
+        assert isinstance(start, RawContentBlockStartEvent)
+        assert isinstance(start.content_block, ToolUseBlock)
+        assert start.content_block.id == "tu_1"
+        assert start.content_block.name == "Bash"
+        assert start.index == 0
+        assert isinstance(delta, RawContentBlockDeltaEvent)
+        assert isinstance(delta.delta, InputJSONDelta)
+        assert delta.delta.partial_json == '{"command": "ls"}'
+        assert isinstance(stop, RawContentBlockStopEvent)
+        assert stop.index == 0
+        assert isinstance(msg_delta, RawMessageDeltaEvent)
+        assert msg_delta.delta.stop_reason == "tool_use"
+
+    @pytest.mark.asyncio
+    async def test_tool_use_buffered_emits_nothing_until_message_delta(self):
+        buf = ToolCallStreamBuffer(_passthrough)
+        out_start = await buf.process(_tool_start(0, "tu_1", "Bash"))
+        out_delta = await buf.process(_json_delta(0, '{"command": "ls"}'))
+        out_stop = await buf.process(_block_stop(0))
+        assert out_start == []
+        assert out_delta == []
+        assert out_stop == []
+
+
+class TestStreamingStopReasonRewrite:
+    @pytest.mark.asyncio
+    async def test_block_all_rewrites_tool_use_to_end_turn(self):
+        buf = ToolCallStreamBuffer(_block_all)
+        await buf.process(_tool_start(0, "tu_1", "Bash"))
+        await buf.process(_json_delta(0, '{"command": "rm -rf /"}'))
+        await buf.process(_block_stop(0))
+        events = await buf.process(_message_delta("tool_use"))
+
+        msg_delta = events[-1]
+        assert isinstance(msg_delta, RawMessageDeltaEvent)
+        assert msg_delta.delta.stop_reason == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_partial_block_preserves_tool_use_stop_reason(self):
+        async def block_first_keep_rest(calls):
+            return [
+                cast(AnthropicContentBlock, {"type": "text", "text": "BLOCKED"}),
+                calls[1].as_content_block(),
+            ]
+
+        buf = ToolCallStreamBuffer(block_first_keep_rest)
+        await buf.process(_tool_start(0, "tu_1", "Bash"))
+        await buf.process(_json_delta(0, '{"command": "rm -rf /"}'))
+        await buf.process(_block_stop(0))
+        await buf.process(_tool_start(1, "tu_2", "Read"))
+        await buf.process(_json_delta(1, '{"path": "/etc/passwd"}'))
+        await buf.process(_block_stop(1))
+        events = await buf.process(_message_delta("tool_use"))
+
+        msg_delta = events[-1]
+        assert isinstance(msg_delta, RawMessageDeltaEvent)
+        assert msg_delta.delta.stop_reason == "tool_use"
+
+    @pytest.mark.asyncio
+    async def test_non_tool_use_stop_reason_not_rewritten(self):
+        buf = ToolCallStreamBuffer(_block_all)
+        await buf.process(_tool_start(0, "tu_1", "Bash"))
+        await buf.process(_json_delta(0, '{"command": "ls"}'))
+        await buf.process(_block_stop(0))
+        events = await buf.process(_message_delta("max_tokens"))
+
+        msg_delta = events[-1]
+        assert isinstance(msg_delta, RawMessageDeltaEvent)
+        assert msg_delta.delta.stop_reason == "max_tokens"
+
+
+class TestStreamingDropAllProducesNoBlocks:
+    @pytest.mark.asyncio
+    async def test_drop_all_emits_only_message_delta_with_end_turn(self):
+        buf = ToolCallStreamBuffer(_drop_all)
+        await buf.process(_tool_start(0, "tu_1", "Bash"))
+        await buf.process(_json_delta(0, '{"command": "ls"}'))
+        await buf.process(_block_stop(0))
+        events = await buf.process(_message_delta("tool_use"))
+
+        assert len(events) == 1
+        assert isinstance(events[0], RawMessageDeltaEvent)
+        assert events[0].delta.stop_reason == "end_turn"
+
+
+class TestStreamingTextThenToolOutputIndices:
+    @pytest.mark.asyncio
+    async def test_text_streams_then_tool_replacement_uses_sequential_indices(self):
+        buf = ToolCallStreamBuffer(_passthrough)
+
+        events: list = []
+        events += await buf.process(_text_start(0))
+        events += await buf.process(_text_delta(0, "thinking..."))
+        events += await buf.process(_block_stop(0))
+        events += await buf.process(_tool_start(1, "tu_1", "Bash"))
+        events += await buf.process(_json_delta(1, '{"command": "ls"}'))
+        events += await buf.process(_block_stop(1))
+        events += await buf.process(_message_delta("tool_use"))
+
+        assert events[0].index == 0  # text start
+        assert events[2].index == 0  # text stop
+        assert events[3].index == 1  # reconstructed tool_use start
+        assert events[5].index == 1  # tool_use stop
+
+
+class TestStreamingMessageStartAndStopPassThrough:
+    @pytest.mark.asyncio
+    async def test_message_start_and_stop_pass_through(self):
+        buf = ToolCallStreamBuffer(_passthrough)
+        start = RawMessageStartEvent(
+            type="message_start",
+            message=RawMessage(
+                id="msg_1",
+                type="message",
+                role="assistant",
+                model="claude-haiku-4-5",
+                content=[],
+                stop_reason=None,
+                stop_sequence=None,
+                usage={"input_tokens": 1, "output_tokens": 0},  # type: ignore[arg-type]
+            ),
+        )
+        stop = RawMessageStopEvent(type="message_stop")
+        assert await buf.process(start) == [start]
+        assert await buf.process(stop) == [stop]
+
+
+class TestNonStreamingTransform:
+    @pytest.mark.asyncio
+    async def test_no_tool_use_returns_response_unchanged(self):
+        response = cast(
+            AnthropicResponse,
+            {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "hello"}],
+                "model": "claude-haiku-4-5",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        )
+        result = await transform_anthropic_response(response, _passthrough)
+        assert result is response
+
+    @pytest.mark.asyncio
+    async def test_block_all_rewrites_stop_reason(self):
+        response = cast(
+            AnthropicResponse,
+            {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "ok"},
+                    {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+                ],
+                "model": "claude-haiku-4-5",
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        )
+        result = await transform_anthropic_response(response, _block_all)
+        assert result.get("stop_reason") == "end_turn"
+        assert result["content"] == [
+            {"type": "text", "text": "ok"},
+            {"type": "text", "text": "BLOCKED"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_passthrough_preserves_content_and_stop_reason(self):
+        response = cast(
+            AnthropicResponse,
+            {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+                ],
+                "model": "claude-haiku-4-5",
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        )
+        result = await transform_anthropic_response(response, _passthrough)
+        assert result.get("stop_reason") == "tool_use"
+        assert result["content"] == [
+            {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_multiple_tool_use_blocks_replaced_with_single_output_at_first_position(self):
+        response = cast(
+            AnthropicResponse,
+            {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "doing two things"},
+                    {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+                    {"type": "tool_use", "id": "t2", "name": "Read", "input": {"path": "/x"}},
+                ],
+                "model": "claude-haiku-4-5",
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        )
+        result = await transform_anthropic_response(response, _block_all)
+        assert result["content"] == [
+            {"type": "text", "text": "doing two things"},
+            {"type": "text", "text": "BLOCKED"},
+        ]
+        assert result.get("stop_reason") == "end_turn"
+
+
+class TestUnsupportedBlockType:
+    @pytest.mark.asyncio
+    async def test_invalid_block_type_in_transform_output_raises(self):
+        async def bad_transform(_):
+            return [cast(AnthropicContentBlock, {"type": "image", "source": {}})]
+
+        buf = ToolCallStreamBuffer(bad_transform)
+        await buf.process(_tool_start(0, "tu_1", "Bash"))
+        await buf.process(_block_stop(0))
+        with pytest.raises(ValueError, match="unsupported block type"):
+            await buf.process(_message_delta("tool_use"))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py
+++ b/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py
@@ -558,6 +558,48 @@ class TestUnsupportedBlockType:
         with pytest.raises(ValueError, match="unsupported block type"):
             await buf.process(_message_delta("tool_use"))
 
+    @pytest.mark.asyncio
+    async def test_tool_use_missing_id_or_name_raises_value_error(self):
+        async def bad_transform(_):
+            return [cast(AnthropicContentBlock, {"type": "tool_use", "input": {}})]
+
+        buf = ToolCallStreamBuffer(bad_transform)
+        await buf.process(_tool_start(0, "tu_1", "Bash"))
+        await buf.process(_block_stop(0))
+        with pytest.raises(ValueError, match="missing required 'id' or 'name'"):
+            await buf.process(_message_delta("tool_use"))
+
+
+class TestTransformContractInvocation:
+    @pytest.mark.asyncio
+    async def test_transform_called_once_with_all_tool_calls(self):
+        """The transform is invoked exactly once per response with the full list
+        of buffered tool calls — not once per content_block_stop. This is the
+        stated motivation for the message_delta-timed decision: policies that
+        need cross-tool context see all calls together.
+        """
+        invocations: list[list[BufferedToolCall]] = []
+
+        async def recording_transform(calls):
+            invocations.append(list(calls))
+            return [c.as_content_block() for c in calls]
+
+        buf = ToolCallStreamBuffer(recording_transform)
+        await buf.process(_tool_start(0, "tu_1", "Bash"))
+        await buf.process(_json_delta(0, '{"command":"ls"}'))
+        await buf.process(_block_stop(0))
+        await buf.process(_tool_start(1, "tu_2", "Read"))
+        await buf.process(_json_delta(1, '{"path":"/x"}'))
+        await buf.process(_block_stop(1))
+        await buf.process(_tool_start(2, "tu_3", "Grep"))
+        await buf.process(_json_delta(2, '{"pattern":"foo"}'))
+        await buf.process(_block_stop(2))
+        await buf.process(_message_delta("tool_use"))
+
+        assert len(invocations) == 1
+        assert len(invocations[0]) == 3
+        assert [tc.name for tc in invocations[0]] == ["Bash", "Read", "Grep"]
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py
+++ b/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py
@@ -430,6 +430,43 @@ class TestNonStreamingTransform:
         assert result.get("stop_reason") == "end_turn"
 
 
+class TestMalformedInputPassthroughPreservesRawBytes:
+    @pytest.mark.asyncio
+    async def test_malformed_json_passthrough_emits_original_bytes(self):
+        """Passthrough of a tool_use with malformed input_json must re-emit the
+        original (broken) bytes verbatim, not a {"_raw": ...} JSON normalization
+        the downstream client could erroneously accept and execute.
+        """
+        buf = ToolCallStreamBuffer(_passthrough)
+        await buf.process(_tool_start(0, "tu_1", "Bash"))
+        await buf.process(_json_delta(0, '{"command":"ls"'))  # missing closing brace
+        await buf.process(_block_stop(0))
+        emitted = await buf.process(_message_delta("tool_use"))
+
+        delta = emitted[1]
+        assert isinstance(delta, RawContentBlockDeltaEvent)
+        assert isinstance(delta.delta, InputJSONDelta)
+        assert delta.delta.partial_json == '{"command":"ls"'
+
+
+class TestUnknownUpstreamIndexDropped:
+    @pytest.mark.asyncio
+    async def test_delta_for_unseen_index_dropped(self):
+        """A delta for an index we never saw a block_start for must not pass
+        through with its raw upstream index (could collide with output indices).
+        """
+        buf = ToolCallStreamBuffer(_passthrough)
+        # Never sent a start event for index 5.
+        result = await buf.process(_text_delta(5, "stray"))
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_stop_for_unseen_index_dropped(self):
+        buf = ToolCallStreamBuffer(_passthrough)
+        result = await buf.process(_block_stop(5))
+        assert result == []
+
+
 class TestUnsupportedBlockType:
     @pytest.mark.asyncio
     async def test_invalid_block_type_in_transform_output_raises(self):

--- a/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py
+++ b/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py
@@ -430,6 +430,85 @@ class TestNonStreamingTransform:
         assert result.get("stop_reason") == "end_turn"
 
 
+class TestNonStreamingPassthroughPreservesExtraFields:
+    @pytest.mark.asyncio
+    async def test_passthrough_preserves_unknown_fields_on_original_tool_use_block(self):
+        """Allowed tool_use on non-streaming path must preserve fields outside
+        {type, id, name, input} (e.g. future Anthropic schema additions).
+        """
+        original_block = {
+            "type": "tool_use",
+            "id": "t1",
+            "name": "Bash",
+            "input": {"command": "ls"},
+            "future_field": "should_survive_passthrough",
+        }
+        response = cast(
+            AnthropicResponse,
+            {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [original_block],
+                "model": "claude-haiku-4-5",
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        )
+        result = await transform_anthropic_response(response, _passthrough)
+        assert result["content"][0] == original_block
+        assert result["content"][0].get("future_field") == "should_survive_passthrough"
+
+
+class TestNonStreamingCountMismatchInterleaved:
+    @pytest.mark.asyncio
+    async def test_single_output_replaces_two_tools_with_text_between(self):
+        """`[text, tool1, text2, tool2]` with a single-output transform produces
+        `[text, BLOCKED, text2]` — tool2's slot is removed, text2 stays.
+        """
+        response = cast(
+            AnthropicResponse,
+            {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "before"},
+                    {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+                    {"type": "text", "text": "middle"},
+                    {"type": "tool_use", "id": "t2", "name": "Read", "input": {"path": "/x"}},
+                ],
+                "model": "claude-haiku-4-5",
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        )
+        result = await transform_anthropic_response(response, _block_all)
+        assert result["content"] == [
+            {"type": "text", "text": "before"},
+            {"type": "text", "text": "BLOCKED"},
+            {"type": "text", "text": "middle"},
+        ]
+
+
+class TestDuplicateMessageDeltaPassthrough:
+    @pytest.mark.asyncio
+    async def test_second_message_delta_passes_through_unchanged(self):
+        """A second `message_delta` after the transform has fired logs and passes through.
+
+        Pinning the documented behavior so it can't silently regress.
+        """
+        buf = ToolCallStreamBuffer(_passthrough)
+        await buf.process(_tool_start(0, "tu_1", "Bash"))
+        await buf.process(_json_delta(0, '{"command":"ls"}'))
+        await buf.process(_block_stop(0))
+        await buf.process(_message_delta("tool_use"))
+
+        second = _message_delta("end_turn")
+        out = await buf.process(second)
+        assert out == [second]
+
+
 class TestMalformedInputPassthroughPreservesRawBytes:
     @pytest.mark.asyncio
     async def test_malformed_json_passthrough_emits_original_bytes(self):

--- a/tests/luthien_proxy/unit_tests/retention/test_archiver.py
+++ b/tests/luthien_proxy/unit_tests/retention/test_archiver.py
@@ -103,9 +103,7 @@ def test_archiver_init_rejects_kms_without_key_id():
 
 
 def test_archiver_init_accepts_kms_with_key_id():
-    arch = S3ConversationArchiver(
-        bucket="b", encryption_mode="aws:kms", kms_key_id="arn:aws:kms:us-east-1:0:key/x"
-    )
+    arch = S3ConversationArchiver(bucket="b", encryption_mode="aws:kms", kms_key_id="arn:aws:kms:us-east-1:0:key/x")
     assert arch._encryption_mode == "aws:kms"
 
 
@@ -121,9 +119,7 @@ def test_valid_encryption_modes_constant():
 async def _fetch_and_upload(archiver, *, conn, cutoff, last_call_id=None, run_id="run0001", batch_index=0):
     """Drive fetch_batch then upload_batch. Helper for tests that previously
     used the combined archive_one_batch API."""
-    body, archived_ids, has_more = await archiver.fetch_batch(
-        db_conn=conn, cutoff=cutoff, last_call_id=last_call_id
-    )
+    body, archived_ids, has_more = await archiver.fetch_batch(db_conn=conn, cutoff=cutoff, last_call_id=last_call_id)
     if archived_ids:
         await archiver.upload_batch(
             body=body, cutoff=cutoff, run_id=run_id, batch_index=batch_index, record_count=len(archived_ids)
@@ -179,9 +175,7 @@ async def test_fetch_batch_no_rows_short_circuits(mock_s3_client, cutoff):
     conn.fetch = AsyncMock(return_value=[])
 
     archiver = S3ConversationArchiver(bucket="b", s3_client=mock_s3_client)
-    body, archived_ids, has_more = await archiver.fetch_batch(
-        db_conn=conn, cutoff=cutoff, last_call_id=None
-    )
+    body, archived_ids, has_more = await archiver.fetch_batch(db_conn=conn, cutoff=cutoff, last_call_id=None)
 
     assert body == b""
     assert archived_ids == []
@@ -211,9 +205,7 @@ async def test_upload_batch_propagates_s3_error(mock_s3_client, cutoff):
     mock_s3_client.put_object = MagicMock(side_effect=RuntimeError("S3 down"))
     archiver = S3ConversationArchiver(bucket="b", s3_client=mock_s3_client)
     with pytest.raises(RuntimeError, match="S3 down"):
-        await archiver.upload_batch(
-            body=b'{"call":{}}\n', cutoff=cutoff, run_id="r", batch_index=0, record_count=1
-        )
+        await archiver.upload_batch(body=b'{"call":{}}\n', cutoff=cutoff, run_id="r", batch_index=0, record_count=1)
 
 
 @pytest.mark.asyncio

--- a/tests/luthien_proxy/unit_tests/retention/test_integration_sqlite.py
+++ b/tests/luthien_proxy/unit_tests/retention/test_integration_sqlite.py
@@ -69,8 +69,7 @@ async def _insert_event(
         # can encode the relative ordering they care about into the id.
         event_id = f"{call_id}-{sequence:04d}"
         await conn.execute(
-            "INSERT INTO conversation_events (id, call_id, event_type, payload)"
-            " VALUES ($1, $2, $3, $4)",
+            "INSERT INTO conversation_events (id, call_id, event_type, payload) VALUES ($1, $2, $3, $4)",
             event_id,
             call_id,
             event_type,
@@ -88,8 +87,7 @@ async def _insert_policy_event(
     pe_id = f"pe-{call_id}-{policy_class}"
     async with pool.connection() as conn:
         await conn.execute(
-            "INSERT INTO policy_events (id, call_id, policy_class, event_type, metadata)"
-            " VALUES ($1, $2, $3, $4, $5)",
+            "INSERT INTO policy_events (id, call_id, policy_class, event_type, metadata) VALUES ($1, $2, $3, $4, $5)",
             pe_id,
             call_id,
             policy_class,
@@ -234,9 +232,7 @@ async def test_purge_partial_run_archives_and_deletes_first_batch_only(sqlite_po
     the per-batch architecture."""
     now = datetime.now(UTC)
     for i in range(3):
-        await _insert_call(
-            sqlite_pool, call_id=f"old-{i}", created_at=now - timedelta(days=40 + i)
-        )
+        await _insert_call(sqlite_pool, call_id=f"old-{i}", created_at=now - timedelta(days=40 + i))
 
     s3_client = MagicMock()
     s3_client.put_object = MagicMock(side_effect=[None, RuntimeError("S3 flapped")])

--- a/tests/luthien_proxy/unit_tests/retention/test_purger.py
+++ b/tests/luthien_proxy/unit_tests/retention/test_purger.py
@@ -64,9 +64,7 @@ def _make_archiver(
     """
     archiver = MagicMock()
     archiver.new_run_id = MagicMock(return_value="testrun1")
-    archiver.fetch_batch = AsyncMock(
-        side_effect=[(b"<jsonl>", call_ids, has_more) for call_ids, has_more in batches]
-    )
+    archiver.fetch_batch = AsyncMock(side_effect=[(b"<jsonl>", call_ids, has_more) for call_ids, has_more in batches])
     if upload_side_effect is None:
         archiver.upload_batch = AsyncMock(return_value=None)
     elif isinstance(upload_side_effect, list):
@@ -142,9 +140,7 @@ async def test_fetch_failure_mid_run_preserves_earlier_batches():
     pool, conn = _make_pool()
     archiver = MagicMock()
     archiver.new_run_id = MagicMock(return_value="testrun1")
-    archiver.fetch_batch = AsyncMock(
-        side_effect=[(b"<jsonl>", ["c1", "c2"], True), RuntimeError("DB error")]
-    )
+    archiver.fetch_batch = AsyncMock(side_effect=[(b"<jsonl>", ["c1", "c2"], True), RuntimeError("DB error")])
     archiver.upload_batch = AsyncMock(return_value=None)
 
     purger = ConversationPurger(db_pool=pool, retention_days=30, archiver=archiver)
@@ -326,9 +322,7 @@ def test_cutoff_calculation():
 @pytest.mark.asyncio
 async def test_start_stop_lifecycle():
     pool, _ = _make_pool()
-    purger = ConversationPurger(
-        db_pool=pool, retention_days=30, initial_delay_seconds=0, interval_seconds=9999
-    )
+    purger = ConversationPurger(db_pool=pool, retention_days=30, initial_delay_seconds=0, interval_seconds=9999)
     purger.start()
     task_ref = purger._task
     assert task_ref is not None and not task_ref.done()
@@ -340,9 +334,7 @@ async def test_start_stop_lifecycle():
 @pytest.mark.asyncio
 async def test_start_is_idempotent():
     pool, _ = _make_pool()
-    purger = ConversationPurger(
-        db_pool=pool, retention_days=30, initial_delay_seconds=0, interval_seconds=9999
-    )
+    purger = ConversationPurger(db_pool=pool, retention_days=30, initial_delay_seconds=0, interval_seconds=9999)
     purger.start()
     first_task = purger._task
     purger.start()
@@ -353,9 +345,7 @@ async def test_start_is_idempotent():
 @pytest.mark.asyncio
 async def test_stop_then_start_creates_new_task():
     pool, _ = _make_pool()
-    purger = ConversationPurger(
-        db_pool=pool, retention_days=30, initial_delay_seconds=0, interval_seconds=9999
-    )
+    purger = ConversationPurger(db_pool=pool, retention_days=30, initial_delay_seconds=0, interval_seconds=9999)
     purger.start()
     first_task = purger._task
     await purger.stop()
@@ -382,9 +372,7 @@ async def test_loop_survives_purge_failure():
     replacing _run_loop wholesale.
     """
     pool, _ = _make_pool()
-    purger = ConversationPurger(
-        db_pool=pool, retention_days=30, initial_delay_seconds=0, interval_seconds=9999
-    )
+    purger = ConversationPurger(db_pool=pool, retention_days=30, initial_delay_seconds=0, interval_seconds=9999)
 
     call_count = {"n": 0}
     failure_done = asyncio.Event()
@@ -423,9 +411,7 @@ async def test_loop_survives_purge_failure():
 @pytest.mark.asyncio
 async def test_loop_exception_logged(caplog):
     pool, _ = _make_pool()
-    purger = ConversationPurger(
-        db_pool=pool, retention_days=30, initial_delay_seconds=0, interval_seconds=9999
-    )
+    purger = ConversationPurger(db_pool=pool, retention_days=30, initial_delay_seconds=0, interval_seconds=9999)
 
     async def failing() -> None:
         raise RuntimeError("boom")


### PR DESCRIPTION
## Summary

Supersedes #728. Extracts the Anthropic streaming tool_use buffering pattern shared by `ToolCallJudgePolicy` and `DogfoodSafetyPolicy` into a policy-agnostic abstraction:

- **`policy_core.ToolCallStreamBuffer`** — per-request streaming filter parameterized by a caller-supplied async transform `Callable[[list[BufferedToolCall]], Awaitable[list[ContentBlock]]]`. Buffers tool_use blocks, runs the transform at `message_delta` (full-context decision), emits replacement events with sequential output indices, rewrites `stop_reason` from the final content shape.
- **`policy_core.transform_anthropic_response`** — non-streaming sibling. Same `Transform` signature.

Each policy now defines only a `_make_transform(context)` closure. Per-request state, output indices, and the `stop_reason` invariant live inside the buffer and cannot be dropped.

## Behavioral change

Tool-call decisions now run at `message_delta` (when the full upstream is known) rather than per-block at `content_block_stop`. Text deltas still stream in real time. This lets policies decide with full context across all tool calls in a response — which is what enables future policies that need to see all tools together (limit total calls, block X if Y is also requested, etc.).

Caveat documented in the module docstring: upstream order `text, tool_use, text` becomes output order `text, text, <transform-output>` rather than interleaved. Acceptable for typical Claude responses where tool calls come at the end; a future `buffer_all` mode could preserve exact ordering.

## Why not #728

#728 extracted *per-event helpers* (build a start, build a delta, build a stop) but lost the `message_delta` `stop_reason` rewrite that lives across events. The cross-event invariant is the actual hard part of this code; the per-event mechanics are not. This PR factors out the state machine that owns the invariant, so a future caller cannot drop it.

## Test plan

- [x] Unit tests for `ToolCallStreamBuffer` (20 tests in `tests/luthien_proxy/unit_tests/policy_core/test_anthropic_tool_call_buffer.py`)
- [x] Existing `DogfoodSafetyPolicy` and `ToolCallJudgePolicy` unit tests updated for the new semantics (events arrive at `message_delta`)
- [x] Full unit suite: 2590 passed
- [x] `./scripts/run_e2e.sh sqlite`: 47 passed
- [x] `./scripts/run_e2e.sh mock`: 203 passed
- [x] `dev_checks.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)