### PR TITLE
feat: rich infra diagnostics on authenticated /api/admin/system-status (supersedes #516)

### DIFF
--- a/changelog.d/rich-health-checks.md
+++ b/changelog.d/rich-health-checks.md
@@ -1,0 +1,5 @@
+---
+category: Features
+---
+
+**Rich health checks on `/health`**: The health endpoint now probes DB (`SELECT 1`) and Redis (`ping`) in parallel and reports per-component status with latency measurements. Overall `status` reflects real infrastructure state: `healthy` / `degraded` (Redis unreachable) / `unhealthy` (DB unreachable). Returns HTTP 200 always — callers inspect the body. Redis absent (SQLite/local mode) is `not_configured` and does not affect the overall status.

--- a/changelog.d/rich-health-checks.md
+++ b/changelog.d/rich-health-checks.md
@@ -1,5 +1,6 @@
 ---
 category: Features
+pr: 516
 ---
 
 **Rich health checks on `/health`**: The health endpoint now probes DB (`SELECT 1`) and Redis (`ping`) in parallel and reports per-component status with latency measurements. Overall `status` reflects real infrastructure state: `healthy` / `degraded` (Redis unreachable) / `unhealthy` (DB unreachable). Returns HTTP 200 always — callers inspect the body. Redis absent (SQLite/local mode) is `not_configured` and does not affect the overall status.

--- a/changelog.d/rich-health-checks.md
+++ b/changelog.d/rich-health-checks.md
@@ -3,4 +3,6 @@ category: Features
 pr: 516
 ---
 
-**Rich health checks on `/health`**: The health endpoint now probes DB (`SELECT 1`) and Redis (`ping`) in parallel and reports per-component status with latency measurements. Overall `status` reflects real infrastructure state: `healthy` / `degraded` (Redis unreachable) / `unhealthy` (DB unreachable). Returns HTTP 200 always — callers inspect the body. Redis absent (SQLite/local mode) is `not_configured` and does not affect the overall status.
+**Rich infrastructure diagnostics on `/api/admin/system-status`**: A new authenticated admin endpoint probes DB (`SELECT 1`) and Redis (`ping`) in parallel — each bounded by a 2s timeout — and reports per-component status with latency. Overall `status` reflects real infrastructure state: `healthy` / `degraded` (Redis unreachable) / `unhealthy` (DB unreachable); Redis absent (SQLite/local mode) is `not_configured` and does not affect the overall status.
+
+`/health` stays a dependency-free liveness probe (`{status, version}`, always 200) so container/k8s liveness probes don't restart the gateway on a transient DB blip, and `/ready` continues to handle traffic-draining readiness. Keeping the rich checks behind admin auth avoids exposing latency/topology fingerprints — and an unbounded DB/Redis probe — on an unauthenticated endpoint.

--- a/changelog.d/rich-health-checks.md
+++ b/changelog.d/rich-health-checks.md
@@ -1,6 +1,6 @@
 ---
 category: Features
-pr: 516
+pr: 774
 ---
 
 **Rich infrastructure diagnostics on `/api/admin/system-status`**: A new authenticated admin endpoint probes DB (`SELECT 1`) and Redis (`ping`) in parallel — each bounded by a 2s timeout — and reports per-component status with latency. Overall `status` reflects real infrastructure state: `healthy` / `degraded` (Redis unreachable) / `unhealthy` (DB unreachable); Redis absent (SQLite/local mode) is `not_configured` and does not affect the overall status.

--- a/dev-README.md
+++ b/dev-README.md
@@ -108,6 +108,7 @@ The gateway is a single FastAPI application:
 - `POST /v1/messages` - Anthropic Messages API (streaming and non-streaming)
 - `GET /health` - Liveness check (always 200 if the process is responsive)
 - `GET /ready` - Readiness probe (503 when DB is unreachable, probe times out, or dependencies are not initialized)
+- `GET /api/admin/system-status` - Rich per-component diagnostics (DB + Redis probes with latency; `healthy`/`degraded`/`unhealthy`). Admin-auth'd; always 200, inspect the body.
 
 **UI Endpoints:**
 

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -850,8 +850,8 @@ async def _probe_db(deps: Dependencies) -> ComponentCheck:
         async with db_pool.connection() as conn:
             await conn.fetchval("SELECT 1")
 
+    t0 = time.perf_counter()
     try:
-        t0 = time.perf_counter()
         await asyncio.wait_for(_run(), timeout=SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS)
         return ComponentCheck(status="ok", latency_ms=round((time.perf_counter() - t0) * 1000, 1))
     except asyncio.TimeoutError:
@@ -871,8 +871,8 @@ async def _probe_redis(deps: Dependencies) -> ComponentCheck:
     redis_client = deps.redis_client
     if redis_client is None:
         return ComponentCheck(status="not_configured")
+    t0 = time.perf_counter()
     try:
-        t0 = time.perf_counter()
         await asyncio.wait_for(redis_client.ping(), timeout=SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS)
         return ComponentCheck(status="ok", latency_ms=round((time.perf_counter() - t0) * 1000, 1))
     except asyncio.TimeoutError:
@@ -891,7 +891,7 @@ async def _probe_redis(deps: Dependencies) -> ComponentCheck:
 async def get_system_status(
     _: str = Depends(verify_admin_token),
     deps: Dependencies = Depends(get_dependencies),
-):
+) -> SystemStatusResponse:
     """Rich per-component health diagnostics for operators and monitoring.
 
     Probes DB and Redis in parallel (each bounded by

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy
 import hashlib
 import json
 import logging
 import os
+import time
 import uuid
 from typing import Any, cast
 
@@ -57,6 +59,10 @@ from luthien_proxy.utils import policy_cache as policy_cache_utils
 from luthien_proxy.webhook.sender import WebhookSender
 
 logger = logging.getLogger(__name__)
+
+# Bounded probe for /api/admin/system-status. Short enough that a hung DB or
+# Redis can't tarpit the request, long enough to absorb routine jitter.
+SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS = 2.0
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
@@ -213,6 +219,27 @@ class BillingStatusResponse(BaseModel):
     auth_mode: str | None
     last_credential_type: str | None
     last_credential_at: float | None
+
+
+class ComponentCheck(BaseModel):
+    """Per-component probe result for the system-status endpoint."""
+
+    status: str  # "ok" | "error" | "not_configured"
+    latency_ms: float | None = None
+    error: str | None = None
+
+
+class SystemStatusResponse(BaseModel):
+    """Rich per-component diagnostics for operators and monitoring tools.
+
+    Behind admin auth (not on unauthenticated /health) so the latency timing
+    and dependency-topology signals can't be used to fingerprint or probe the
+    gateway, and so the DB/Redis probes can't be used as an unauthenticated
+    DoS amplifier against the connection pool.
+    """
+
+    status: str  # "healthy" | "degraded" | "unhealthy"
+    checks: dict[str, ComponentCheck]
 
 
 class AuthConfigUpdateRequest(BaseModel):
@@ -811,6 +838,75 @@ async def get_billing_status(
         last_credential_type=last_type,
         last_credential_at=last_at,
     )
+
+
+async def _probe_db(deps: Dependencies) -> ComponentCheck:
+    """Probe the database with a bounded SELECT 1."""
+    db_pool = getattr(deps, "db_pool", None)
+    if db_pool is None:
+        return ComponentCheck(status="not_configured")
+
+    async def _run() -> None:
+        async with db_pool.connection() as conn:
+            await conn.fetchval("SELECT 1")
+
+    try:
+        t0 = time.perf_counter()
+        await asyncio.wait_for(_run(), timeout=SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS)
+        return ComponentCheck(status="ok", latency_ms=round((time.perf_counter() - t0) * 1000, 1))
+    except asyncio.TimeoutError:
+        logger.warning("system-status: DB probe timed out after %.1fs", SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS)
+        return ComponentCheck(status="error", error="database check timed out")
+    except Exception:
+        logger.warning("system-status: DB probe failed", exc_info=True)
+        return ComponentCheck(status="error", error="database check failed")
+
+
+async def _probe_redis(deps: Dependencies) -> ComponentCheck:
+    """Probe Redis with a bounded ping."""
+    redis_client = getattr(deps, "redis_client", None)
+    if redis_client is None:
+        return ComponentCheck(status="not_configured")
+    try:
+        t0 = time.perf_counter()
+        await asyncio.wait_for(redis_client.ping(), timeout=SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS)
+        return ComponentCheck(status="ok", latency_ms=round((time.perf_counter() - t0) * 1000, 1))
+    except asyncio.TimeoutError:
+        logger.warning("system-status: Redis probe timed out after %.1fs", SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS)
+        return ComponentCheck(status="error", error="redis check timed out")
+    except Exception:
+        logger.warning("system-status: Redis probe failed", exc_info=True)
+        return ComponentCheck(status="error", error="redis check failed")
+
+
+@router.get("/system-status", response_model=SystemStatusResponse)
+async def get_system_status(
+    _: str = Depends(verify_admin_token),
+    deps: Dependencies = Depends(get_dependencies),
+):
+    """Rich per-component health diagnostics for operators and monitoring.
+
+    Probes DB and Redis in parallel (each bounded by
+    SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS) and reports per-component status and
+    latency so a degraded gateway (e.g. Redis down) can be distinguished from
+    an unhealthy one (DB down).
+
+    This is deliberately NOT on /health: /health is a dependency-free liveness
+    probe for container/k8s restart logic, and /ready handles traffic-draining
+    readiness. This endpoint is for a monitoring system that parses the body,
+    and is behind admin auth so its timing and topology signals aren't exposed
+    to unauthenticated probes.
+    """
+    db_check, redis_check = await asyncio.gather(_probe_db(deps), _probe_redis(deps))
+
+    if db_check.status == "error":
+        overall = "unhealthy"
+    elif redis_check.status == "error":
+        overall = "degraded"
+    else:
+        overall = "healthy"
+
+    return SystemStatusResponse(status=overall, checks={"db": db_check, "redis": redis_check})
 
 
 @router.post("/auth/config", response_model=AuthConfigResponse)

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -10,7 +10,7 @@ import logging
 import os
 import time
 import uuid
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import litellm
 from fastapi import APIRouter, Depends, HTTPException, Path, Request
@@ -224,7 +224,7 @@ class BillingStatusResponse(BaseModel):
 class ComponentCheck(BaseModel):
     """Per-component probe result for the system-status endpoint."""
 
-    status: str  # "ok" | "error" | "not_configured"
+    status: Literal["ok", "error", "not_configured"]
     latency_ms: float | None = None
     error: str | None = None
 
@@ -238,7 +238,7 @@ class SystemStatusResponse(BaseModel):
     DoS amplifier against the connection pool.
     """
 
