### PR TITLE
feat(history): server-side session search query layer (replaces #581)

### DIFF
--- a/changelog.d/session-search-query-layer.md
+++ b/changelog.d/session-search-query-layer.md
@@ -1,0 +1,8 @@
+---
+category: Features
+---
+
+**Server-side session search**: `/api/history/sessions` now accepts `model`, `from`, `to`, `q` (full-text content), and `policy_intervention` filters, on top of the existing `user_id`. Resolves #558.
+  - Builds on the existing dual-backend FTS infra (Postgres `tsvector` / SQLite FTS5) via `utils.search.session_fts_filter_sql` — no new migration.
+  - `q` is porter-stemmed and term-conjunctive with parity across backends; `model`/`q` match if any turn matches, while time and intervention filters operate on session-level aggregates so per-session stats stay whole.
+  - `total` in the response now reflects the filtered count (was always the global count). The unfiltered list path is unchanged.

--- a/changelog.d/session-search-query-layer.md
+++ b/changelog.d/session-search-query-layer.md
@@ -1,5 +1,6 @@
 ---
 category: Features
+pr: 773
 ---
 
 **Server-side session search**: `/api/history/sessions` now accepts `model`, `from`, `to`, `q` (full-text content), and `policy_intervention` filters, on top of the existing `user_id`. Resolves #558.

--- a/src/luthien_proxy/history/models.py
+++ b/src/luthien_proxy/history/models.py
@@ -6,6 +6,7 @@ Defines Pydantic models for:
 - Policy annotations for interventions
 """
 
+from datetime import datetime
 from enum import Enum
 from typing import Any
 
@@ -85,11 +86,56 @@ class SessionSummary(BaseModel):
     user_ids: list[str] = Field(default_factory=list)  # X-Luthien-User-Id or JWT sub claim
 
 
+class SessionSearchParams(BaseModel):
+    """Optional server-side filters for the session list endpoint.
+
+    All fields default to "no filter". When several are set they combine with
+    AND. A session is the unit of matching: model/q ask "does any event in this
+    session match?", while the time and intervention filters operate on
+    session-level aggregates.
+
+    Semantics:
+      - model: session used this exact ``final_model`` in at least one turn.
+      - from_time / to_time: the session's *last activity* (the max event
+        timestamp) falls within ``[from_time, to_time]``, inclusive. Either
+        bound may be omitted. (Last-activity, not overlap — consistent with the
+        list's ``ORDER BY last_ts``.)
+      - q: full-text content search over indexed conversation text. Postgres
+        uses the ``search_vector`` tsvector column; SQLite uses the
+        ``conversation_events_fts`` FTS5 table. Both are porter-stemmed and
+        treat the query as a conjunction of terms (see ``utils.search``). A
+        session matches if any of its events matches.
+      - policy_intervention: when True, restrict to sessions with at least one
+        policy intervention.
+
+    Known limitation (tracked separately): the search corpus is built from
+    ``final_request`` text, which includes gateway-injected ``<policy-context>``
+    blocks. Queries for policy-context terms can therefore over-match on
+    sessions that ran under an output-modifying policy.
+    """
+
+    model: str | None = None
+    from_time: datetime | None = None
+    to_time: datetime | None = None
+    q: str | None = None
+    policy_intervention: bool = False
+
+    def is_empty(self) -> bool:
+        """True when no filter is active (the unfiltered list fast path applies)."""
+        return (
+            self.model is None
+            and self.from_time is None
+            and self.to_time is None
+            and not (self.q and self.q.strip())
+            and not self.policy_intervention
+        )
+
+
 class SessionListResponse(BaseModel):
     """Response for session list endpoint."""
 
     sessions: list[SessionSummary]
-    total: int  # Total count of all sessions in database
+    total: int  # Total count of sessions matching the active filters (all sessions when unfiltered)
     offset: int = 0  # Current offset for pagination
     has_more: bool = False  # Whether there are more sessions after this page
 
@@ -111,6 +157,7 @@ __all__ = [
     "ConversationMessage",
     "ConversationTurn",
     "SessionSummary",
+    "SessionSearchParams",
     "SessionListResponse",
     "SessionDetail",
 ]

--- a/src/luthien_proxy/history/models.py
+++ b/src/luthien_proxy/history/models.py
@@ -6,11 +6,11 @@ Defines Pydantic models for:
 - Policy annotations for interventions
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class MessageType(str, Enum):
@@ -99,7 +99,11 @@ class SessionSearchParams(BaseModel):
       - from_time / to_time: the session's *last activity* (the max event
         timestamp) falls within ``[from_time, to_time]``, inclusive. Either
         bound may be omitted. (Last-activity, not overlap — consistent with the
-        list's ``ORDER BY last_ts``.)
+        list's ``ORDER BY last_ts``.) Bounds are interpreted as UTC: a
+        timezone-aware value is converted to UTC and a naive value is taken
+        as-is (see the validator below). When ``user_id`` is also set, "last
+        activity" is scoped to *that user's* events in the session, not the
+        session's last activity overall.
       - q: full-text content search over indexed conversation text. Postgres
         uses the ``search_vector`` tsvector column; SQLite uses the
         ``conversation_events_fts`` FTS5 table. Both are porter-stemmed and
@@ -119,6 +123,20 @@ class SessionSearchParams(BaseModel):
     to_time: datetime | None = None
     q: str | None = None
     policy_intervention: bool = False
+
+    @field_validator("from_time", "to_time")
+    @classmethod
+    def _to_naive_utc(cls, value: datetime | None) -> datetime | None:
+        """Normalize time bounds to naive UTC.
+
+        ``created_at`` is compared as a UTC timestamp (Postgres ``timestamptz``)
+        / lexicographic ISO text (SQLite). A timezone-aware input is converted
+        to UTC and stripped of tzinfo so comparison is consistent across
+        backends; a naive input is left as-is (already assumed UTC).
+        """
+        if value is not None and value.tzinfo is not None:
+            return value.astimezone(timezone.utc).replace(tzinfo=None)
+        return value
 
     def is_empty(self) -> bool:
         """True when no filter is active (the unfiltered list fast path applies)."""

--- a/src/luthien_proxy/history/routes.py
+++ b/src/luthien_proxy/history/routes.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import FileResponse, PlainTextResponse
@@ -23,7 +24,7 @@ from luthien_proxy.utils.constants import (
 )
 from luthien_proxy.utils.db import DatabasePool
 
-from .models import SessionDetail, SessionListResponse
+from .models import SessionDetail, SessionListResponse, SessionSearchParams
 from .service import export_session_jsonl, export_session_markdown, fetch_session_detail, fetch_session_list
 
 logger = logging.getLogger(__name__)
@@ -79,14 +80,50 @@ async def list_sessions(
             "X-Luthien-User-Id header (when TRUST_USER_ID_HEADER=true) or JWT sub claim."
         ),
     ),
+    model: str | None = Query(
+        default=None,
+        description="Filter to sessions that used this exact model (matches final_model on any turn).",
+    ),
+    from_time: datetime | None = Query(
+        default=None,
+        alias="from",
+        description="Lower bound (inclusive) on session last activity, ISO 8601.",
+    ),
+    to_time: datetime | None = Query(
+        default=None,
+        alias="to",
+        description="Upper bound (inclusive) on session last activity, ISO 8601.",
+    ),
+    q: str | None = Query(
+        default=None,
+        description=(
+            "Full-text content search over conversation text (porter-stemmed, "
+            "terms ANDed). A session matches if any turn matches. Note: the index "
+            "currently includes gateway-injected policy-context text, so queries "
+            "for policy-context terms may over-match on policy-active sessions."
+        ),
+    ),
+    policy_intervention: bool = Query(
+        default=False,
+        description="When true, return only sessions that had at least one policy intervention.",
+    ),
 ) -> SessionListResponse:
     """List recent sessions with summaries.
 
     Returns a list of session summaries ordered by most recent activity,
     including turn counts, policy interventions, and models used.
-    Supports pagination via limit and offset parameters.
+    Supports pagination via limit and offset, plus optional server-side
+    filters (user_id, model, from/to time range, full-text q, policy_intervention).
+    ``total`` reflects the count after filters are applied.
     """
-    return await fetch_session_list(limit, db_pool, offset, user_id=user_id)
+    search = SessionSearchParams(
+        model=model,
+        from_time=from_time,
+        to_time=to_time,
+        q=q,
+        policy_intervention=policy_intervention,
+    )
+    return await fetch_session_list(limit, db_pool, offset, user_id=user_id, search=search)
 
 
 @api_router.get("/sessions/{session_id}", response_model=SessionDetail)

--- a/src/luthien_proxy/history/routes.py
+++ b/src/luthien_proxy/history/routes.py
@@ -87,12 +87,16 @@ async def list_sessions(
     from_time: datetime | None = Query(
         default=None,
         alias="from",
-        description="Lower bound (inclusive) on session last activity, ISO 8601.",
+        description="Lower bound (inclusive) on session last activity, ISO 8601. Interpreted as UTC.",
     ),
     to_time: datetime | None = Query(
         default=None,
         alias="to",
-        description="Upper bound (inclusive) on session last activity, ISO 8601.",
+        description=(
+            "Upper bound (inclusive) on session last activity, ISO 8601. Interpreted as UTC. "
+            "Inclusive at the timestamp level: to include all of a calendar day, pass end-of-day "
+            "(e.g. 2026-04-30T23:59:59)."
+        ),
     ),
     q: str | None = Query(
         default=None,

--- a/src/luthien_proxy/history/service.py
+++ b/src/luthien_proxy/history/service.py
@@ -354,6 +354,25 @@ def _extract_preview_message(payload: dict[str, Any] | str | None) -> str | None
     return None
 
 
+# A "real" policy intervention is any policy.* event that is not a judge
+# lifecycle/evaluation event. This predicate (over alias ``ce``) is the single
+# source of truth — consumed by both the per-session stat aggregate and the
+# policy_intervention filter, on both backends. Keep it here so the stat and
+# the filter can never drift out of sync.
+_INTERVENTION_PREDICATE = "ce.event_type LIKE 'policy.%' AND ce.event_type NOT LIKE 'policy.%judge.evaluation%'"
+
+
+def _intervention_count_expr(is_postgres: bool) -> str:
+    """Aggregate expression counting real policy interventions for a session.
+
+    Postgres uses a ``COUNT(*) FILTER`` aggregate; SQLite lacks ``FILTER`` so it
+    uses ``SUM(CASE ...)``. Both wrap the same :data:`_INTERVENTION_PREDICATE`.
+    """
+    if is_postgres:
+        return f"COUNT(*) FILTER (WHERE {_INTERVENTION_PREDICATE})"
+    return f"SUM(CASE WHEN {_INTERVENTION_PREDICATE} THEN 1 ELSE 0 END)"
+
+
 def _build_session_filter_sql(
     search: SessionSearchParams,
     db_pool: DatabasePool,
@@ -420,16 +439,7 @@ def _build_session_filter_sql(
         having.append(f"MAX(ce.created_at) <= {placeholder}")
 
     if search.policy_intervention:
-        if db_pool.is_postgres:
-            having.append(
-                "COUNT(*) FILTER (WHERE ce.event_type LIKE 'policy.%' "
-                "AND ce.event_type NOT LIKE 'policy.%judge.evaluation%') > 0"
-            )
-        else:
-            having.append(
-                "SUM(CASE WHEN ce.event_type LIKE 'policy.%' "
-                "AND ce.event_type NOT LIKE 'policy.%judge.evaluation%' THEN 1 ELSE 0 END) > 0"
-            )
+        having.append(f"{_intervention_count_expr(db_pool.is_postgres)} > 0")
 
     return where_gates, having
 
@@ -565,10 +575,7 @@ async def _fetch_session_list_pg(
                     MAX(ce.created_at) as last_ts,
                     COUNT(*) as total_events,
                     COUNT(DISTINCT ce.call_id) as turn_count,
-                    COUNT(*) FILTER (
-                        WHERE ce.event_type LIKE 'policy.%'
-                        AND ce.event_type NOT LIKE 'policy.%judge.evaluation%'
-                    ) as policy_interventions
+                    {_intervention_count_expr(True)} as policy_interventions
                 FROM conversation_events ce
                 WHERE ce.session_id IS NOT NULL
                 {user_call_filter}
@@ -764,11 +771,7 @@ async def _fetch_session_list_sqlite(
                 MAX(ce.created_at) as last_ts,
                 COUNT(*) as total_events,
                 COUNT(DISTINCT ce.call_id) as turn_count,
-                SUM(CASE
-                    WHEN ce.event_type LIKE 'policy.%'
-                    AND ce.event_type NOT LIKE 'policy.%judge.evaluation%'
-                    THEN 1 ELSE 0
-                END) as policy_interventions
+                {_intervention_count_expr(False)} as policy_interventions
             FROM conversation_events ce
             WHERE ce.session_id IS NOT NULL
             {user_call_filter}

--- a/src/luthien_proxy/history/service.py
+++ b/src/luthien_proxy/history/service.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from typing import Any, TypedDict, cast
 
 from luthien_proxy.utils.db import DatabasePool, parse_db_ts
+from luthien_proxy.utils.search import session_fts_filter_sql
 
 from .models import (
     ConversationMessage,
@@ -23,6 +24,7 @@ from .models import (
     PolicyAnnotation,
     SessionDetail,
     SessionListResponse,
+    SessionSearchParams,
     SessionSummary,
 )
 
@@ -352,12 +354,103 @@ def _extract_preview_message(payload: dict[str, Any] | str | None) -> str | None
     return None
 
 
+def _build_session_filter_sql(
+    search: SessionSearchParams,
+    db_pool: DatabasePool,
+    args: list[Any],
+    *,
+    user_scope_sql: str = "",
+) -> tuple[list[str], list[str]]:
+    """Build session-qualifying WHERE gates and HAVING clauses for a search.
+
+    Appends bound parameters to ``args`` (asyncpg-style ``$N``, 1-indexed over
+    the final args list) and returns ``(where_gates, having)``:
+
+    * ``where_gates`` are *session-level* predicates over ``conversation_events
+      ce`` — each of the form ``ce.session_id IN (...)``. Because they constrain
+      ``session_id`` rather than individual events, a qualifying session keeps
+      *all* of its events in the aggregation, so per-session stats (turn_count,
+      models, policy_interventions) stay correct.
+    * ``having`` are aggregate predicates ANDed into ``GROUP BY ... HAVING``.
+
+    ``user_scope_sql`` (when non-empty) is an ``AND ce.call_id IN (...)`` clause
+    using an already-allocated user_id placeholder; it is appended inside the
+    model/q gate subqueries so a session can only qualify on *this* user's
+    events. The time/policy HAVING clauses need no scoping — they run over the
+    caller's session_stats, which is already user-scoped.
+
+    SECURITY INVARIANT: every user-supplied value is bound via ``args`` and
+    referenced only by a ``$N`` placeholder the builder controls; no user input
+    is interpolated into SQL text. ``session_fts_filter_sql`` owns sanitizing
+    the free-text ``q`` for each backend.
+    """
+    where_gates: list[str] = []
+    having: list[str] = []
+
+    def add_param(value: Any) -> str:
+        args.append(value)
+        return f"${len(args)}"
+
+    if search.model is not None:
+        model_col = "ce.payload->>'final_model'" if db_pool.is_postgres else "json_extract(ce.payload, '$.final_model')"
+        placeholder = add_param(search.model)
+        where_gates.append(
+            "ce.session_id IN ("
+            "SELECT ce.session_id FROM conversation_events ce "
+            f"WHERE ce.event_type = 'transaction.request_recorded' AND {model_col} = {placeholder} "
+            f"{user_scope_sql})"
+        )
+
+    if search.q and search.q.strip():
+        # session_fts_filter_sql inlines the placeholder verbatim, so reserve the
+        # next slot first, then bind the (sanitized) value it returns into it.
+        placeholder = f"${len(args) + 1}"
+        fragment, bind_value = session_fts_filter_sql(db_pool, search.q, placeholder=placeholder)
+        add_param(bind_value)
+        where_gates.append(
+            f"ce.session_id IN (SELECT ce.session_id FROM conversation_events ce WHERE {fragment} {user_scope_sql})"
+        )
+
+    if search.from_time is not None:
+        placeholder = add_param(search.from_time if db_pool.is_postgres else search.from_time.isoformat())
+        having.append(f"MAX(ce.created_at) >= {placeholder}")
+
+    if search.to_time is not None:
+        placeholder = add_param(search.to_time if db_pool.is_postgres else search.to_time.isoformat())
+        having.append(f"MAX(ce.created_at) <= {placeholder}")
+
+    if search.policy_intervention:
+        if db_pool.is_postgres:
+            having.append(
+                "COUNT(*) FILTER (WHERE ce.event_type LIKE 'policy.%' "
+                "AND ce.event_type NOT LIKE 'policy.%judge.evaluation%') > 0"
+            )
+        else:
+            having.append(
+                "SUM(CASE WHEN ce.event_type LIKE 'policy.%' "
+                "AND ce.event_type NOT LIKE 'policy.%judge.evaluation%' THEN 1 ELSE 0 END) > 0"
+            )
+
+    return where_gates, having
+
+
+def _gate_clause(where_gates: list[str]) -> str:
+    """Render session-qualifying gates as a WHERE continuation (``AND ...``) or ``""``."""
+    return ("AND " + " AND ".join(where_gates)) if where_gates else ""
+
+
+def _having_clause(having: list[str]) -> str:
+    """Render aggregate predicates as a ``HAVING ...`` clause or ``""``."""
+    return ("HAVING " + " AND ".join(having)) if having else ""
+
+
 async def fetch_session_list(
     limit: int,
     db_pool: DatabasePool,
     offset: int = 0,
     *,
     user_id: str | None = None,
+    search: SessionSearchParams | None = None,
 ) -> SessionListResponse:
     """Fetch list of recent sessions with summaries.
 
@@ -367,13 +460,17 @@ async def fetch_session_list(
         offset: Number of sessions to skip for pagination
         user_id: If provided, only return sessions whose conversation_calls
             row has this exact user_id. Used to attribute traffic per user.
+        search: Optional server-side filters (model, time range, full-text
+            ``q``, policy_intervention). When None/empty the unfiltered hot path
+            runs unchanged. ``total`` reflects the filtered count.
 
     Returns:
         List of session summaries ordered by most recent activity
     """
+    search = search or SessionSearchParams()
     if db_pool.is_sqlite:
-        return await _fetch_session_list_sqlite(limit, db_pool, offset, user_id=user_id)
-    return await _fetch_session_list_pg(limit, db_pool, offset, user_id=user_id)
+        return await _fetch_session_list_sqlite(limit, db_pool, offset, user_id=user_id, search=search)
+    return await _fetch_session_list_pg(limit, db_pool, offset, user_id=user_id, search=search)
 
 
 async def _fetch_session_list_pg(
@@ -382,35 +479,63 @@ async def _fetch_session_list_pg(
     offset: int = 0,
     *,
     user_id: str | None = None,
+    search: SessionSearchParams | None = None,
 ) -> SessionListResponse:
     """PostgreSQL version using PG-specific features (FILTER, DISTINCT ON, array_agg)."""
-    # SECURITY INVARIANT: user_id is bound as a query parameter, never
-    # interpolated into the SQL string. The placeholder slot is fixed,
-    # only the WHERE-clause presence is conditional on whether a filter
-    # was requested. See test_fetch_session_list_user_filter_sql_injection.
+    # SECURITY INVARIANT: user_id and every search value are bound as query
+    # parameters, never interpolated into the SQL string. The user_id slot is
+    # fixed at $3; search params (built by _build_session_filter_sql) occupy
+    # $4+ when present. See test_fetch_session_list_user_filter_sql_injection.
     #
     # PERF: the user_id-population join to conversation_calls is intentionally
     # OUT of the main aggregation query. When no filter is requested we never
     # touch conversation_calls in the hot CTE — user_ids come from a separate
     # post-query keyed on the page's session_ids (mirrors the SQLite pattern).
+    search = search or SessionSearchParams()
     async with db_pool.connection() as conn:
-        if user_id is not None:
-            total_count = await conn.fetchval(
-                """
-                SELECT COUNT(DISTINCT ce.session_id)
-                FROM conversation_events ce
-                JOIN conversation_calls cc ON ce.call_id = cc.call_id
-                WHERE ce.session_id IS NOT NULL AND cc.user_id = $1
-                """,
-                user_id,
-            )
+        if search.is_empty():
+            if user_id is not None:
+                total_count = await conn.fetchval(
+                    """
+                    SELECT COUNT(DISTINCT ce.session_id)
+                    FROM conversation_events ce
+                    JOIN conversation_calls cc ON ce.call_id = cc.call_id
+                    WHERE ce.session_id IS NOT NULL AND cc.user_id = $1
+                    """,
+                    user_id,
+                )
+            else:
+                total_count = await conn.fetchval(
+                    """
+                    SELECT COUNT(DISTINCT session_id)
+                    FROM conversation_events
+                    WHERE session_id IS NOT NULL
+                    """
+                )
         else:
+            # Filtered count: count sessions that survive the same qualifying
+            # gates + HAVING as the page query. user_id (when set) is $1 here.
+            count_args: list[Any] = []
+            count_user_filter = ""
+            if user_id is not None:
+                count_args.append(user_id)
+                count_user_filter = "AND ce.call_id IN (SELECT call_id FROM conversation_calls WHERE user_id = $1)"
+            count_gates, count_having = _build_session_filter_sql(
+                search, db_pool, count_args, user_scope_sql=count_user_filter
+            )
             total_count = await conn.fetchval(
-                """
-                SELECT COUNT(DISTINCT session_id)
-                FROM conversation_events
-                WHERE session_id IS NOT NULL
-                """
+                f"""
+                SELECT COUNT(*) FROM (
+                    SELECT ce.session_id
+                    FROM conversation_events ce
+                    WHERE ce.session_id IS NOT NULL
+                    {count_user_filter}
+                    {_gate_clause(count_gates)}
+                    GROUP BY ce.session_id
+                    {_having_clause(count_having)}
+                ) AS qualifying
+                """,
+                *count_args,
             )
 
         # When the caller filters by user_id we restrict the events under
@@ -425,6 +550,11 @@ async def _fetch_session_list_pg(
         query_args: list[Any] = [limit, offset]
         if user_id is not None:
             query_args.append(user_id)
+
+        # Search params occupy $4+ (after limit=$1, offset=$2, user_id=$3).
+        where_gates, having = _build_session_filter_sql(search, db_pool, query_args, user_scope_sql=user_call_filter)
+        gate_clause = _gate_clause(where_gates)
+        having_clause = _having_clause(having)
 
         rows = await conn.fetch(
             f"""
@@ -442,7 +572,9 @@ async def _fetch_session_list_pg(
                 FROM conversation_events ce
                 WHERE ce.session_id IS NOT NULL
                 {user_call_filter}
+                {gate_clause}
                 GROUP BY ce.session_id
+                {having_clause}
             ),
             session_models AS (
                 SELECT DISTINCT
@@ -551,6 +683,7 @@ async def _fetch_session_list_sqlite(
     offset: int = 0,
     *,
     user_id: str | None = None,
+    search: SessionSearchParams | None = None,
 ) -> SessionListResponse:
     """SQLite version: 3 queries total (vs PostgreSQL's 2).
 
@@ -558,26 +691,52 @@ async def _fetch_session_list_sqlite(
     query each, then merging in Python. PostgreSQL uses array_agg/DISTINCT ON
     in a single CTE; SQLite lacks those, so we use IN (session_ids) instead.
     """
-    # SECURITY INVARIANT: user_id is bound as a query parameter, never
-    # interpolated into the SQL string.
+    # SECURITY INVARIANT: user_id and every search value are bound as query
+    # parameters, never interpolated into the SQL string. user_id occupies $3
+    # in the page query ($1 in the filtered count); search params follow.
+    search = search or SessionSearchParams()
     async with db_pool.connection() as conn:
-        if user_id is not None:
-            total_count = await conn.fetchval(
-                """
-                SELECT COUNT(DISTINCT ce.session_id)
-                FROM conversation_events ce
-                JOIN conversation_calls cc ON ce.call_id = cc.call_id
-                WHERE ce.session_id IS NOT NULL AND cc.user_id = $1
-                """,
-                user_id,
-            )
+        if search.is_empty():
+            if user_id is not None:
+                total_count = await conn.fetchval(
+                    """
+                    SELECT COUNT(DISTINCT ce.session_id)
+                    FROM conversation_events ce
+                    JOIN conversation_calls cc ON ce.call_id = cc.call_id
+                    WHERE ce.session_id IS NOT NULL AND cc.user_id = $1
+                    """,
+                    user_id,
+                )
+            else:
+                total_count = await conn.fetchval(
+                    """
+                    SELECT COUNT(DISTINCT session_id)
+                    FROM conversation_events
+                    WHERE session_id IS NOT NULL
+                    """
+                )
         else:
+            count_args: list[Any] = []
+            count_user_filter = ""
+            if user_id is not None:
+                count_args.append(user_id)
+                count_user_filter = "AND ce.call_id IN (SELECT call_id FROM conversation_calls WHERE user_id = $1)"
+            count_gates, count_having = _build_session_filter_sql(
+                search, db_pool, count_args, user_scope_sql=count_user_filter
+            )
             total_count = await conn.fetchval(
-                """
-                SELECT COUNT(DISTINCT session_id)
-                FROM conversation_events
-                WHERE session_id IS NOT NULL
-                """
+                f"""
+                SELECT COUNT(*) FROM (
+                    SELECT ce.session_id
+                    FROM conversation_events ce
+                    WHERE ce.session_id IS NOT NULL
+                    {count_user_filter}
+                    {_gate_clause(count_gates)}
+                    GROUP BY ce.session_id
+                    {_having_clause(count_having)}
+                ) AS qualifying
+                """,
+                *count_args,
             )
 
         # PERF: only filter through conversation_calls when a user filter is
@@ -593,6 +752,9 @@ async def _fetch_session_list_sqlite(
         query_args: list[Any] = [limit, offset]
         if user_id is not None:
             query_args.append(user_id)
+
+        # Search params occupy $4+ (after limit=$1, offset=$2, user_id=$3).
+        where_gates, having = _build_session_filter_sql(search, db_pool, query_args, user_scope_sql=user_call_filter)
 
         rows = await conn.fetch(
             f"""
@@ -610,7 +772,9 @@ async def _fetch_session_list_sqlite(
             FROM conversation_events ce
             WHERE ce.session_id IS NOT NULL
             {user_call_filter}
+            {_gate_clause(where_gates)}
             GROUP BY ce.session_id
+            {_having_clause(having)}
             ORDER BY last_ts DESC
             LIMIT $1 OFFSET $2
             """,

--- a/tests/luthien_proxy/unit_tests/history/test_routes.py
+++ b/tests/luthien_proxy/unit_tests/history/test_routes.py
@@ -17,6 +17,7 @@ from luthien_proxy.history.models import (
     MessageType,
     SessionDetail,
     SessionListResponse,
+    SessionSearchParams,
     SessionSummary,
 )
 from luthien_proxy.history.routes import (
@@ -57,7 +58,18 @@ class TestListSessionsRoute:
             new_callable=AsyncMock,
             return_value=expected_response,
         ) as mock_fetch:
-            result = await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=50, offset=0, user_id=None)
+            result = await list_sessions(
+                _=AUTH_TOKEN,
+                db_pool=mock_db_pool,
+                limit=50,
+                offset=0,
+                user_id=None,
+                model=None,
+                from_time=None,
+                to_time=None,
+                q=None,
+                policy_intervention=False,
+            )
 
             assert isinstance(result, SessionListResponse)
             assert result.total == 100
@@ -65,7 +77,7 @@ class TestListSessionsRoute:
             assert result.has_more is True
             assert len(result.sessions) == 1
             assert result.sessions[0].session_id == "session-1"
-            mock_fetch.assert_called_once_with(50, mock_db_pool, 0, user_id=None)
+            mock_fetch.assert_called_once_with(50, mock_db_pool, 0, user_id=None, search=SessionSearchParams())
 
     @pytest.mark.asyncio
     async def test_list_sessions_custom_limit(self):
@@ -77,8 +89,19 @@ class TestListSessionsRoute:
             new_callable=AsyncMock,
             return_value=SessionListResponse(sessions=[], total=0),
         ) as mock_fetch:
-            await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=100, offset=0, user_id=None)
-            mock_fetch.assert_called_once_with(100, mock_db_pool, 0, user_id=None)
+            await list_sessions(
+                _=AUTH_TOKEN,
+                db_pool=mock_db_pool,
+                limit=100,
+                offset=0,
+                user_id=None,
+                model=None,
+                from_time=None,
+                to_time=None,
+                q=None,
+                policy_intervention=False,
+            )
+            mock_fetch.assert_called_once_with(100, mock_db_pool, 0, user_id=None, search=SessionSearchParams())
 
     @pytest.mark.asyncio
     async def test_list_sessions_with_offset(self):
@@ -96,11 +119,59 @@ class TestListSessionsRoute:
             new_callable=AsyncMock,
             return_value=expected_response,
         ) as mock_fetch:
-            result = await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=50, offset=50, user_id=None)
+            result = await list_sessions(
+                _=AUTH_TOKEN,
+                db_pool=mock_db_pool,
+                limit=50,
+                offset=50,
+                user_id=None,
+                model=None,
+                from_time=None,
+                to_time=None,
+                q=None,
+                policy_intervention=False,
+            )
 
             assert result.offset == 50
             assert result.has_more is True
