### PR TITLE
chore: set objective to fix stop_reason over-aggressive rewrite (#card 6a03a845)

### DIFF
--- a/changelog.d/stop-reason-conservative-rewrite.md
+++ b/changelog.d/stop-reason-conservative-rewrite.md
@@ -1,0 +1,20 @@
+---
+category: Fixes
+pr: 754
+---
+
+**AnthropicMessageBuilder: stop_reason rewrite is now conservative; diagnostic upstream reasons preserved**
+  - Previously the builder unconditionally rewrote `stop_reason` to
+    `tool_use` or `end_turn` based on whether any tool was actually
+    emitted. That clobbered legitimate upstream `max_tokens`,
+    `stop_sequence`, `refusal`, and `pause_turn` values, masking
+    information clients depend on (e.g. a `max_tokens` truncation
+    looked like a normal `end_turn` to the client and never triggered
+    continuation logic).
+  - **Fix**: only rewrite when upstream is *known wrong* given what we
+    emitted — specifically, `stop_reason == "tool_use"` with no tool
+    on the wire becomes `end_turn`. Every other reason is preserved
+    verbatim. Mirrors the conservative shape established in PR #721.
+  - Affects all Anthropic streaming and non-streaming policies that
+    route through `AnthropicMessageBuilder` (SimpleLLM, DogfoodSafety,
+    ToolCallJudge).

--- a/src/luthien_proxy/policy_core/anthropic_message_builder.py
+++ b/src/luthien_proxy/policy_core/anthropic_message_builder.py
@@ -24,8 +24,11 @@ Other invariants the builder owns:
 - The judge-unavailable warning and the consolidated blocked-tool marker
   emit at `finalize()` in the pre-tool slot, so they can never violate the
   trailing-tool_use invariant regardless of when they were noted.
-- `stop_reason` is rewritten at `finalize()` / `to_anthropic_response()`
-  to match whether any tool_use was actually emitted.
+- `stop_reason` is corrected at `finalize()` / `to_anthropic_response()`
+  *only* when upstream is known wrong given what we emitted: a
+  `tool_use` reason with no buffered tool becomes `end_turn`. Every
+  other reason (`max_tokens`, `stop_sequence`, `refusal`, etc.) is
+  preserved — clients depend on those signals.
 """
 
 from __future__ import annotations
@@ -434,13 +437,14 @@ class AnthropicMessageBuilder:
         for tool in s.buffered_tools:
             events.extend(self._emit_tool_now(tool))
 
-        # Adjust stop_reason based on what was actually emitted.
-        any_tool = bool(s.buffered_tools)
-        expected_stop = "tool_use" if any_tool else "end_turn"
-        if message_delta.delta.stop_reason != expected_stop:
+        # Conservative stop_reason correction: only rewrite when upstream is
+        # known wrong given what we actually emitted. Preserve max_tokens,
+        # stop_sequence, refusal, pause_turn, and anything else — clients
+        # depend on those signals.
+        if message_delta.delta.stop_reason == "tool_use" and not s.buffered_tools:
             message_delta = RawMessageDeltaEvent.model_construct(
                 type="message_delta",
-                delta=message_delta.delta.model_copy(update={"stop_reason": expected_stop}),
+                delta=message_delta.delta.model_copy(update={"stop_reason": "end_turn"}),
                 usage=message_delta.usage,
             )
 
@@ -491,11 +495,14 @@ class AnthropicMessageBuilder:
         if not new_content and s.pending_fallback_text is not None:
             new_content.append({"type": "text", "text": s.pending_fallback_text})
 
-        expected_stop = "tool_use" if s.buffered_tools else "end_turn"
-
+        # Conservative stop_reason correction (see finalize() for rationale):
+        # only rewrite the one upstream value known to be wrong given what we
+        # emitted. Preserve everything else.
         modified = cast("AnthropicResponse", dict(template))
         modified["content"] = new_content
-        modified["stop_reason"] = expected_stop
+        upstream_stop = modified.get("stop_reason")
+        if upstream_stop == "tool_use" and not s.buffered_tools:
+            modified["stop_reason"] = "end_turn"
         return modified
 
     # ------------------------------------------------------------------

--- a/tests/luthien_proxy/unit_tests/policies/test_tool_call_judge_policy.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_tool_call_judge_policy.py
@@ -482,12 +482,14 @@ class TestStreamingStopReasonCorrection:
         assert msg_events == [original]
 
     @pytest.mark.asyncio
-    async def test_stop_reason_rewritten_to_match_emitted_content(self):
-        """When all tools are blocked, stop_reason is rewritten to end_turn regardless of upstream value.
+    async def test_stop_reason_preserved_when_upstream_is_diagnostic(self):
+        """Diagnostic stop_reasons (max_tokens, stop_sequence, refusal) are preserved
+        even when all tools are blocked.
 
-        The builder owns stop_reason consistency: the value on the wire
-        must match what content actually shipped. Preserving an upstream
-        max_tokens while emitting no tool_use would mislead downstream.
+        The builder corrects stop_reason only in the one known-wrong case
+        (tool_use upstream + no tool emitted). Diagnostic reasons carry
+        information the client needs (e.g. max_tokens → trigger continuation
+        logic); clobbering them silently degrades client behavior.
         """
         policy = _make_policy()
         ctx = _make_context()
@@ -507,7 +509,7 @@ class TestStreamingStopReasonCorrection:
 
         delta_events = [e for e in msg_events if isinstance(e, RawMessageDeltaEvent)]
         assert len(delta_events) == 1
-        assert delta_events[0].delta.stop_reason == "end_turn"
+        assert delta_events[0].delta.stop_reason == "max_tokens"
 
     @pytest.mark.asyncio
     async def test_stop_reason_rewritten_to_end_turn_when_no_blocks_seen(self):

--- a/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_message_builder.py
+++ b/tests/luthien_proxy/unit_tests/policy_core/test_anthropic_message_builder.py
@@ -139,13 +139,23 @@ class TestBufferToolAndFinalize:
     @pytest.mark.parametrize(
         "upstream_stop,buffered_tool,expected",
         [
-            ("tool_use", False, "end_turn"),  # claimed tool, sent none
-            ("end_turn", True, "tool_use"),  # claimed end, sent tool
-            ("max_tokens", False, "end_turn"),  # builder forces consistency
-            ("max_tokens", True, "tool_use"),
+            # The only correction the builder makes: upstream claimed tool_use
+            # but every tool was blocked/dropped.
+            ("tool_use", False, "end_turn"),
+            # Every other case preserves upstream verbatim.
+            ("tool_use", True, "tool_use"),
+            ("end_turn", False, "end_turn"),
+            ("end_turn", True, "end_turn"),
+            ("max_tokens", False, "max_tokens"),
+            ("max_tokens", True, "max_tokens"),
+            ("stop_sequence", False, "stop_sequence"),
+            ("stop_sequence", True, "stop_sequence"),
+            ("refusal", False, "refusal"),
+            ("refusal", True, "refusal"),
+            ("pause_turn", False, "pause_turn"),
         ],
     )
-    def test_finalize_corrects_stop_reason(self, upstream_stop: str, buffered_tool: bool, expected: str):
+    def test_finalize_stop_reason_conservative(self, upstream_stop: str, buffered_tool: bool, expected: str):
         builder = AnthropicMessageBuilder()
         if buffered_tool:
             builder.buffer_tool(id="t1", name="Bash", input_json="{}")
@@ -285,11 +295,41 @@ class TestToAnthropicResponse:
     def test_tool_only(self):
         builder = AnthropicMessageBuilder()
         builder.buffer_tool(id="t1", name="Bash", input_json='{"command": "ls"}')
-        result = builder.to_anthropic_response(_response_template())
+        template = _response_template()
+        template["stop_reason"] = "tool_use"
+        result = builder.to_anthropic_response(template)
         assert result["content"] == [
             {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
         ]
         assert result["stop_reason"] == "tool_use"
+
+    @pytest.mark.parametrize(
+        "upstream_stop,buffered_tool,expected",
+        [
+            # The only correction the builder makes.
+            ("tool_use", False, "end_turn"),
+            # Everything else preserved verbatim.
+            ("tool_use", True, "tool_use"),
+            ("end_turn", False, "end_turn"),
+            ("end_turn", True, "end_turn"),
+            ("max_tokens", False, "max_tokens"),
+            ("max_tokens", True, "max_tokens"),
+            ("stop_sequence", False, "stop_sequence"),
+            ("stop_sequence", True, "stop_sequence"),
+            ("refusal", False, "refusal"),
+            ("refusal", True, "refusal"),
+        ],
+    )
+    def test_stop_reason_conservative(self, upstream_stop: str, buffered_tool: bool, expected: str):
+        builder = AnthropicMessageBuilder()
+        if buffered_tool:
+            builder.buffer_tool(id="t1", name="Bash", input_json="{}")
+        else:
+            builder.commit_text("hi")
+        template = _response_template()
+        template["stop_reason"] = upstream_stop  # type: ignore[typeddict-item]
+        result = builder.to_anthropic_response(template)
+        assert result["stop_reason"] == expected
 
     def test_tool_trails_text_even_when_added_first(self):
         builder = AnthropicMessageBuilder()


### PR DESCRIPTION
## Summary

Fix the over-aggressive `stop_reason` rewrite in `AnthropicMessageBuilder.finalize` / `to_anthropic_response`. Previously the builder unconditionally rewrote `stop_reason` to `tool_use` or `end_turn` based on whether any tool was emitted, silently clobbering legitimate upstream `max_tokens`, `stop_sequence`, `refusal`, and `pause_turn` values.

The user-visible bug: a `max_tokens` truncation looked like a normal `end_turn` to the client and never triggered continuation logic. `refusal` was silently dropped. Same for `stop_sequence`.

## The fix

Only rewrite when upstream is *known wrong* given what we emitted:

- `stop_reason == "tool_use"` and **no** tool buffered → rewrite to `"end_turn"`. (Upstream claimed a tool but we blocked/dropped them all.)
- Every other case → preserve verbatim.

Mirrors the conservative shape from PR #721 (the original `ToolCallJudgePolicy` streaming fix). The card (Trello `6a03a845`) explicitly called for this shape.

## Why "tool_use → end_turn" is the only safe rewrite

When upstream says `tool_use` but the wire has no tool, the client is told to respond with `tool_result` for a block that doesn't exist — a guaranteed protocol violation. The rewrite is unambiguously correct.

Every other direction is judgment-dependent and the conservative answer is "trust upstream":
- `max_tokens`: telling the client we hit max_tokens is *information they need to act on*. Losing it is the bug.
- `stop_sequence`, `refusal`, `pause_turn`: same shape.
- `end_turn` upstream with a tool emitted: would only happen if a policy *injected* a tool unprompted. None of our current policies do this; if a future one does, we revisit then.

## Test changes

- `test_anthropic_message_builder.py::TestBufferToolAndFinalize::test_finalize_stop_reason_conservative` — expanded parametrization covering all 5 stop_reason values × {tool, no-tool}. The previous version encoded the over-aggressive behavior (asserted `max_tokens → end_turn`).
- `test_anthropic_message_builder.py::TestToAnthropicResponse::test_stop_reason_conservative` — new parametrized non-streaming sibling test.
- `test_anthropic_message_builder.py::TestToAnthropicResponse::test_tool_only` — uses `tool_use` upstream template instead of relying on the inverse rewrite that no longer exists.
- `test_tool_call_judge_policy.py::TestStreamingStopReasonCorrection::test_stop_reason_preserved_when_upstream_is_diagnostic` — replaces `test_stop_reason_rewritten_to_match_emitted_content`, which encoded the bug.

## Test plan

- [x] 2646 unit tests pass
- [x] 206 mock_e2e tests pass
- [x] `scripts/dev_checks.sh` clean (format + lint + tests + pyright)

Trello: https://trello.com/c/9PgPNFBn

---
*Posted by Claude Code (claude-opus-4-7)*