-    status: str  # "healthy" | "degraded" | "unhealthy"
+    status: Literal["healthy", "degraded", "unhealthy"]
     checks: dict[str, ComponentCheck]
 
 
@@ -842,7 +842,7 @@ async def get_billing_status(
 
 async def _probe_db(deps: Dependencies) -> ComponentCheck:
     """Probe the database with a bounded SELECT 1."""
-    db_pool = getattr(deps, "db_pool", None)
+    db_pool = deps.db_pool
     if db_pool is None:
         return ComponentCheck(status="not_configured")
 
@@ -864,7 +864,7 @@ async def _probe_db(deps: Dependencies) -> ComponentCheck:
 
 async def _probe_redis(deps: Dependencies) -> ComponentCheck:
     """Probe Redis with a bounded ping."""
-    redis_client = getattr(deps, "redis_client", None)
+    redis_client = deps.redis_client
     if redis_client is None:
         return ComponentCheck(status="not_configured")
     try:

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -856,10 +856,14 @@ async def _probe_db(deps: Dependencies) -> ComponentCheck:
         return ComponentCheck(status="ok", latency_ms=round((time.perf_counter() - t0) * 1000, 1))
     except asyncio.TimeoutError:
         logger.warning("system-status: DB probe timed out after %.1fs", SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS)
-        return ComponentCheck(status="error", error="database check timed out")
+        return ComponentCheck(
+            status="error", latency_ms=round((time.perf_counter() - t0) * 1000, 1), error="database check timed out"
+        )
     except Exception:
         logger.warning("system-status: DB probe failed", exc_info=True)
-        return ComponentCheck(status="error", error="database check failed")
+        return ComponentCheck(
+            status="error", latency_ms=round((time.perf_counter() - t0) * 1000, 1), error="database check failed"
+        )
 
 
 async def _probe_redis(deps: Dependencies) -> ComponentCheck:
@@ -873,10 +877,14 @@ async def _probe_redis(deps: Dependencies) -> ComponentCheck:
         return ComponentCheck(status="ok", latency_ms=round((time.perf_counter() - t0) * 1000, 1))
     except asyncio.TimeoutError:
         logger.warning("system-status: Redis probe timed out after %.1fs", SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS)
-        return ComponentCheck(status="error", error="redis check timed out")
+        return ComponentCheck(
+            status="error", latency_ms=round((time.perf_counter() - t0) * 1000, 1), error="redis check timed out"
+        )
     except Exception:
         logger.warning("system-status: Redis probe failed", exc_info=True)
-        return ComponentCheck(status="error", error="redis check failed")
+        return ComponentCheck(
+            status="error", latency_ms=round((time.perf_counter() - t0) * 1000, 1), error="redis check failed"
+        )
 
 
 @router.get("/system-status", response_model=SystemStatusResponse)
@@ -899,7 +907,11 @@ async def get_system_status(
     """
     db_check, redis_check = await asyncio.gather(_probe_db(deps), _probe_redis(deps))
 
-    if db_check.status == "error":
+    # DB is required: error OR not_configured means the gateway can't serve
+    # traffic (matches /ready's 503 when db_pool is None). Redis is optional —
+    # not_configured (SQLite/local mode) stays healthy; only a Redis *error*
+    # degrades.
+    if db_check.status in ("error", "not_configured"):
         overall = "unhealthy"
     elif redis_check.status == "error":
         overall = "degraded"

--- a/src/luthien_proxy/admin/routes.py
+++ b/src/luthien_proxy/admin/routes.py
@@ -904,6 +904,12 @@ async def get_system_status(
     readiness. This endpoint is for a monitoring system that parses the body,
     and is behind admin auth so its timing and topology signals aren't exposed
     to unauthenticated probes.
+
+    Always returns HTTP 200 — the overall verdict is in the body's `status`
+    field. Do NOT switch this to 503 on `unhealthy`: this is a body-parsed
+    diagnostics endpoint, not a probe wired to restart/drain logic (that's
+    /health and /ready). Returning non-2xx here would mislead HTTP-status
+    monitors into treating a reported-but-handled state as an endpoint outage.
     """
     db_check, redis_check = await asyncio.gather(_probe_db(deps), _probe_redis(deps))
 
@@ -911,6 +917,7 @@ async def get_system_status(
     # traffic (matches /ready's 503 when db_pool is None). Redis is optional —
     # not_configured (SQLite/local mode) stays healthy; only a Redis *error*
     # degrades.
+    overall: Literal["healthy", "degraded", "unhealthy"]
     if db_check.status in ("error", "not_configured"):
         overall = "unhealthy"
     elif redis_check.status == "error":

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -8,6 +8,7 @@ import enum
 import logging
 import os
 import secrets
+import time
 from collections.abc import MutableMapping
 from contextlib import asynccontextmanager
 
@@ -453,17 +454,58 @@ def create_app(
 
     # Simple utility endpoints
     @app.get("/health")
-    async def health():
+    async def health(request: Request):
         """Liveness probe endpoint.
 
-        Always returns HTTP 200 if the process is responsive. Kept minimal:
-        a probe attacker shouldn't be able to fingerprint the gateway's auth
-        mode or recent credential activity from this endpoint. The admin UI
-        gets billing-mode signals from /api/admin/billing-status instead.
+        Probes DB and Redis in parallel and reports per-component status so
+        operators and monitoring tools can distinguish degraded from unhealthy.
+        Returns HTTP 200 always — callers must inspect the body for status.
+
+        Kept free of auth-mode and credential signals: a probe attacker
+        shouldn't be able to fingerprint the gateway's auth configuration or
+        recent credential activity from this unauthenticated endpoint. The
+        admin UI gets those signals from /api/admin/billing-status instead.
         """
+        deps = getattr(request.app.state, "dependencies", None)
+
+        async def _check_db() -> dict[str, object]:
+            db_pool = getattr(deps, "db_pool", None) if deps else None
+            if db_pool is None:
+                return {"status": "not_configured"}
+            try:
+                t0 = time.perf_counter()
+                async with db_pool.connection() as conn:
+                    await conn.execute("SELECT 1")
+                return {"status": "ok", "latency_ms": round((time.perf_counter() - t0) * 1000, 1)}
+            except Exception:
+                logger.exception("Health check: DB probe failed")
+                return {"status": "error", "error": "database check failed"}
+
+        async def _check_redis() -> dict[str, object]:
+            redis_client = getattr(deps, "redis_client", None) if deps else None
+            if redis_client is None:
+                return {"status": "not_configured"}
+            try:
+                t0 = time.perf_counter()
+                await redis_client.ping()
+                return {"status": "ok", "latency_ms": round((time.perf_counter() - t0) * 1000, 1)}
+            except Exception:
+                logger.exception("Health check: Redis probe failed")
+                return {"status": "error", "error": "redis check failed"}
+
+        db_check, redis_check = await asyncio.gather(_check_db(), _check_redis())
+
+        if db_check["status"] == "error":
+            overall = "unhealthy"
+        elif redis_check["status"] == "error":
+            overall = "degraded"
+        else:
+            overall = "healthy"
+
         return {
-            "status": "healthy",
+            "status": overall,
             "version": PROXY_DISPLAY_VERSION,
+            "checks": {"db": db_check, "redis": redis_check},
         }
 
     @app.get("/ready")

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -8,7 +8,6 @@ import enum
 import logging
 import os
 import secrets
-import time
 from collections.abc import MutableMapping
 from contextlib import asynccontextmanager
 
@@ -454,58 +453,24 @@ def create_app(
 
     # Simple utility endpoints
     @app.get("/health")
-    async def health(request: Request):
+    async def health():
         """Liveness probe endpoint.
 
-        Probes DB and Redis in parallel and reports per-component status so
-        operators and monitoring tools can distinguish degraded from unhealthy.
-        Returns HTTP 200 always — callers must inspect the body for status.
+        Always returns HTTP 200 if the process is responsive, with no
+        dependency on DB or Redis. This is deliberate: container HEALTHCHECKs
+        and k8s liveness probes consume /health, and a liveness probe that
+        fails on a transient DB blip would trigger a restart that cannot fix
+        the dependency — the textbook cascading-failure outage. Dependency
+        readiness (for traffic draining) lives on /ready; rich per-component
+        diagnostics live on the authenticated /api/admin/system-status.
 
-        Kept free of auth-mode and credential signals: a probe attacker
-        shouldn't be able to fingerprint the gateway's auth configuration or
-        recent credential activity from this unauthenticated endpoint. The
-        admin UI gets those signals from /api/admin/billing-status instead.
+        Kept minimal so an unauthenticated probe attacker can't fingerprint
+        the gateway's auth mode, dependency topology, or recent credential
+        activity from this endpoint.
         """
-        deps = getattr(request.app.state, "dependencies", None)
-
-        async def _check_db() -> dict[str, object]:
-            db_pool = getattr(deps, "db_pool", None) if deps else None
-            if db_pool is None:
-                return {"status": "not_configured"}
-            try:
-                t0 = time.perf_counter()
-                async with db_pool.connection() as conn:
-                    await conn.execute("SELECT 1")
-                return {"status": "ok", "latency_ms": round((time.perf_counter() - t0) * 1000, 1)}
-            except Exception:
-                logger.warning("Health check: DB probe failed", exc_info=True)
-                return {"status": "error", "error": "database check failed"}
-
-        async def _check_redis() -> dict[str, object]:
-            redis_client = getattr(deps, "redis_client", None) if deps else None
-            if redis_client is None:
-                return {"status": "not_configured"}
-            try:
-                t0 = time.perf_counter()
-                await redis_client.ping()
-                return {"status": "ok", "latency_ms": round((time.perf_counter() - t0) * 1000, 1)}
-            except Exception:
-                logger.warning("Health check: Redis probe failed", exc_info=True)
-                return {"status": "error", "error": "redis check failed"}
-
-        db_check, redis_check = await asyncio.gather(_check_db(), _check_redis())
-
-        if db_check["status"] == "error":
-            overall = "unhealthy"
-        elif redis_check["status"] == "error":
-            overall = "degraded"
-        else:
-            overall = "healthy"
-
         return {
-            "status": overall,
+            "status": "healthy",
             "version": PROXY_DISPLAY_VERSION,
-            "checks": {"db": db_check, "redis": redis_check},
         }
 
     @app.get("/ready")

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -478,7 +478,7 @@ def create_app(
                     await conn.execute("SELECT 1")
                 return {"status": "ok", "latency_ms": round((time.perf_counter() - t0) * 1000, 1)}
             except Exception:
-                logger.exception("Health check: DB probe failed")
+                logger.warning("Health check: DB probe failed", exc_info=True)
                 return {"status": "error", "error": "database check failed"}
 
         async def _check_redis() -> dict[str, object]:
@@ -490,7 +490,7 @@ def create_app(
                 await redis_client.ping()
                 return {"status": "ok", "latency_ms": round((time.perf_counter() - t0) * 1000, 1)}
             except Exception:
-                logger.exception("Health check: Redis probe failed")
+                logger.warning("Health check: Redis probe failed", exc_info=True)
                 return {"status": "error", "error": "redis check failed"}
 
         db_check, redis_check = await asyncio.gather(_check_db(), _check_redis())

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -498,6 +498,8 @@ class TestCreateApp:
             assert data["status"] == "unhealthy"
             assert data["checks"]["db"]["status"] == "error"
             assert data["checks"]["db"]["error"] == "database check failed"
+            # Latency is populated even on the error path (useful for ops).
+            assert data["checks"]["db"]["latency_ms"] is not None
             assert "db.internal" not in response.text
 
     def test_system_status_degraded_when_redis_error(self, policy_config_file, mock_db_pool, mock_redis_client):
@@ -593,6 +595,56 @@ class TestCreateApp:
             assert data["status"] == "unhealthy"
             assert data["checks"]["db"]["status"] == "error"
             assert data["checks"]["db"]["error"] == "database check timed out"
+
+    def test_system_status_db_not_configured_is_unhealthy(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """DB is required: a missing db_pool is unhealthy, not healthy (unlike optional Redis)."""
+        app = create_app(
+            api_key="test-key",
+            admin_key="test-admin-key",
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            app.state.dependencies.db_pool = None
+            data = client.get(
+                "/api/admin/system-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            ).json()
+            assert data["status"] == "unhealthy"
+            assert data["checks"]["db"]["status"] == "not_configured"
+            assert data["checks"]["redis"]["status"] == "ok"
+
+    def test_system_status_redis_timeout_is_bounded(
+        self, policy_config_file, mock_db_pool, mock_redis_client, monkeypatch
+    ):
+        """A hung Redis ping is bounded by the probe timeout (symmetry with the DB probe)."""
+        from luthien_proxy.admin import routes as admin_routes
+
+        monkeypatch.setattr(admin_routes, "SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS", 0.05)
+
+        async def _hang(*args, **kwargs):
+            await asyncio.sleep(1.0)
+
+        mock_redis_client.ping = _hang
+        app = create_app(
+            api_key="test-key",
+            admin_key="test-admin-key",
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            data = client.get(
+                "/api/admin/system-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            ).json()
+            # DB ok + Redis timed out → degraded (Redis is optional).
+            assert data["status"] == "degraded"
+            assert data["checks"]["redis"]["status"] == "error"
+            assert data["checks"]["redis"]["error"] == "redis check timed out"
 
     def test_billing_status_returns_403_without_auth(self, policy_config_file, mock_db_pool, mock_redis_client):
         """Billing status is gated by admin auth — unauthenticated callers get 403."""

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -491,6 +491,41 @@ class TestCreateApp:
             assert data["checks"]["db"]["status"] == "ok"
             assert data["checks"]["redis"]["status"] == "not_configured"
 
+    def test_create_app_health_endpoint_db_not_configured(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Health endpoint shows db not_configured when db_pool is None on deps at request time."""
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            app.state.dependencies.db_pool = None
+            data = client.get("/health").json()
+            assert data["status"] == "healthy"
+            assert data["checks"]["db"]["status"] == "not_configured"
+            assert data["checks"]["redis"]["status"] == "ok"
+
+    def test_create_app_health_endpoint_both_infra_error(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """DB error takes priority over Redis error — overall status is unhealthy not degraded."""
+        mock_db_pool._mock_conn.execute = AsyncMock(side_effect=Exception("db down"))
+        mock_redis_client.ping = AsyncMock(side_effect=Exception("redis down"))
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            data = client.get("/health").json()
+            assert data["status"] == "unhealthy"
+            assert data["checks"]["db"]["status"] == "error"
+            assert data["checks"]["redis"]["status"] == "error"
+
     def test_billing_status_returns_403_without_auth(self, policy_config_file, mock_db_pool, mock_redis_client):
         """Billing status is gated by admin auth — unauthenticated callers get 403."""
         mock_redis_client.get = AsyncMock(return_value=None)

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -409,12 +409,12 @@ class TestCreateApp:
         assert "/v1/messages" in routes or any("/v1/messages" in str(r) for r in routes if r)
 
     def test_create_app_health_endpoint(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """Health endpoint returns healthy with DB and Redis both ok.
+        """/health is a dependency-free liveness probe: always {status, version} at 200.
 
-        /health is unauthenticated, so it must not leak auth_mode or recent
-        credential activity (those would let a probe attacker fingerprint
-        the gateway). Billing-mode signals live on
-        /api/admin/billing-status instead.
+        It must not probe DB/Redis (a liveness probe that fails on a DB blip
+        would trigger pointless restarts) and must not leak auth_mode or
+        credential activity to unauthenticated callers. Rich diagnostics live
+        on /api/admin/system-status; billing signals on /api/admin/billing-status.
         """
         mock_redis_client.get = AsyncMock(return_value=None)
         app = create_app(
@@ -429,102 +429,168 @@ class TestCreateApp:
             response = client.get("/health")
             assert response.status_code == 200
             data = response.json()
-            assert data["status"] == "healthy"
+            assert data == {"status": "healthy", "version": data["version"]}
             assert data["version"] and data["version"] != "unknown"
-            assert data["checks"]["db"]["status"] == "ok"
-            assert data["checks"]["redis"]["status"] == "ok"
-            # Unauthenticated endpoint must not leak auth/credential signals.
+            # Liveness must not depend on or expose dependency state.
+            assert "checks" not in data
             assert "auth_mode" not in data
             assert "last_credential_type" not in data
             assert "last_credential_at" not in data
 
-    def test_create_app_health_endpoint_db_error(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """Health endpoint returns unhealthy when DB probe fails."""
-        mock_db_pool._mock_conn.execute = AsyncMock(side_effect=Exception("connection refused"))
+    def test_system_status_returns_403_without_auth(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """system-status is gated by admin auth — unauthenticated callers get 403.
+
+        This is the whole point of moving the rich checks off /health: the
+        timing/topology signals are not exposed to unauthenticated probes.
+        """
         app = create_app(
             api_key="test-key",
-            admin_key=None,
+            admin_key="test-admin-key",
             db_pool=mock_db_pool,
             redis_client=mock_redis_client,
             startup_policy_path=policy_config_file,
         )
 
         with TestClient(app) as client:
-            data = client.get("/health").json()
+            assert client.get("/api/admin/system-status").status_code == 403
+
+    def test_system_status_healthy_when_both_ok(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """system-status reports healthy with per-component ok + latency when DB and Redis answer."""
+        app = create_app(
+            api_key="test-key",
+            admin_key="test-admin-key",
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/admin/system-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "healthy"
+            assert data["checks"]["db"]["status"] == "ok"
+            assert data["checks"]["redis"]["status"] == "ok"
+            assert data["checks"]["db"]["latency_ms"] is not None
+
+    def test_system_status_unhealthy_when_db_error(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """DB probe failure → overall unhealthy; raw exception text is not leaked."""
+        mock_db_pool._mock_conn.fetchval = AsyncMock(side_effect=Exception("connection refused: db.internal:5432"))
+        app = create_app(
+            api_key="test-key",
+            admin_key="test-admin-key",
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/admin/system-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            )
+            data = response.json()
             assert data["status"] == "unhealthy"
             assert data["checks"]["db"]["status"] == "error"
             assert data["checks"]["db"]["error"] == "database check failed"
-            assert "connection refused" not in data["checks"]["db"]["error"]
+            assert "db.internal" not in response.text
 
-    def test_create_app_health_endpoint_redis_error(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """Health endpoint returns degraded when Redis probe fails but DB is ok."""
+    def test_system_status_degraded_when_redis_error(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Redis probe failure with DB ok → overall degraded (not unhealthy)."""
         mock_redis_client.ping = AsyncMock(side_effect=Exception("timeout"))
         app = create_app(
             api_key="test-key",
-            admin_key=None,
+            admin_key="test-admin-key",
             db_pool=mock_db_pool,
             redis_client=mock_redis_client,
             startup_policy_path=policy_config_file,
         )
 
         with TestClient(app) as client:
-            data = client.get("/health").json()
+            data = client.get(
+                "/api/admin/system-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            ).json()
             assert data["status"] == "degraded"
             assert data["checks"]["db"]["status"] == "ok"
             assert data["checks"]["redis"]["status"] == "error"
             assert data["checks"]["redis"]["error"] == "redis check failed"
-            assert "timeout" not in data["checks"]["redis"]["error"]
 
-    def test_create_app_health_endpoint_redis_not_configured(self, policy_config_file, mock_db_pool):
-        """Health endpoint shows redis not_configured when no Redis client is available."""
+    def test_system_status_redis_not_configured(self, policy_config_file, mock_db_pool):
+        """No Redis client → redis not_configured, overall still healthy."""
         app = create_app(
             api_key="test-key",
-            admin_key=None,
+            admin_key="test-admin-key",
             db_pool=mock_db_pool,
             redis_client=None,
             startup_policy_path=policy_config_file,
         )
 
         with TestClient(app) as client:
-            data = client.get("/health").json()
+            data = client.get(
+                "/api/admin/system-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            ).json()
             assert data["status"] == "healthy"
             assert data["checks"]["db"]["status"] == "ok"
             assert data["checks"]["redis"]["status"] == "not_configured"
 
-    def test_create_app_health_endpoint_db_not_configured(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """Health endpoint shows db not_configured when db_pool is None on deps at request time."""
-        app = create_app(
-            api_key="test-key",
-            admin_key=None,
-            db_pool=mock_db_pool,
-            redis_client=mock_redis_client,
-            startup_policy_path=policy_config_file,
-        )
-
-        with TestClient(app) as client:
-            app.state.dependencies.db_pool = None
-            data = client.get("/health").json()
-            assert data["status"] == "healthy"
-            assert data["checks"]["db"]["status"] == "not_configured"
-            assert data["checks"]["redis"]["status"] == "ok"
-
-    def test_create_app_health_endpoint_both_infra_error(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """DB error takes priority over Redis error — overall status is unhealthy not degraded."""
-        mock_db_pool._mock_conn.execute = AsyncMock(side_effect=Exception("db down"))
+    def test_system_status_db_priority_over_redis(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """DB error takes priority over Redis error — overall is unhealthy, not degraded."""
+        mock_db_pool._mock_conn.fetchval = AsyncMock(side_effect=Exception("db down"))
         mock_redis_client.ping = AsyncMock(side_effect=Exception("redis down"))
         app = create_app(
             api_key="test-key",
-            admin_key=None,
+            admin_key="test-admin-key",
             db_pool=mock_db_pool,
             redis_client=mock_redis_client,
             startup_policy_path=policy_config_file,
         )
 
         with TestClient(app) as client:
-            data = client.get("/health").json()
+            data = client.get(
+                "/api/admin/system-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            ).json()
             assert data["status"] == "unhealthy"
             assert data["checks"]["db"]["status"] == "error"
             assert data["checks"]["redis"]["status"] == "error"
+
+    def test_system_status_db_timeout_is_bounded(
+        self, policy_config_file, mock_db_pool, mock_redis_client, monkeypatch
+    ):
+        """A hung DB connection is bounded by the probe timeout, not left to tarpit the request."""
+        from contextlib import asynccontextmanager
+
+        from luthien_proxy.admin import routes as admin_routes
+
+        monkeypatch.setattr(admin_routes, "SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS", 0.05)
+
+        @asynccontextmanager
+        async def hanging_connection():
+            await asyncio.sleep(1.0)
+            yield  # unreachable under the patched timeout
+
+        mock_db_pool.connection = hanging_connection
+        app = create_app(
+            api_key="test-key",
+            admin_key="test-admin-key",
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            data = client.get(
+                "/api/admin/system-status",
+                headers={"Authorization": "Bearer test-admin-key"},
+            ).json()
+            assert data["status"] == "unhealthy"
+            assert data["checks"]["db"]["status"] == "error"
+            assert data["checks"]["db"]["error"] == "database check timed out"
 
     def test_billing_status_returns_403_without_auth(self, policy_config_file, mock_db_pool, mock_redis_client):
         """Billing status is gated by admin auth — unauthenticated callers get 403."""

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -321,7 +321,7 @@ def mock_db_pool():
     mock.is_sqlite = False
 
     mock_conn = AsyncMock()
-    mock_conn.execute = AsyncMock(return_value=None)
+    mock_conn.fetchval = AsyncMock(return_value=1)
 
     @asynccontextmanager
     async def _connection():
@@ -475,6 +475,8 @@ class TestCreateApp:
             assert data["checks"]["db"]["status"] == "ok"
             assert data["checks"]["redis"]["status"] == "ok"
             assert data["checks"]["db"]["latency_ms"] is not None
+            # Lock the probe query to match /ready's contract.
+            mock_db_pool._mock_conn.fetchval.assert_called_with("SELECT 1")
 
     def test_system_status_unhealthy_when_db_error(self, policy_config_file, mock_db_pool, mock_redis_client):
         """DB probe failure → overall unhealthy; raw exception text is not leaked."""

--- a/tests/luthien_proxy/unit_tests/test_main.py
+++ b/tests/luthien_proxy/unit_tests/test_main.py
@@ -311,13 +311,24 @@ policy:
 @pytest.fixture
 def mock_db_pool():
     """Create a mock database pool for testing."""
+    from contextlib import asynccontextmanager
+
     mock = AsyncMock()
     mock_pool = AsyncMock()
-    # fetchrow returns None by default (no rows found)
     mock_pool.fetchrow = AsyncMock(return_value=None)
     mock.get_pool = AsyncMock(return_value=mock_pool)
     mock.close = AsyncMock()
     mock.is_sqlite = False
+
+    mock_conn = AsyncMock()
+    mock_conn.execute = AsyncMock(return_value=None)
+
+    @asynccontextmanager
+    async def _connection():
+        yield mock_conn
+
+    mock.connection = _connection
+    mock._mock_conn = mock_conn
     return mock
 
 
@@ -398,7 +409,7 @@ class TestCreateApp:
         assert "/v1/messages" in routes or any("/v1/messages" in str(r) for r in routes if r)
 
     def test_create_app_health_endpoint(self, policy_config_file, mock_db_pool, mock_redis_client):
-        """Test health endpoint returns the minimal liveness shape only.
+        """Health endpoint returns healthy with DB and Redis both ok.
 
         /health is unauthenticated, so it must not leak auth_mode or recent
         credential activity (those would let a probe attacker fingerprint
@@ -418,11 +429,67 @@ class TestCreateApp:
             response = client.get("/health")
             assert response.status_code == 200
             data = response.json()
-            assert data == {"status": "healthy", "version": data["version"]}
+            assert data["status"] == "healthy"
             assert data["version"] and data["version"] != "unknown"
+            assert data["checks"]["db"]["status"] == "ok"
+            assert data["checks"]["redis"]["status"] == "ok"
+            # Unauthenticated endpoint must not leak auth/credential signals.
             assert "auth_mode" not in data
             assert "last_credential_type" not in data
             assert "last_credential_at" not in data
+
+    def test_create_app_health_endpoint_db_error(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Health endpoint returns unhealthy when DB probe fails."""
+        mock_db_pool._mock_conn.execute = AsyncMock(side_effect=Exception("connection refused"))
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            data = client.get("/health").json()
+            assert data["status"] == "unhealthy"
+            assert data["checks"]["db"]["status"] == "error"
+            assert data["checks"]["db"]["error"] == "database check failed"
+            assert "connection refused" not in data["checks"]["db"]["error"]
+
+    def test_create_app_health_endpoint_redis_error(self, policy_config_file, mock_db_pool, mock_redis_client):
+        """Health endpoint returns degraded when Redis probe fails but DB is ok."""
+        mock_redis_client.ping = AsyncMock(side_effect=Exception("timeout"))
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=mock_redis_client,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            data = client.get("/health").json()
+            assert data["status"] == "degraded"
+            assert data["checks"]["db"]["status"] == "ok"
+            assert data["checks"]["redis"]["status"] == "error"
+            assert data["checks"]["redis"]["error"] == "redis check failed"
+            assert "timeout" not in data["checks"]["redis"]["error"]
+
+    def test_create_app_health_endpoint_redis_not_configured(self, policy_config_file, mock_db_pool):
+        """Health endpoint shows redis not_configured when no Redis client is available."""
+        app = create_app(
+            api_key="test-key",
+            admin_key=None,
+            db_pool=mock_db_pool,
+            redis_client=None,
+            startup_policy_path=policy_config_file,
+        )
+
+        with TestClient(app) as client:
+            data = client.get("/health").json()
+            assert data["status"] == "healthy"
+            assert data["checks"]["db"]["status"] == "ok"
+            assert data["checks"]["redis"]["status"] == "not_configured"
 
     def test_billing_status_returns_403_without_auth(self, policy_config_file, mock_db_pool, mock_redis_client):
         """Billing status is gated by admin auth — unauthenticated callers get 403."""


### PR DESCRIPTION
Commandeers and redesigns #516. Keeps the intent (rich per-component DB/Redis health visibility) but fixes a blocking design flaw in the original, which put the checks on `/health`.

## Why #516 needed a redesign

`/health` is consumed by container `HEALTHCHECK`s and k8s/launch-script probes that key off the **HTTP status code** / `curl -f` exit — none read the body:
- `docker/Dockerfile.gateway:55`, `docker/Dockerfile.standalone:80`: `curl -f .../health`
- `scripts/run_e2e.sh:176`, `scripts/quick_start.sh:261`: `curl -sf .../health`
- `luthien_cli` onboard/up: poll for any response

#516 returned **HTTP 200 always** ("callers inspect the body"), so a DB-down gateway reported **healthy** to all of them (false green). The naive fix — return 503 when unhealthy — is also wrong: `/health` feeds liveness probes, and a liveness failure on a transient DB blip triggers a restart that can't fix the DB (cascading-restart outage). A liveness probe must not depend on external deps.

## Redesign

- **`/health`** → dependency-free liveness probe (`{status, version}`, always 200). Restored to its pre-#516 contract, so every existing consumer keeps working.
- **`/ready`** → unchanged; still handles traffic-draining readiness (bounded DB probe, 503 on failure).
- **`GET /api/admin/system-status`** (new, `verify_admin_token`) → the rich diagnostics: parallel DB (`SELECT 1` via `fetchval`, matching `/ready`) + Redis (`ping`) probes, **each bounded by `SYSTEM_STATUS_PROBE_TIMEOUT_SECONDS = 2.0`**, per-component `{status, latency_ms}`, overall `healthy`/`degraded`/`unhealthy`.

Putting it behind admin auth also closes three issues with the original endpoint, all on an unauthenticated surface: a DoS amplifier against the DB pool, a `latency_ms`/topology fingerprint, and an unbounded probe.

## Tests

- `/health` asserted trivial (no `checks`, no `auth_mode`/credential leak).
- `system-status`: 403 without auth; healthy/degraded/unhealthy; db & redis `not_configured`; DB-error-priority; sanitized error strings; bounded-timeout path.
- Full unit suite green (2666 passed); pyright + ruff clean.

Credit to @PaoloC68 — his commits are preserved in the history and he's co-authored on the redesign commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)