### PR TITLE
fix(simple-llm): emit replacement blocks at monotonically increasing indices

### DIFF
--- a/changelog.d/fix-simple-llm-replacement-monotonic-indices.md
+++ b/changelog.d/fix-simple-llm-replacement-monotonic-indices.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**SimpleLLMPolicy: emit replacement blocks at monotonically increasing indices**: When a judge replaced one upstream content block with multiple blocks (N>1), all replacement blocks were emitted at the same index, producing an invalid Anthropic stream. Fixed by tracking `index_shift` on per-request state; replacement now emits at sequential indices and subsequent passthrough blocks are shifted to avoid collisions.

--- a/src/luthien_proxy/policies/simple_llm_policy.py
+++ b/src/luthien_proxy/policies/simple_llm_policy.py
@@ -101,6 +101,13 @@ class _SimpleLLMAnthropicState:
     # Cumulative downstream offset from multi-block replacements: when one
     # upstream block is replaced with N>1 blocks, every subsequent downstream
     # index shifts by N-1 to avoid colliding with the extra emitted blocks.
+    #
+    # Invariant: every emitted content_block_{start,delta,stop}.index equals
+    # `upstream_event.index + state.index_shift` at emission time. All emit
+    # paths — buffered text, buffered tool_use, replacement events, AND
+    # passthrough for unbuffered block types (e.g. thinking blocks) — must
+    # apply this shift. Violating the invariant produces duplicate indices
+    # downstream and breaks Anthropic SDK clients.
     index_shift: int = 0
 
 
@@ -357,7 +364,15 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             state.pending_text_start[index] = cast(MessageStreamEvent, event)
             return []
 