-            mock_fetch.assert_called_once_with(50, mock_db_pool, 50, user_id=None)
+            mock_fetch.assert_called_once_with(50, mock_db_pool, 50, user_id=None, search=SessionSearchParams())
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_forwards_search_filters(self):
+        """Search query params are assembled into SessionSearchParams and forwarded."""
+        from datetime import datetime
+
+        mock_db_pool = MagicMock()
+        with patch(
+            "luthien_proxy.history.routes.fetch_session_list",
+            new_callable=AsyncMock,
+            return_value=SessionListResponse(sessions=[], total=0),
+        ) as mock_fetch:
+            await list_sessions(
+                _=AUTH_TOKEN,
+                db_pool=mock_db_pool,
+                limit=50,
+                offset=0,
+                user_id="sami",
+                model="claude-opus-4-6",
+                from_time=datetime(2026, 4, 1),
+                to_time=datetime(2026, 4, 12),
+                q="error",
+                policy_intervention=True,
+            )
+            mock_fetch.assert_called_once_with(
+                50,
+                mock_db_pool,
+                0,
+                user_id="sami",
+                search=SessionSearchParams(
+                    model="claude-opus-4-6",
+                    from_time=datetime(2026, 4, 1),
+                    to_time=datetime(2026, 4, 12),
+                    q="error",
+                    policy_intervention=True,
+                ),
+            )
 
     @pytest.mark.asyncio
     async def test_list_sessions_empty(self):
