### PR TITLE
feat(track-a): opencode-luthien plugin integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/opencode-luthien"]
+	path = plugins/opencode-luthien
+	url = https://github.com/LuthienResearch/opencode-luthien.git

--- a/README.md
+++ b/README.md
@@ -282,6 +282,29 @@ Base classes and building blocks in `src/luthien_proxy/policies/` — see **[doc
 **Composition**:
 - `MultiSerialPolicy` - Chain policies sequentially
 
+## OpenCode Plugin
+
+The `opencode-luthien` plugin routes [OpenCode](https://opencode.ai) AI traffic through the Luthien gateway for observability and control.
+
+**Install:**
+```bash
+npm install opencode-luthien
+```
+
+**Configure** in `opencode.json`:
+```json
+{
+  "plugins": ["opencode-luthien"]
+}
+```
+
+**Set gateway URL:**
+```bash
+export LUTHIEN_PROXY_URL=https://your-luthien-gateway.example.com
+```
+
+See the [plugin README](https://github.com/LuthienResearch/opencode-luthien) and [header contract](docs/plugin-header-contract.md) for full documentation.
+
 ## Usage Telemetry
 
 Luthien collects anonymous, aggregate usage metrics to help track adoption and improve the project. **No model names, API keys, IP addresses, or request/response content is collected.**

--- a/changelog.d/track-a-plugin.md
+++ b/changelog.d/track-a-plugin.md
@@ -1,0 +1,9 @@
+# Track A: opencode-luthien Plugin Integration
+
+Adds the opencode-luthien plugin as a git submodule under `plugins/opencode-luthien`.
+
+- `.gitmodules`: Points to `LuthienResearch/opencode-luthien`
+- `plugins/README.md`: Plugin installation instructions
+- `README.md`: Updated install section
+- `dev-README.md`: Smoke test section
+- `scripts/track_a_smoke.sh`: End-to-end smoke test (uses `CLIENT_API_KEY`)

--- a/dev-README.md
+++ b/dev-README.md
@@ -234,6 +234,55 @@ luthien logs
 docker compose logs gateway | tail -50
 ```
 
+## Track A Smoke Test
+
+The Track A smoke test validates the full end-to-end flow: real OpenCode binary + opencode-luthien plugin + Luthien gateway + mock provider servers.
+
+### Prerequisites
+
+1. OpenCode installed: `opencode --version` (tested with v1.14.28)
+2. `opencode-luthien` plugin built and installed:
+   ```bash
+   cd plugins/opencode-luthien
+   bun run build
+   cp dist/index.js ~/.config/opencode/plugins/opencode-luthien.js
+   ```
+3. Gateway dependencies: `uv sync`
+4. `.env` file with `PROXY_API_KEY` set
+
+### Running the Smoke Test
+
+**Happy path (A1-A5):**
+```bash
+./scripts/track_a_smoke.sh
+```
+
+**A6 fallback (gateway down → plugin degrades gracefully):**
+```bash
+./scripts/track_a_smoke.sh --a6-fallback
+```
+
+### What It Tests
+
+| Scenario | Expected |
+|---|---|
+| A1: Anthropic chat via plugin | Request logged with session_id, agent, model |
+| A2: OpenAI streaming via plugin | SSE chunks arrive incrementally |
+| A3: Gemini chat via plugin | x-goog-api-key injected by gateway |
+| A4: Header persistence | request_logs.session_id, agent, model populated |
+| A5: All 3 providers | 3 request_logs rows with distinct endpoints |
+| A6: Gateway down | Plugin warns, OpenCode routes direct, no x-luthien-* headers |
+
+### Evidence
+
+Evidence is saved to `.sisyphus/evidence/track-a-17-smoke/` (gitignored).
+
+### Notes
+
+- The smoke test uses mock servers (not real Anthropic/OpenAI/Gemini) — no API costs
+- The pytest file `tests/luthien_proxy/e2e_tests/sqlite/test_opencode_plugin_smoke.py` is marked `@pytest.mark.skip` — it documents the procedure but does not run in CI
+- Track B will replace the passthrough routes with native pipelines; this smoke test will be updated accordingly
+
 ## Observability (Optional)
 
 The gateway supports **OpenTelemetry** for distributed tracing and log correlation.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,11 @@
+# Plugins
+
+This directory contains git submodules for Luthien gateway plugins.
+
+## opencode-luthien
+
+The `opencode-luthien` plugin routes OpenCode AI traffic through the Luthien gateway.
+
+- **Repo**: https://github.com/PaoloC68/opencode-luthien
+- **Install**: See plugin README for installation instructions
+- **Update submodule**: `git submodule update --remote plugins/opencode-luthien`

--- a/scripts/track_a_smoke.sh
+++ b/scripts/track_a_smoke.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Track A Smoke Test: OpenCode + opencode-luthien plugin + gateway + mock providers
+#
+# Usage:
+#   ./scripts/track_a_smoke.sh           # Happy path (A1-A5)
+#   ./scripts/track_a_smoke.sh --a6-fallback  # A6 fallback test
+#
+# Prerequisites:
+#   - OpenCode installed (opencode --version)
+#   - opencode-luthien plugin built and installed to ~/.config/opencode/plugins/
+#   - Gateway dependencies installed (uv sync)
+#   - CLIENT_API_KEY set in .env
+#
+# See dev-README.md "Track A Smoke Test" for full procedure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+EVIDENCE_DIR="$REPO_ROOT/.sisyphus/evidence/track-a-17-smoke"
+
+# Load .env
+if [ -f "$REPO_ROOT/.env" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/.env"
+    set +a
+fi
+
+A6_FALLBACK="${1:-}"
+
+echo "=== Track A Smoke Test ==="
+echo "Evidence dir: $EVIDENCE_DIR"
+mkdir -p "$EVIDENCE_DIR/happy-path" "$EVIDENCE_DIR/a6-fallback"
+
+# Pick free ports
+MOCK_ANTHROPIC_PORT=9000
+MOCK_OPENAI_PORT=9001
+MOCK_GEMINI_PORT=9002
+GATEWAY_PORT=8000
+
+echo "Starting mock servers..."
+export MOCK_ANTHROPIC_PORT MOCK_OPENAI_PORT MOCK_GEMINI_PORT
+export ANTHROPIC_BASE_URL="http://localhost:$MOCK_ANTHROPIC_PORT"
+export OPENAI_BASE_URL="http://localhost:$MOCK_OPENAI_PORT"
+export GEMINI_BASE_URL="http://localhost:$MOCK_GEMINI_PORT"
+
+# Start mock servers
+uv run python -m tests.luthien_proxy.e2e_tests.mock_anthropic.server --port "$MOCK_ANTHROPIC_PORT" &
+MOCK_ANTHROPIC_PID=$!
+uv run python -m tests.luthien_proxy.e2e_tests.mock_openai.server --port "$MOCK_OPENAI_PORT" &
+MOCK_OPENAI_PID=$!
+uv run python -m tests.luthien_proxy.e2e_tests.mock_gemini.server --port "$MOCK_GEMINI_PORT" &
+MOCK_GEMINI_PID=$!
+
+sleep 2
+
+echo "Starting gateway on port $GATEWAY_PORT..."
+uv run python -m luthien_proxy.main --gateway-port "$GATEWAY_PORT" &
+GATEWAY_PID=$!
+sleep 3
+
+cleanup() {
+    echo "Cleaning up..."
+    kill "$GATEWAY_PID" "$MOCK_ANTHROPIC_PID" "$MOCK_OPENAI_PID" "$MOCK_GEMINI_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+export LUTHIEN_PROXY_URL="http://localhost:$GATEWAY_PORT"
+
+if [ "$A6_FALLBACK" = "--a6-fallback" ]; then
+    echo "=== A6 Fallback Test ==="
+    echo "Stopping gateway..."
+    kill "$GATEWAY_PID" 2>/dev/null || true
+    sleep 1
+    echo "Running OpenAI chat with gateway down..."
+    opencode run --model openai/gpt-4o "say hi" \
+        2>"$EVIDENCE_DIR/a6-fallback/opencode-stderr.log" \
+        >"$EVIDENCE_DIR/a6-fallback/opencode-stdout.log" || true
+    echo "A6 fallback test complete. Check evidence:"
+    echo "  $EVIDENCE_DIR/a6-fallback/"
+else
+    echo "=== Happy Path Test ==="
+    echo "Running Anthropic chat..."
+    opencode run --model anthropic/claude-3-5-sonnet-20241022 "say hi" \
+        2>"$EVIDENCE_DIR/happy-path/anthropic-session.log" || true
+    echo "Running OpenAI chat..."
+    opencode run --model openai/gpt-4o "say hi" \
+        2>"$EVIDENCE_DIR/happy-path/openai-session.log" || true
+    echo "Running Gemini chat..."
+    opencode run --model google/gemini-1.5-flash "say hi" \
+        2>"$EVIDENCE_DIR/happy-path/gemini-session.log" || true
+
+    echo "Querying request_logs..."
+    sqlite3 ~/.luthien/local.db \
+        "SELECT session_id, agent, model, endpoint FROM request_logs WHERE session_id IS NOT NULL ORDER BY created_at DESC LIMIT 10;" \
+        > "$EVIDENCE_DIR/happy-path/request-logs-query.txt" 2>&1 || true
+
+    echo "Happy path test complete. Check evidence:"
+    echo "  $EVIDENCE_DIR/happy-path/"
+fi


### PR DESCRIPTION
Part 3 of 3 splitting PR #614.

**Depends on PR #758** (passthrough routes used by smoke test) — merge order: #757 → #758 → #759.

## Changes
- `.gitmodules`: Adds opencode-luthien submodule (URL: `LuthienResearch/opencode-luthien`)
- `plugins/README.md`: Plugin installation instructions
- `README.md`: Updated install section
- `dev-README.md`: Smoke test section
- `scripts/track_a_smoke.sh`: End-to-end smoke test (uses `CLIENT_API_KEY` per PR #758 auth model)

## Notes
- `.gitmodules` URL corrected from `PaoloC68/opencode-luthien` to `LuthienResearch/opencode-luthien`
- Smoke test uses `CLIENT_API_KEY` (aligned with PR #758's strict auth model)
- Run `git submodule sync && git submodule update --init --recursive` after pulling

Closes part of #614.