-        return [event]
+        # Passthrough for unbuffered block types (thinking, redacted_thinking,
+        # future types). Must apply index_shift to maintain monotonic indices
+        # after a prior multi-block replacement.
+        shifted = RawContentBlockStartEvent(
+            type="content_block_start",
+            index=index + state.index_shift,
+            content_block=event.content_block,
+        )
+        return [cast(MessageStreamEvent, shifted)]
 
     def _handle_block_delta(
         self, event: RawContentBlockDeltaEvent, context: "PolicyContext"
@@ -374,7 +389,15 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             state.tool_buffer[index].input_json += delta.partial_json
             return []  # buffer
 
-        return [event]
+        # Passthrough delta for unbuffered block types (e.g. thinking deltas).
+        # Apply index_shift to match the shifted start/stop emitted for the
+        # same upstream block.
+        shifted = RawContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=index + state.index_shift,
+            delta=event.delta,
+        )
+        return [cast(MessageStreamEvent, shifted)]
 
     async def _handle_block_stop(
         self, event: RawContentBlockStopEvent, context: "PolicyContext"
@@ -449,7 +472,14 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             state.emitted_blocks.append(self._block_descriptor_from_text(blocked_text))
             return self._make_anthropic_text_block_events(emitted_index, blocked_text)
 
-        return [cast(MessageStreamEvent, event)]
+        # Passthrough stop for unbuffered block types (e.g. thinking blocks).
+        # Apply index_shift to match the shifted start/delta emitted for the
+        # same upstream block.
+        shifted = RawContentBlockStopEvent(
+            type="content_block_stop",
+            index=index + state.index_shift,
+        )
+        return [cast(MessageStreamEvent, shifted)]
 
     def _handle_message_delta(self, event: RawMessageDeltaEvent, context: "PolicyContext") -> list[MessageStreamEvent]:
         """Handle message_delta event: inject warning and correct stop_reason.

--- a/src/luthien_proxy/policies/simple_llm_policy.py
+++ b/src/luthien_proxy/policies/simple_llm_policy.py
@@ -98,6 +98,10 @@ class _SimpleLLMAnthropicState:
     emitted_blocks: list[BlockDescriptor] = field(default_factory=list)
     original_had_tool_use: bool = False
     judge_error_occurred: bool = False
+    # Cumulative downstream offset from multi-block replacements: when one
+    # upstream block is replaced with N>1 blocks, every subsequent downstream
+    # index shifts by N-1 to avoid colliding with the extra emitted blocks.
+    index_shift: int = 0
 
 
 class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
@@ -395,15 +399,22 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             if action.judge_failed:
                 state.judge_error_occurred = True
 
+            emitted_index = index + state.index_shift
             if action.action == "pass":
                 state.emitted_blocks.append(descriptor)
                 events: list[MessageStreamEvent] = []
                 if pending_start is not None:
-                    events.append(pending_start)
-                events.extend(self._emit_anthropic_text_events(index, text, event))
+                    orig_start = cast(RawContentBlockStartEvent, pending_start)
+                    shifted_start = RawContentBlockStartEvent(
+                        type="content_block_start",
+                        index=emitted_index,
+                        content_block=orig_start.content_block,
+                    )
+                    events.append(cast(MessageStreamEvent, shifted_start))
+                events.extend(self._emit_anthropic_text_events(emitted_index, text))
                 return events
             elif action.action == "replace":
-                return self._emit_anthropic_replacement_events(index, action, state, event)
+                return self._emit_anthropic_replacement_events(emitted_index, action, state)
             # Judge blocked the text block — suppress entirely (pending_start was
             # never emitted, so there's nothing to close).
             return []
@@ -423,11 +434,12 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             if action.judge_failed:
                 state.judge_error_occurred = True
 
+            emitted_index = index + state.index_shift
             if action.action == "pass":
                 state.emitted_blocks.append(descriptor)
-                return self._emit_anthropic_tool_events(index, buffered, event)
+                return self._emit_anthropic_tool_events(emitted_index, buffered)
             elif action.action == "replace":
-                return self._emit_anthropic_replacement_events(index, action, state, event)
+                return self._emit_anthropic_replacement_events(emitted_index, action, state)
             # Tool start was suppressed — emit a text block so the client
             # knows the tool call was blocked and can continue the conversation.
             if action.judge_failed:
@@ -435,7 +447,7 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
             else:
                 blocked_text = _blocked_tool_message(buffered.name)
             state.emitted_blocks.append(self._block_descriptor_from_text(blocked_text))
-            return self._make_anthropic_text_block_events(index, blocked_text)
+            return self._make_anthropic_text_block_events(emitted_index, blocked_text)
 
         return [cast(MessageStreamEvent, event)]
 
@@ -475,26 +487,26 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
         self,
         index: int,
         text: str,
-        stop_event: RawContentBlockStopEvent,
     ) -> list[MessageStreamEvent]:
-        """Emit buffered text as a single delta + stop."""
+        """Emit buffered text as a single delta + stop at the given (possibly shifted) index."""
         text_delta = TextDelta.model_construct(type="text_delta", text=text)
         delta_event = RawContentBlockDeltaEvent.model_construct(
             type="content_block_delta", index=index, delta=text_delta
         )
+        stop_event = RawContentBlockStopEvent(type="content_block_stop", index=index)
         return [cast(MessageStreamEvent, delta_event), cast(MessageStreamEvent, stop_event)]
 
     def _emit_anthropic_tool_events(
         self,
         index: int,
         buffered: _BufferedToolUse,
-        stop_event: RawContentBlockStopEvent,
     ) -> list[MessageStreamEvent]:
-        """Reconstruct tool_use block events: start + json delta + stop."""
+        """Reconstruct tool_use block events at the given (possibly shifted) index: start + json delta + stop."""
         tool_block = ToolUseBlock(type="tool_use", id=buffered.id, name=buffered.name, input={})
         start_event = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=tool_block)
         json_delta = InputJSONDelta(type="input_json_delta", partial_json=buffered.input_json or "{}")
         delta_event = RawContentBlockDeltaEvent(type="content_block_delta", index=index, delta=json_delta)
+        stop_event = RawContentBlockStopEvent(type="content_block_stop", index=index)
         return [
             cast(MessageStreamEvent, start_event),
             cast(MessageStreamEvent, delta_event),
@@ -523,43 +535,73 @@ class SimpleLLMPolicy(BasePolicy, AnthropicHookPolicy):
         index: int,
         action: JudgeAction,
         state: _SimpleLLMAnthropicState,
-        stop_event: RawContentBlockStopEvent,
     ) -> list[MessageStreamEvent]:
-        """Emit replacement block events."""
+        """Emit replacement block events with monotonically increasing indices.
+
+        When the judge replaces one upstream block with N blocks, each emitted
+        block gets a distinct index starting at `index` (which already includes
+        any prior index_shift). For N>1 we update state.index_shift so that
+        subsequent passthrough/replacement blocks land at non-colliding indices.
+        """
         events: list[MessageStreamEvent] = []
+        current_index = index
 
         for rblock in action.blocks or ():
-            state.emitted_blocks.append(self._block_descriptor_from_replacement(rblock))
+            block_stop = RawContentBlockStopEvent(type="content_block_stop", index=current_index)
 
             if rblock.type == "text":
                 text_block = TextBlock(type="text", text="")
-                start = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=text_block)
+                start = RawContentBlockStartEvent(
+                    type="content_block_start", index=current_index, content_block=text_block
+                )
                 text_delta = TextDelta.model_construct(type="text_delta", text=rblock.text or "")
                 delta = RawContentBlockDeltaEvent.model_construct(
-                    type="content_block_delta", index=index, delta=text_delta
+                    type="content_block_delta", index=current_index, delta=text_delta
                 )
                 events.extend(
                     [
                         cast(MessageStreamEvent, start),
                         cast(MessageStreamEvent, delta),
+                        cast(MessageStreamEvent, block_stop),
                     ]
                 )
 
             elif rblock.type == "tool_use":
                 tool_id = f"toolu_{uuid4().hex[:24]}"
                 tool_block = ToolUseBlock(type="tool_use", id=tool_id, name=rblock.name or "", input={})
-                start = RawContentBlockStartEvent(type="content_block_start", index=index, content_block=tool_block)
+                start = RawContentBlockStartEvent(
+                    type="content_block_start", index=current_index, content_block=tool_block
+                )
                 json_str = json.dumps(rblock.input or {})
                 json_delta = InputJSONDelta(type="input_json_delta", partial_json=json_str)
-                delta = RawContentBlockDeltaEvent(type="content_block_delta", index=index, delta=json_delta)
+                delta = RawContentBlockDeltaEvent(type="content_block_delta", index=current_index, delta=json_delta)
                 events.extend(
                     [
                         cast(MessageStreamEvent, start),
                         cast(MessageStreamEvent, delta),
+                        cast(MessageStreamEvent, block_stop),
                     ]
                 )
 
-        events.append(cast(MessageStreamEvent, stop_event))
+            else:
+                # Unknown rblock type: skip, don't consume an index slot or
+                # append a descriptor — keeps state.emitted_blocks aligned with
+                # what was actually emitted.
+                logger.warning(
+                    "SimpleLLMPolicy: unknown replacement block type %r — skipping, index not consumed",
+                    rblock.type,
+                )
+                continue
+
+            state.emitted_blocks.append(self._block_descriptor_from_replacement(rblock))
+            current_index += 1
+
+        num_emitted = current_index - index
+        # 1-for-1 replacement consumes the same upstream index slot it came
+        # from, so downstream indices are unaffected. Only shift when N>1.
+        if num_emitted > 1:
+            state.index_shift += num_emitted - 1
+
         return events
 
     async def on_anthropic_streaming_policy_complete(self, context: "PolicyContext") -> None:

--- a/tests/luthien_proxy/unit_tests/policies/anthropic_event_builders.py
+++ b/tests/luthien_proxy/unit_tests/policies/anthropic_event_builders.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 from anthropic.lib.streaming import MessageStreamEvent
 from anthropic.types import (
     InputJSONDelta,
+    Message,
     RawContentBlockDeltaEvent,
     RawContentBlockStartEvent,
     RawContentBlockStopEvent,
     RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawMessageStopEvent,
     TextBlock,
     TextDelta,
     ToolUseBlock,
@@ -69,3 +72,22 @@ def message_delta(stop_reason: str = "end_turn") -> RawMessageDeltaEvent:
 def event_types(events: list[MessageStreamEvent]) -> list[str]:
     """Extract event type strings for easy assertion."""
     return [getattr(e, "type", None) for e in events]
+
+
+def full_stream(events: list) -> list:
+    """Wrap events in message_start + ... + message_stop for the stream validator."""
+    message_start = RawMessageStartEvent(
+        type="message_start",
+        message=Message.model_construct(
+            type="message",
+            id="test",
+            role="assistant",
+            content=[],
+            model="claude-haiku",
+            stop_reason=None,
+            stop_sequence=None,
+            usage=Usage(input_tokens=1, output_tokens=1),
+        ),
+    )
+    message_stop = RawMessageStopEvent(type="message_stop")
+    return [message_start, *events, message_stop]

--- a/tests/luthien_proxy/unit_tests/policies/test_simple_llm_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_simple_llm_policy.py
@@ -20,9 +20,11 @@ from anthropic.types import (
     TextDelta,
     ToolUseBlock,
 )
+from tests.luthien_proxy.fixtures.anthropic_stream_validator import validate_anthropic_event_ordering
 from tests.luthien_proxy.unit_tests.policies.anthropic_event_builders import (
     block_stop,
     event_types,
+    full_stream,
     message_delta,
     text_delta,
     text_start,
@@ -569,3 +571,79 @@ class TestJudgeErrorEmptyResponseInjection:
             e for e in msg_events if isinstance(e, RawContentBlockDeltaEvent) and isinstance(e.delta, TextDelta)
         ]
         assert any(JUDGE_ERROR_BLOCKED_MESSAGE in d.delta.text for d in error_deltas)
+
+
+# ============================================================================
+# Multi-block replacement indices: monotonicity + no-collision-with-passthrough
+# ============================================================================
+
+
+class TestMultiBlockReplacementIndices:
+    @pytest.mark.asyncio
+    async def test_replacement_with_multiple_blocks_uses_monotonic_indices(self):
+        """Two replacement blocks must use indices [0, 1], not [0, 0]."""
+        policy = _make_policy()
+        ctx = _make_context()
+
+        blocks = (
+            ReplacementBlock(type="text", text="A"),
+            ReplacementBlock(type="text", text="B"),
+        )
+        with patch.object(policy, "_judge_block", new_callable=AsyncMock) as mock_judge:
+            mock_judge.return_value = JudgeAction(action="replace", blocks=blocks)
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"command":"ls"}', 0)), ctx)
+            stop_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+            msg_events = await policy.on_anthropic_stream_event(
+                cast(MessageStreamEvent, message_delta("tool_use")), ctx
+            )
+
+        all_events = stop_events + msg_events
+        start_indices = [e.index for e in all_events if isinstance(e, RawContentBlockStartEvent)]
+
+        assert len(start_indices) == 2, f"Expected 2 replacement blocks, got {len(start_indices)}"
+        assert start_indices[0] < start_indices[1], (
+            f"Replacement block indices must be monotonically increasing, got {start_indices}"
+        )
+
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()
+
+    @pytest.mark.asyncio
+    async def test_replacement_then_passthrough_no_index_collision(self):
+        """Replacing one block with 2 then passing the next upstream block must not collide.
+
+        tool@0 → replace([A, B]) emits at [0, 1]; tool@1 → pass must emit at 2 (not 1).
+        """
+        policy = _make_policy()
+        ctx = _make_context()
+
+        replace_action = JudgeAction(
+            action="replace",
+            blocks=(ReplacementBlock(type="text", text="A"), ReplacementBlock(type="text", text="B")),
+        )
+        pass_action = JudgeAction(action="pass")
+
+        with patch.object(policy, "_judge_block", new_callable=AsyncMock) as mock_judge:
+            mock_judge.side_effect = [replace_action, pass_action]
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"cmd":"ls"}', 0)), ctx)
+            replace_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(1)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"cmd":"echo"}', 1)), ctx)
+            pass_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(1)), ctx)
+
+            msg_events = await policy.on_anthropic_stream_event(
+                cast(MessageStreamEvent, message_delta("tool_use")), ctx
+            )
+
+        all_events = replace_events + pass_events + msg_events
+        start_indices = [e.index for e in all_events if isinstance(e, RawContentBlockStartEvent)]
+
+        assert len(start_indices) == 3, f"Expected A, B, tool — got {start_indices}"
+        assert start_indices == sorted(set(start_indices)), (
+            f"Indices must be strictly increasing with no duplicates, got {start_indices}"
+        )
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()

--- a/tests/luthien_proxy/unit_tests/policies/test_simple_llm_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_simple_llm_policy.py
@@ -15,9 +15,11 @@ from anthropic.lib.streaming import MessageStreamEvent
 from anthropic.types import (
     RawContentBlockDeltaEvent,
     RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
     RawMessageDeltaEvent,
     TextBlock,
     TextDelta,
+    ThinkingBlock,
     ToolUseBlock,
 )
 from tests.luthien_proxy.fixtures.anthropic_stream_validator import validate_anthropic_event_ordering
@@ -647,3 +649,213 @@ class TestMultiBlockReplacementIndices:
             f"Indices must be strictly increasing with no duplicates, got {start_indices}"
         )
         validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()
+
+    @pytest.mark.asyncio
+    async def test_thinking_block_passthrough_after_multi_replace_uses_shifted_index(self):
+        """Thinking block (passthrough, not buffered) must apply index_shift.
+
+        tool@0 → replace([A, B]) emits at [0, 1] and shifts; subsequent
+        thinking@1 must emit at shifted index 2, not collide at 1.
+        """
+        policy = _make_policy()
+        ctx = _make_context()
+
+        replace = JudgeAction(
+            action="replace",
+            blocks=(ReplacementBlock(type="text", text="A"), ReplacementBlock(type="text", text="B")),
+        )
+        with patch.object(policy, "_judge_block", new_callable=AsyncMock) as mock_judge:
+            mock_judge.return_value = replace
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"x":1}', 0)), ctx)
+            replace_events = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+
+            thinking_start = RawContentBlockStartEvent(
+                type="content_block_start",
+                index=1,
+                content_block=ThinkingBlock(type="thinking", thinking="hmm", signature="sig"),
+            )
+            thinking_stop = RawContentBlockStopEvent(type="content_block_stop", index=1)
+            t_start = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, thinking_start), ctx)
+            t_stop = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, thinking_stop), ctx)
+
+            msg_events = await policy.on_anthropic_stream_event(
+                cast(MessageStreamEvent, message_delta("tool_use")), ctx
+            )
+
+        all_events = replace_events + t_start + t_stop + msg_events
+        starts = [e.index for e in all_events if isinstance(e, RawContentBlockStartEvent)]
+        assert starts == [0, 1, 2], f"Thinking-block passthrough must emit at index+shift=2, got starts {starts}"
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()
+
+    @pytest.mark.asyncio
+    async def test_two_multi_block_replacements_compound_shift(self):
+        """Two multi-block replacements in series must compound index_shift.
+
+        tool@0 → replace([A,B]) → emits [0,1] shift=1
+        tool@1 → replace([C,D]) → emits at shifted [2,3] shift=3
+        tool@2 → pass → emits at shifted index 4
+        Guards against `index_shift = N-1` regression vs `+=`.
+        """
+        policy = _make_policy()
+        ctx = _make_context()
+
+        replace_ab = JudgeAction(
+            action="replace",
+            blocks=(ReplacementBlock(type="text", text="A"), ReplacementBlock(type="text", text="B")),
+        )
+        replace_cd = JudgeAction(
+            action="replace",
+            blocks=(ReplacementBlock(type="text", text="C"), ReplacementBlock(type="text", text="D")),
+        )
+        pass_action = JudgeAction(action="pass")
+
+        with patch.object(policy, "_judge_block", new_callable=AsyncMock) as mock_judge:
+            mock_judge.side_effect = [replace_ab, replace_cd, pass_action]
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"x":1}', 0)), ctx)
+            e1 = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(1)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"x":2}', 1)), ctx)
+            e2 = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(1)), ctx)
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(2)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"x":3}', 2)), ctx)
+            e3 = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(2)), ctx)
+
+            msg = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, message_delta("tool_use")), ctx)
+
+        all_events = e1 + e2 + e3 + msg
+        starts = [e.index for e in all_events if isinstance(e, RawContentBlockStartEvent)]
+        assert starts == [0, 1, 2, 3, 4], f"Compound shift broken: expected [0,1,2,3,4], got {starts}"
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()
+
+    @pytest.mark.asyncio
+    async def test_one_for_one_replace_after_multi_block_replace_no_extra_shift(self):
+        """1-for-1 replace consumes its upstream slot; no extra shift.
+
+        tool@0 → replace([A,B]) shifts by 1; tool@1 → replace([C]) is 1-for-1
+        and must emit at shifted index 2 without bumping shift further;
+        tool@2 → pass emits at shifted index 3.
+        """
+        policy = _make_policy()
+        ctx = _make_context()
+
+        replace_ab = JudgeAction(
+            action="replace",
+            blocks=(ReplacementBlock(type="text", text="A"), ReplacementBlock(type="text", text="B")),
+        )
+        replace_c = JudgeAction(action="replace", blocks=(ReplacementBlock(type="text", text="C"),))
+        pass_action = JudgeAction(action="pass")
+
+        with patch.object(policy, "_judge_block", new_callable=AsyncMock) as mock_judge:
+            mock_judge.side_effect = [replace_ab, replace_c, pass_action]
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"x":1}', 0)), ctx)
+            e1 = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(1)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"x":2}', 1)), ctx)
+            e2 = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(1)), ctx)
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(2)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"x":3}', 2)), ctx)
+            e3 = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(2)), ctx)
+
+            msg = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, message_delta("tool_use")), ctx)
+
+        all_events = e1 + e2 + e3 + msg
+        starts = [e.index for e in all_events if isinstance(e, RawContentBlockStartEvent)]
+        assert starts == [0, 1, 2, 3], f"1-for-1 replace bumped shift unexpectedly: expected [0,1,2,3], got {starts}"
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()
+
+    @pytest.mark.asyncio
+    async def test_text_passthrough_after_multi_block_replacement(self):
+        """Text pass after multi-replace must shift via pending_text_start rebuild.
+
+        tool@0 → replace([A,B]); text@1 → pass — exercises the
+        pending_text_start shift branch in _handle_block_stop.
+        """
+        policy = _make_policy()
+        ctx = _make_context()
+
+        replace_ab = JudgeAction(
+            action="replace",
+            blocks=(ReplacementBlock(type="text", text="A"), ReplacementBlock(type="text", text="B")),
+        )
+        pass_action = JudgeAction(action="pass")
+
+        with patch.object(policy, "_judge_block", new_callable=AsyncMock) as mock_judge:
+            mock_judge.side_effect = [replace_ab, pass_action]
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"x":1}', 0)), ctx)
+            e1 = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, text_start(1)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, text_delta("hello", 1)), ctx)
+            e2 = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(1)), ctx)
+
+            msg = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, message_delta("tool_use")), ctx)
+
+        all_events = e1 + e2 + msg
+        starts = [e.index for e in all_events if isinstance(e, RawContentBlockStartEvent)]
+        assert starts == [0, 1, 2], f"Text passthrough must shift to 2 after [A,B] at [0,1], got {starts}"
+        validate_anthropic_event_ordering(full_stream(all_events)).assert_valid()
+
+    @pytest.mark.asyncio
+    async def test_replacement_stream_accumulates_via_anthropic_sdk(self):
+        """End-to-end: SDK accumulator must rebuild the stream without IndexError.
+
+        The validator catches structural violations; this catches what the
+        actual downstream Anthropic SDK client would do with the bytes.
+        """
+        from anthropic.lib.streaming._messages import accumulate_event
+        from anthropic.types import Message, RawMessageStartEvent, RawMessageStopEvent, Usage
+
+        policy = _make_policy()
+        ctx = _make_context()
+
+        replace_ab = JudgeAction(
+            action="replace",
+            blocks=(ReplacementBlock(type="text", text="A"), ReplacementBlock(type="text", text="B")),
+        )
+        pass_action = JudgeAction(action="pass")
+
+        with patch.object(policy, "_judge_block", new_callable=AsyncMock) as mock_judge:
+            mock_judge.side_effect = [replace_ab, pass_action]
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(0)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"x":1}', 0)), ctx)
+            e1 = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(0)), ctx)
+
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_start(1)), ctx)
+            await policy.on_anthropic_stream_event(cast(MessageStreamEvent, tool_delta('{"y":2}', 1)), ctx)
+            e2 = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, block_stop(1)), ctx)
+
+            msg = await policy.on_anthropic_stream_event(cast(MessageStreamEvent, message_delta("tool_use")), ctx)
+
+        message_start = RawMessageStartEvent(
+            type="message_start",
+            message=Message.model_construct(
+                type="message",
+                id="test",
+                role="assistant",
+                model="test-model",
+                content=[],
+                stop_reason=None,
+                stop_sequence=None,
+                usage=Usage(input_tokens=0, output_tokens=0),
+            ),
+        )
+        message_stop = RawMessageStopEvent(type="message_stop")
+
+        snapshot: Message | None = None
+        for ev in [message_start, *e1, *e2, *msg, message_stop]:
+            snapshot = accumulate_event(event=ev, current_snapshot=snapshot)
+        assert snapshot is not None
+        assert len(snapshot.content) == 3, f"SDK accumulator should see 3 blocks, got {len(snapshot.content)}"


### PR DESCRIPTION
## Summary

Split out the H2 fix from #719 — when `SimpleLLMPolicy._emit_anthropic_replacement_events` replaces one upstream content block with N>1 blocks, all replacement blocks were emitted at the same upstream index, producing an invalid Anthropic stream (duplicate `content_block_start` indices). This is the one fix from #719 that has tests demonstrably failing against unmodified `main`.

## Fix

- Add `index_shift: int = 0` to `_SimpleLLMAnthropicState`.
- `_emit_anthropic_replacement_events` now emits each replacement block at a sequential `current_index`, starting at `index` (which already includes prior shift). For `N > 1` blocks, `state.index_shift` is incremented by `N-1` so subsequent passthrough/replacement blocks land at non-colliding indices.
- `_handle_block_stop` shifts the emit index via `emitted_index = index + state.index_shift` on the pass / replace / blocked-tool paths (and shifts a deferred `pending_text_start` accordingly).
- `_emit_anthropic_text_events` / `_emit_anthropic_tool_events` now construct their own `block_stop` event using the (possibly shifted) `index` rather than reusing the upstream `stop_event` — necessary because the upstream stop event carries the unshifted index.

## Tests

New `TestMultiBlockReplacementIndices`:
- `test_replacement_with_multiple_blocks_uses_monotonic_indices` — judge replaces one tool with `[A, B]`; asserts emitted indices are `[0, 1]`, not `[0, 0]`.
- `test_replacement_then_passthrough_no_index_collision` — `tool@0 → replace([A, B])`; `tool@1 → pass`; asserts emitted indices are `[0, 1, 2]`, not `[0, 1, 1]`.

Both tests fail on `main` and pass with this fix. Validator `validate_anthropic_event_ordering` is invoked end-to-end.

Also hoists a shared `full_stream(events)` helper into `tests/luthien_proxy/unit_tests/policies/anthropic_event_builders.py` for reuse.

## Scope

This PR is **only the H2 fix from #719**. Background: I ran #719's new tests against unmodified `main` and found 5 of 7 passed without any source change (i.e. they aren't regression tests for real bugs). Only the two `TestMultiBlockReplacementIndices` tests failed on `main`, demonstrating a real regression. See the discussion on #719 (https://github.com/LuthienResearch/luthien-proxy/pull/719#issuecomment-4424016579).

Follow-up PRs (separate branches) will land H3 and H5 once they have failing-on-main tests to justify them. The customer issue #708 has been reopened — a Trello card tracks empirically reproducing Yash's actual failure with a real captured stream.

Credit to @PaoloC68 for the original analysis and patch in #719.

## Test plan
- [x] `uv run pytest tests/luthien_proxy/unit_tests/policies/test_simple_llm_policy.py` — 20 pass (18 existing + 2 new)
- [x] `uv run pytest tests/luthien_proxy/unit_tests/policies/` — 454 pass
- [x] New tests fail on `main` (verified before applying fix)
- [ ] CI green

---
*Posted by Claude Code (claude-opus-4-7)*