@@ -112,7 +183,18 @@ class TestListSessionsRoute:
             new_callable=AsyncMock,
             return_value=SessionListResponse(sessions=[], total=0),
         ):
-            result = await list_sessions(_=AUTH_TOKEN, db_pool=mock_db_pool, limit=50, offset=0, user_id=None)
+            result = await list_sessions(
+                _=AUTH_TOKEN,
+                db_pool=mock_db_pool,
+                limit=50,
+                offset=0,
+                user_id=None,
+                model=None,
+                from_time=None,
+                to_time=None,
+                q=None,
+                policy_intervention=False,
+            )
 
             assert result.total == 0
             assert result.sessions == []

--- a/tests/luthien_proxy/unit_tests/history/test_search.py
+++ b/tests/luthien_proxy/unit_tests/history/test_search.py
@@ -1,0 +1,475 @@
+"""Tests for server-side session search filters on ``fetch_session_list``.
+
+The end-to-end filter behavior (model / time range / full-text ``q`` /
+policy_intervention) is exercised against a real in-memory SQLite database with
+all migrations applied, so the FTS5 virtual table and its sync triggers are
+live — these are integration-grade unit tests, not mock-driven.
+
+The Postgres dialect has no test tier in this repo, so its clause shape is
+covered by direct unit tests of ``_build_session_filter_sql`` with a fake
+postgres pool (``test_build_session_filter_sql_*``). That catches FTS-fragment
+and aggregate-syntax regressions on the PG path without a live database.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from luthien_proxy.history.models import SessionSearchParams
+from luthien_proxy.history.service import _build_session_filter_sql, fetch_session_list
+from luthien_proxy.utils.db import DatabasePool
+from luthien_proxy.utils.db_sqlite import SqliteConnection
+
+
+@pytest.fixture
+async def sqlite_pool() -> DatabasePool:
+    """In-memory SQLite pool with all migrations applied (incl. FTS5 infra)."""
+    pool = DatabasePool("sqlite://:memory:")
+    migrations_dir = Path(__file__).parent.parent.parent.parent.parent / "migrations" / "sqlite"
+    async with pool.connection() as conn:
+        assert isinstance(conn, SqliteConnection)
+        for migration_file in sorted(migrations_dir.glob("*.sql")):
+            await conn.executescript(migration_file.read_text())
+    yield pool
+    await pool.close()
+
+
+async def _seed_request(
+    pool: DatabasePool,
+    *,
+    call_id: str,
+    session_id: str,
+    created_at: str,
+    model: str = "gpt-4",
+    content: str = "hello world",
+    user_id: str | None = None,
+    event_id: str | None = None,
+) -> None:
+    """Insert one conversation_calls row + one request_recorded event.
+
+    The FTS5 insert trigger fires on the event, indexing ``content`` from the
+    payload's first user message.
+    """
+    async with pool.connection() as conn:
+        await conn.execute(
+            """
+            INSERT INTO conversation_calls (call_id, model_name, provider, status, session_id, user_id, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            call_id,
+            model,
+            "openai",
+            "completed",
+            session_id,
+            user_id,
+            created_at,
+        )
+        await conn.execute(
+            """
+            INSERT INTO conversation_events (id, call_id, event_type, payload, session_id, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            event_id or f"event-{call_id}",
+            call_id,
+            "transaction.request_recorded",
+            json.dumps(
+                {
+                    "final_model": model,
+                    "final_request": {"messages": [{"role": "user", "content": content}]},
+                }
+            ),
+            session_id,
+            created_at,
+        )
+
+
+async def _add_event(
+    pool: DatabasePool,
+    *,
+    event_id: str,
+    call_id: str,
+    session_id: str,
+    event_type: str,
+    created_at: str,
+    payload: dict | None = None,
+) -> None:
+    """Append an extra event (e.g. a policy intervention) to an existing session."""
+    async with pool.connection() as conn:
+        await conn.execute(
+            """
+            INSERT INTO conversation_events (id, call_id, event_type, payload, session_id, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            event_id,
+            call_id,
+            event_type,
+            json.dumps(payload or {}),
+            session_id,
+            created_at,
+        )
+
+
+class TestModelFilter:
+    @pytest.mark.asyncio
+    async def test_model_filter_returns_only_matching(self, sqlite_pool: DatabasePool):
+        await _seed_request(
+            sqlite_pool, call_id="c1", session_id="s-opus", created_at="2026-04-01T10:00:00", model="claude-opus-4-6"
+        )
+        await _seed_request(
+            sqlite_pool, call_id="c2", session_id="s-gpt", created_at="2026-04-01T11:00:00", model="gpt-4"
+        )
+
+        result = await fetch_session_list(
+            limit=10, db_pool=sqlite_pool, search=SessionSearchParams(model="claude-opus-4-6")
+        )
+        assert [s.session_id for s in result.sessions] == ["s-opus"]
+        assert result.total == 1
+
+    @pytest.mark.asyncio
+    async def test_model_filter_no_match(self, sqlite_pool: DatabasePool):
+        await _seed_request(sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00", model="gpt-4")
+        result = await fetch_session_list(
+            limit=10, db_pool=sqlite_pool, search=SessionSearchParams(model="model-that-does-not-exist")
+        )
+        assert result.sessions == []
+        assert result.total == 0
+
+    @pytest.mark.asyncio
+    async def test_model_filter_keeps_full_session_stats(self, sqlite_pool: DatabasePool):
+        """A session qualifies on one model but its stats include all turns."""
+        await _seed_request(sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00", model="gpt-4")
+        await _seed_request(
+            sqlite_pool, call_id="c2", session_id="s1", created_at="2026-04-01T10:05:00", model="claude-opus-4-6"
+        )
+        result = await fetch_session_list(limit=10, db_pool=sqlite_pool, search=SessionSearchParams(model="gpt-4"))
+        assert len(result.sessions) == 1
+        session = result.sessions[0]
+        # Both turns counted even though only one used gpt-4.
+        assert session.turn_count == 2
+        assert sorted(session.models_used) == ["claude-opus-4-6", "gpt-4"]
+
+
+class TestContentSearch:
+    @pytest.mark.asyncio
+    async def test_q_matches_user_message_text(self, sqlite_pool: DatabasePool):
+        await _seed_request(
+            sqlite_pool,
+            call_id="c1",
+            session_id="s-needle",
+            created_at="2026-04-01T10:00:00",
+            content="please find the needle",
+        )
+        await _seed_request(
+            sqlite_pool,
+            call_id="c2",
+            session_id="s-other",
+            created_at="2026-04-01T11:00:00",
+            content="totally unrelated text",
+        )
+        result = await fetch_session_list(limit=10, db_pool=sqlite_pool, search=SessionSearchParams(q="needle"))
+        assert [s.session_id for s in result.sessions] == ["s-needle"]
+
+    @pytest.mark.asyncio
+    async def test_q_is_porter_stemmed(self, sqlite_pool: DatabasePool):
+        """FTS5 porter tokenizer stems, so 'run' matches 'running' (parity with PG english config)."""
+        await _seed_request(
+            sqlite_pool,
+            call_id="c1",
+            session_id="s1",
+            created_at="2026-04-01T10:00:00",
+            content="the server is running",
+        )
+        result = await fetch_session_list(limit=10, db_pool=sqlite_pool, search=SessionSearchParams(q="run"))
+        assert [s.session_id for s in result.sessions] == ["s1"]
+
+    @pytest.mark.asyncio
+    async def test_q_no_match_returns_empty(self, sqlite_pool: DatabasePool):
+        await _seed_request(
+            sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00", content="hello"
+        )
+        result = await fetch_session_list(limit=10, db_pool=sqlite_pool, search=SessionSearchParams(q="absent"))
+        assert result.sessions == []
+        assert result.total == 0
+
+    @pytest.mark.asyncio
+    async def test_q_with_fts_special_chars_does_not_crash(self, sqlite_pool: DatabasePool):
+        """FTS5 metacharacters in q are sanitized by session_fts_filter_sql, not injected."""
+        await _seed_request(
+            sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00", content="hello"
+        )
+        # A query full of FTS5 operators must not raise; it simply matches nothing here.
+        result = await fetch_session_list(limit=10, db_pool=sqlite_pool, search=SessionSearchParams(q='" OR - + : ('))
+        assert result.sessions == []
+
+
+class TestTimeRangeFilter:
+    @pytest.mark.asyncio
+    async def test_to_time_excludes_sessions_with_later_activity(self, sqlite_pool: DatabasePool):
+        """Last-activity semantics: a session whose last event is after to_time is excluded."""
+        # Session spans 10:00 and 12:00; to_time is 11:00 → last activity (12:00) > to → excluded.
+        await _seed_request(sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00")
+        await _add_event(
+            sqlite_pool,
+            event_id="e-late",
+            call_id="c1",
+            session_id="s1",
+            event_type="transaction.streaming_response_recorded",
+            created_at="2026-04-01T12:00:00",
+        )
+        result = await fetch_session_list(
+            limit=10, db_pool=sqlite_pool, search=SessionSearchParams(to_time=datetime(2026, 4, 1, 11, 0, 0))
+        )
+        assert result.sessions == []
+
+    @pytest.mark.asyncio
+    async def test_time_range_keeps_full_stats_for_contained_session(self, sqlite_pool: DatabasePool):
+        """Regression (#581 review): time filter is a HAVING on last-activity, so it must
+        not mutilate per-session stats by dropping out-of-window events."""
+        await _seed_request(sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00")
+        await _add_event(
+            sqlite_pool,
+            event_id="e2",
+            call_id="c1",
+            session_id="s1",
+            event_type="transaction.streaming_response_recorded",
+            created_at="2026-04-01T10:00:01",
+        )
+        result = await fetch_session_list(
+            limit=10,
+            db_pool=sqlite_pool,
+            search=SessionSearchParams(from_time=datetime(2026, 4, 1, 9, 0, 0), to_time=datetime(2026, 4, 1, 11, 0, 0)),
+        )
+        assert len(result.sessions) == 1
+        # Both events counted — the time filter did not strip the response event.
+        assert result.sessions[0].total_events == 2
+
+    @pytest.mark.asyncio
+    async def test_from_time_excludes_older_sessions(self, sqlite_pool: DatabasePool):
+        await _seed_request(sqlite_pool, call_id="c-old", session_id="s-old", created_at="2026-03-01T10:00:00")
+        await _seed_request(sqlite_pool, call_id="c-new", session_id="s-new", created_at="2026-04-15T10:00:00")
+        result = await fetch_session_list(
+            limit=10, db_pool=sqlite_pool, search=SessionSearchParams(from_time=datetime(2026, 4, 1, 0, 0, 0))
+        )
+        assert [s.session_id for s in result.sessions] == ["s-new"]
+
+
+class TestPolicyInterventionFilter:
+    @pytest.mark.asyncio
+    async def test_only_sessions_with_interventions(self, sqlite_pool: DatabasePool):
+        await _seed_request(sqlite_pool, call_id="c-clean", session_id="s-clean", created_at="2026-04-01T10:00:00")
+        await _seed_request(sqlite_pool, call_id="c-flagged", session_id="s-flagged", created_at="2026-04-01T11:00:00")
+        await _add_event(
+            sqlite_pool,
+            event_id="e-block",
+            call_id="c-flagged",
+            session_id="s-flagged",
+            event_type="policy.anthropic_judge.tool_call_blocked",
+            created_at="2026-04-01T11:00:01",
+            payload={"summary": "blocked"},
+        )
+        result = await fetch_session_list(
+            limit=10, db_pool=sqlite_pool, search=SessionSearchParams(policy_intervention=True)
+        )
+        assert [s.session_id for s in result.sessions] == ["s-flagged"]
+        assert result.total == 1
+
+    @pytest.mark.asyncio
+    async def test_evaluation_events_do_not_qualify(self, sqlite_pool: DatabasePool):
+        """A session whose only policy events are judge evaluations is not an intervention."""
+        await _seed_request(sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00")
+        await _add_event(
+            sqlite_pool,
+            event_id="e-eval",
+            call_id="c1",
+            session_id="s1",
+            event_type="policy.anthropic_judge.evaluation_started",
+            created_at="2026-04-01T10:00:01",
+        )
+        result = await fetch_session_list(
+            limit=10, db_pool=sqlite_pool, search=SessionSearchParams(policy_intervention=True)
+        )
+        assert result.sessions == []
+
+
+class TestCombinedFilters:
+    @pytest.mark.asyncio
+    async def test_model_and_q_and_time_combined(self, sqlite_pool: DatabasePool):
+        # Target: opus session containing "needle" in April.
+        await _seed_request(
+            sqlite_pool,
+            call_id="c-hit",
+            session_id="s-hit",
+            created_at="2026-04-10T10:00:00",
+            model="claude-opus-4-6",
+            content="the needle is here",
+        )
+        # Right model + text but wrong time.
+        await _seed_request(
+            sqlite_pool,
+            call_id="c-oldtime",
+            session_id="s-oldtime",
+            created_at="2026-01-10T10:00:00",
+            model="claude-opus-4-6",
+            content="the needle is here",
+        )
+        # Right time + text but wrong model.
+        await _seed_request(
+            sqlite_pool,
+            call_id="c-wrongmodel",
+            session_id="s-wrongmodel",
+            created_at="2026-04-10T10:00:00",
+            model="gpt-4",
+            content="the needle is here",
+        )
+        # Right model + time but wrong text.
+        await _seed_request(
+            sqlite_pool,
+            call_id="c-wrongtext",
+            session_id="s-wrongtext",
+            created_at="2026-04-10T10:00:00",
+            model="claude-opus-4-6",
+            content="nothing relevant",
+        )
+        result = await fetch_session_list(
+            limit=10,
+            db_pool=sqlite_pool,
+            search=SessionSearchParams(
+                model="claude-opus-4-6",
+                q="needle",
+                from_time=datetime(2026, 4, 1, 0, 0, 0),
+                to_time=datetime(2026, 4, 30, 0, 0, 0),
+            ),
+        )
+        assert [s.session_id for s in result.sessions] == ["s-hit"]
+        assert result.total == 1
+
+
+class TestTotalReflectsFilter:
+    @pytest.mark.asyncio
+    async def test_total_is_filtered_count_not_global(self, sqlite_pool: DatabasePool):
+        await _seed_request(sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00", model="gpt-4")
+        await _seed_request(sqlite_pool, call_id="c2", session_id="s2", created_at="2026-04-01T11:00:00", model="gpt-4")
+        await _seed_request(
+            sqlite_pool, call_id="c3", session_id="s3", created_at="2026-04-01T12:00:00", model="claude-opus-4-6"
+        )
+        result = await fetch_session_list(
+            limit=10, db_pool=sqlite_pool, search=SessionSearchParams(model="claude-opus-4-6")
+        )
+        assert result.total == 1  # filtered, not the global 3
+        assert result.has_more is False
+
+
+class TestEmptySearchParityWithUnfiltered:
+    @pytest.mark.asyncio
+    async def test_empty_search_matches_no_search(self, sqlite_pool: DatabasePool):
+        await _seed_request(sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00")
+        await _seed_request(sqlite_pool, call_id="c2", session_id="s2", created_at="2026-04-01T11:00:00")
+        unfiltered = await fetch_session_list(limit=10, db_pool=sqlite_pool)
+        empty_search = await fetch_session_list(limit=10, db_pool=sqlite_pool, search=SessionSearchParams())
+        assert unfiltered.total == empty_search.total == 2
+        assert [s.session_id for s in unfiltered.sessions] == [s.session_id for s in empty_search.sessions]
+
+
+class TestSearchInjectionSafe:
+    @pytest.mark.asyncio
+    async def test_model_value_is_bound_not_interpolated(self, sqlite_pool: DatabasePool):
+        await _seed_request(sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00", model="gpt-4")
+        result = await fetch_session_list(
+            limit=10,
+            db_pool=sqlite_pool,
+            search=SessionSearchParams(model="gpt-4'; DROP TABLE conversation_events;--"),
+        )
+        assert result.sessions == []
+        # Table still intact and queryable.
+        intact = await fetch_session_list(limit=10, db_pool=sqlite_pool)
+        assert len(intact.sessions) == 1
+
+
+class _FakePool:
+    """Minimal DatabasePool stand-in for dialect-shape unit tests."""
+
+    def __init__(self, *, is_postgres: bool) -> None:
+        self.is_postgres = is_postgres
+        self.is_sqlite = not is_postgres
+
+
+class TestBuildSessionFilterSql:
+    """Dialect-shape coverage for the clause builder (esp. the un-runnable PG path)."""
+
+    def test_empty_search_produces_no_clauses(self):
+        args: list = [1, 2]
+        gates, having = _build_session_filter_sql(SessionSearchParams(), _FakePool(is_postgres=True), args)
+        assert gates == []
+        assert having == []
+        assert args == [1, 2]  # untouched
+
+    def test_postgres_q_uses_plainto_tsquery_and_search_vector(self):
+        args: list = []
+        gates, having = _build_session_filter_sql(SessionSearchParams(q="needle"), _FakePool(is_postgres=True), args)
+        assert len(gates) == 1
+        assert "search_vector @@ plainto_tsquery('english', $1)" in gates[0]
+        assert args == ["needle"]  # raw value bound; PG sanitizes via plainto_tsquery
+
+    def test_sqlite_q_uses_fts_match_table(self):
+        args: list = []
+        gates, _ = _build_session_filter_sql(SessionSearchParams(q="needle"), _FakePool(is_postgres=False), args)
+        assert "conversation_events_fts MATCH $1" in gates[0]
+        assert args == ['"needle"']  # phrase-quoted for FTS5
+
+    def test_postgres_model_uses_jsonb_arrow(self):
+        args: list = []
+        gates, _ = _build_session_filter_sql(
+            SessionSearchParams(model="claude-opus-4-6"), _FakePool(is_postgres=True), args
+        )
+        assert "ce.payload->>'final_model' = $1" in gates[0]
+        assert args == ["claude-opus-4-6"]
+
+    def test_sqlite_model_uses_json_extract(self):
+        args: list = []
+        gates, _ = _build_session_filter_sql(SessionSearchParams(model="gpt-4"), _FakePool(is_postgres=False), args)
+        assert "json_extract(ce.payload, '$.final_model') = $1" in gates[0]
+
+    def test_postgres_policy_intervention_uses_filter_aggregate(self):
+        args: list = []
+        _, having = _build_session_filter_sql(
+            SessionSearchParams(policy_intervention=True), _FakePool(is_postgres=True), args
+        )
+        assert any("FILTER (WHERE ce.event_type LIKE 'policy.%'" in h and "> 0" in h for h in having)
+
+    def test_sqlite_policy_intervention_uses_sum_case(self):
+        args: list = []
+        _, having = _build_session_filter_sql(
+            SessionSearchParams(policy_intervention=True), _FakePool(is_postgres=False), args
+        )
+        assert any("SUM(CASE WHEN ce.event_type LIKE 'policy.%'" in h for h in having)
+
+    def test_time_bounds_use_max_having_and_dialect_bind(self):
+        # Postgres binds the datetime object; SQLite binds an ISO string.
+        dt = datetime(2026, 4, 1, 12, 0, 0)
+        pg_args: list = []
+        _, pg_having = _build_session_filter_sql(
+            SessionSearchParams(from_time=dt, to_time=dt), _FakePool(is_postgres=True), pg_args
+        )
+        assert pg_having == ["MAX(ce.created_at) >= $1", "MAX(ce.created_at) <= $2"]
+        assert pg_args == [dt, dt]
+
+        sqlite_args: list = []
+        _build_session_filter_sql(
+            SessionSearchParams(from_time=dt, to_time=dt), _FakePool(is_postgres=False), sqlite_args
+        )
+        assert sqlite_args == [dt.isoformat(), dt.isoformat()]
+
+    def test_user_scope_sql_appended_to_gate_subqueries(self):
+        args: list = []
+        scope = "AND ce.call_id IN (SELECT call_id FROM conversation_calls WHERE user_id = $3)"
+        gates, _ = _build_session_filter_sql(
+            SessionSearchParams(model="gpt-4"), _FakePool(is_postgres=True), args, user_scope_sql=scope
+        )
+        assert scope in gates[0]
+
+
+__all__ = []

--- a/tests/luthien_proxy/unit_tests/history/test_search.py
+++ b/tests/luthien_proxy/unit_tests/history/test_search.py
@@ -14,7 +14,7 @@ and aggregate-syntax regressions on the PG path without a live database.
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -256,6 +256,16 @@ class TestTimeRangeFilter:
         )
         assert [s.session_id for s in result.sessions] == ["s-new"]
 
+    @pytest.mark.asyncio
+    async def test_bounds_are_inclusive_at_exact_timestamp(self, sqlite_pool: DatabasePool):
+        """A session whose last activity equals from_time or to_time exactly is included."""
+        await _seed_request(sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00")
+        exact = datetime(2026, 4, 1, 10, 0, 0)
+        at_from = await fetch_session_list(limit=10, db_pool=sqlite_pool, search=SessionSearchParams(from_time=exact))
+        at_to = await fetch_session_list(limit=10, db_pool=sqlite_pool, search=SessionSearchParams(to_time=exact))
+        assert [s.session_id for s in at_from.sessions] == ["s1"]
+        assert [s.session_id for s in at_to.sessions] == ["s1"]
+
 
 class TestPolicyInterventionFilter:
     @pytest.mark.asyncio
@@ -387,6 +397,93 @@ class TestSearchInjectionSafe:
         # Table still intact and queryable.
         intact = await fetch_session_list(limit=10, db_pool=sqlite_pool)
         assert len(intact.sessions) == 1
+
+    @pytest.mark.asyncio
+    async def test_q_value_is_bound_not_interpolated(self, sqlite_pool: DatabasePool):
+        """The free-text q is sanitized + bound by session_fts_filter_sql, never interpolated."""
+        await _seed_request(
+            sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00", content="hello"
+        )
+        result = await fetch_session_list(
+            limit=10,
+            db_pool=sqlite_pool,
+            search=SessionSearchParams(q="needle'; DROP TABLE conversation_events_fts;--"),
+        )
+        assert result.sessions == []
+        # FTS table and base data both intact.
+        intact = await fetch_session_list(limit=10, db_pool=sqlite_pool)
+        assert len(intact.sessions) == 1
+
+
+class TestUserScopedSearch:
+    @pytest.mark.asyncio
+    async def test_q_filter_does_not_match_another_users_text_in_shared_session(self, sqlite_pool: DatabasePool):
+        """Under ?user_id=alice, q must only match alice's events — not bob's, in a shared session.
+
+        This is the cross-user content-isolation property the user_scope_sql threading exists for:
+        without it, the q gate subquery would qualify the shared session on bob's matching text.
+        """
+        # Bob's call carries the searched term; alice's does not.
+        await _seed_request(
+            sqlite_pool,
+            call_id="c-bob",
+            session_id="shared",
+            created_at="2026-04-01T10:00:00",
+            user_id="bob",
+            content="the secret needle",
+        )
+        await _seed_request(
+            sqlite_pool,
+            call_id="c-alice",
+            session_id="shared",
+            created_at="2026-04-01T10:01:00",
+            user_id="alice",
+            content="just a haystack",
+        )
+        # q=needle matches only bob's event → alice-scoped search must not surface the session.
+        bob_term = await fetch_session_list(
+            limit=10, db_pool=sqlite_pool, user_id="alice", search=SessionSearchParams(q="needle")
+        )
+        assert bob_term.sessions == []
+        assert bob_term.total == 0
+        # q=haystack matches alice's own event → session surfaces.
+        alice_term = await fetch_session_list(
+            limit=10, db_pool=sqlite_pool, user_id="alice", search=SessionSearchParams(q="haystack")
+        )
+        assert [s.session_id for s in alice_term.sessions] == ["shared"]
+        assert alice_term.total == 1
+
+
+class TestTimezoneNormalization:
+    def test_aware_bounds_normalized_to_naive_utc(self):
+        """A tz-aware from/to is converted to UTC and stripped of tzinfo by the model validator."""
+        aware = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone(timedelta(hours=2)))  # 07:00 UTC
+        params = SessionSearchParams(from_time=aware, to_time=aware)
+        assert params.from_time == datetime(2026, 4, 1, 7, 0, 0)
+        assert params.from_time.tzinfo is None
+        assert params.to_time == datetime(2026, 4, 1, 7, 0, 0)
+
+    def test_naive_bounds_left_as_is(self):
+        naive = datetime(2026, 4, 1, 9, 0, 0)
+        assert SessionSearchParams(from_time=naive).from_time == naive
+
+    @pytest.mark.asyncio
+    async def test_aware_from_time_filters_by_utc_instant(self, sqlite_pool: DatabasePool):
+        await _seed_request(sqlite_pool, call_id="c1", session_id="s1", created_at="2026-04-01T10:00:00")
+        # 09:00+02:00 == 07:00 UTC < 10:00 → included.
+        included = await fetch_session_list(
+            limit=10,
+            db_pool=sqlite_pool,
+            search=SessionSearchParams(from_time=datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone(timedelta(hours=2)))),
+        )
+        assert [s.session_id for s in included.sessions] == ["s1"]
+        # 13:00+02:00 == 11:00 UTC > 10:00 → excluded.
+        excluded = await fetch_session_list(
+            limit=10,
+            db_pool=sqlite_pool,
+            search=SessionSearchParams(from_time=datetime(2026, 4, 1, 13, 0, 0, tzinfo=timezone(timedelta(hours=2)))),
+        )
+        assert excluded.sessions == []
 
 
 class _FakePool:


### PR DESCRIPTION
Replaces #581. Resolves #558.

## Why a new PR instead of rebasing #581

#581 was 440 commits behind main and conflicting. On investigation (a `/devil` pass plus a diff against current main), its approach turned out to be **obsolete**, not just stale:

1. **Its migration collides with main.** Main already shipped session-search infrastructure in commit `5ceeff3f` (`014_add_session_search_fts.sql`): a Postgres `tsvector` `search_vector` column + GIN index, *and* a SQLite **FTS5** virtual table with porter stemming for cross-dialect parity. #581 adds its own `014_add_session_search_tsvector.sql` — a duplicate of the Postgres half.
2. **Its SQLite path is strictly worse.** #581 searches content via `json_tree` + `LIKE` (O(rows × nodes), no index, no stemming). Main's FTS5 table is indexed and stemmed. Rebasing would mean re-introducing the inferior path or deleting most of #581's diff.
3. **Its headline refactor targets code that no longer exists.** #581's main value-add over #578 was inlining the `_fetch_session_list_pg`/`_sqlite` wrapper "sentinel-attribute" dance — but main's `service.py` has long since replaced those with clean, substantive dialect functions.

So the residual value of rebasing #581 was ~zero. What main *lacked* was the **query layer**: the FTS infra was merged but unwired, and `/api/history/sessions` exposed only `user_id`. This PR adds that layer.

## What this adds

`GET /api/history/sessions` now accepts, in addition to `user_id`:

| Param | Meaning |
|-------|---------|
| `model` | session used this exact `final_model` in any turn |
| `from` / `to` | session **last activity** within `[from, to]`, inclusive (ISO 8601) |
| `q` | full-text content search (porter-stemmed, terms ANDed) — matches if any turn matches |
| `policy_intervention` | only sessions with ≥1 policy intervention |

Implementation:
- **`_build_session_filter_sql`** — a single dialect-aware clause builder. `model`/`q` are *session-level* WHERE gates (`session_id IN (...)`), so a qualifying session keeps **all** its events and per-session stats stay whole. `from`/`to`/`policy_intervention` are `HAVING` aggregates on session last-activity / intervention count.
- `q` routes through the existing `utils.search.session_fts_filter_sql`, which owns FTS sanitization and dialect dispatch — **no manual `is_postgres` branching, no new migration.**
- Gate subqueries are **user-scoped when `user_id` is also set**, preserving main's documented cross-user content-isolation invariant.
- `total` now reflects the **filtered** count (was always the global count). The unfiltered list path is byte-for-byte unchanged (hot path preserved).

## Tests

- `tests/.../history/test_search.py`: real in-memory SQLite (all migrations applied → live FTS5 + triggers) exercising each filter, combined filters, full-stats-preservation, `total`-is-filtered, FTS metachar safety, and model SQL-injection safety.
- The Postgres dialect has no test tier in this repo, so `_build_session_filter_sql` is unit-tested directly against a fake postgres pool to pin the PG clause shape (`plainto_tsquery`/`search_vector`, `FILTER` aggregate, jsonb `->>`).
- `./scripts/dev_checks.sh` clean (shellcheck, ruff, pyright 0/0, full unit suite).

## Follow-ups filed separately (the `/devil` pass found two bugs in main's *already-merged* FTS infra — out of scope here per One PR = One Concern)

1. **Search corpus indexes `final_request` only.** Per maintainer direction, **both** `original_request` and `final_request` should be indexed; today only `final_request` is, so gateway-injected `<policy-context>` text is searchable and `q` for policy-context terms over-matches on policy-active sessions. (The preview path already reads `original_request` — see `fix-preview-from-original-request`.) Surfaced to the user in the `q` field docstring as a known limitation.
2. **Quadratic corpus duplication.** Each `request_recorded` event stores the full accumulated `final_request.messages` (turns 1..N), so a session's text is indexed once per turn. Worth deciding per-turn-delta vs full-payload indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
