### PR TITLE
feat: De-AI policy preset (port of #485 onto SimpleLLMPolicy infra)

### DIFF
--- a/changelog.d/deai-preset.md
+++ b/changelog.d/deai-preset.md
@@ -1,0 +1,5 @@
+---
+category: Features
+---
+
+**De-AI policy**: New preset that rewrites LLM responses to remove common AI writing patterns (inflated significance, promotional adjectives, overused vocabulary, copula avoidance, em-dash overuse, chatbot artifacts, filler) while preserving technical content. Built on the `SimpleLLMPolicy` judge infrastructure as a comprehensive superset of the No Yapping, No Apologies, and Plain Dashes presets.

--- a/src/luthien_proxy/policies/presets/deai.py
+++ b/src/luthien_proxy/policies/presets/deai.py
@@ -1,0 +1,77 @@
+"""Policy that rewrites responses to remove common AI writing patterns."""
+
+from luthien_proxy.policies.simple_llm_policy import SimpleLLMJudgeConfig, SimpleLLMPolicy
+from luthien_proxy.policy_core import Category, UIMetadata
+
+_DEAI_INSTRUCTIONS = """\
+Rewrite text content to sound naturally human-written, removing common AI writing \
+patterns while preserving meaning and technical accuracy. The patterns to eliminate:
+
+Content patterns:
+- Undue emphasis on significance/legacy: "stands as", "testament", "crucial", "pivotal", "underscores"
+- Notability inflation: claiming broad recognition without evidence
+- Superficial -ing analyses: present-participle phrases tacked on for fake depth ("symbolizing", "reflecting")
+- Promotional language: "vibrant", "breathtaking", "nestled", "stunning", "renowned"
+- Vague attributions: "Experts argue", "Industry reports", "Some critics"
+- Formulaic sections: generic "Challenges and Future Prospects" outlines
+
+Language and grammar:
+- Overused AI vocabulary: additionally, align, crucial, delve, enhance, fostering, garner, highlight, \
+interplay, intricate, landscape, pivotal, showcase, tapestry, testament, underscore, valuable, vibrant, \
+multifaceted, comprehensive, innovative, leverage, streamline, utilize, cutting-edge, paradigm, holistic, synergy
+- Copula avoidance: "serves as", "stands as", "features", "boasts" instead of plain "is/are"
+- Negative parallelisms: "Not only...but..." or "It's not just...it's..." constructions
+- Rule-of-three overuse: forcing ideas into groups of three
+- Elegant variation: excessive synonym cycling to avoid repeating a word
+- False ranges: "From X to Y" where X and Y aren't on a meaningful scale
+
+Style:
+- Em-dash overuse, excessive boldface, inline-header vertical lists, Title Case In Every Heading, \
+decorative emojis in headings/bullets, curly quotation marks
+
+Communication and filler:
+- Chatbot artifacts: "I hope this helps", "Of course!", "Certainly!", "Let me know"
+- Knowledge-cutoff disclaimers, sycophantic tone
+- Filler phrases: "In order to", "Due to the fact that", "It is worth noting that", "It's important to note"
+- Excessive hedging, generic positive conclusions ("The future looks bright")
+
+How to rewrite:
+- Preserve ALL technical content, code blocks, data, and factual claims exactly
+- Replace AI-isms with plain, direct language; use "is/are" instead of "serves as/stands as"
+- Cut filler phrases entirely rather than replacing them; remove promotional adjectives
+- Vary sentence rhythm; keep the same overall structure and information ordering
+- Do NOT add new information or opinions
+- Do NOT change tool calls
+
+If the text already reads naturally and contains none of these patterns, pass it through unchanged.\
+"""
+
+
+class DeAIPolicy(SimpleLLMPolicy):
+    """Rewrites LLM responses to remove common AI writing patterns.
+
+    Strips the tells of AI-generated prose - inflated significance, promotional
+    adjectives, overused vocabulary ("delve", "tapestry", "underscore"), copula
+    avoidance, em-dash overuse, chatbot artifacts, and filler - while preserving
+    technical content, code, and the original meaning. A comprehensive superset
+    of the No Yapping, No Apologies, and Plain Dashes presets.
+    """
+
+    ui = UIMetadata(
+        display_name="De-AI",
+        short_description="Rewrites responses to remove common AI writing patterns.",
+        category=Category.FUN_AND_GOOFY,
+    )
+
+    def __init__(self) -> None:
+        """Initialize with hardcoded preset config."""
+        super().__init__(
+            config=SimpleLLMJudgeConfig(
+                instructions=_DEAI_INSTRUCTIONS,
+                model="claude-haiku-4-5",
+                temperature=0.7,
+                max_tokens=8192,
+                on_error="pass",
+                auth_provider="user_credentials",
+            )
+        )

--- a/src/luthien_proxy/policies/presets/deai.py
+++ b/src/luthien_proxy/policies/presets/deai.py
@@ -69,7 +69,16 @@ class DeAIPolicy(SimpleLLMPolicy):
             config=SimpleLLMJudgeConfig(
                 instructions=_DEAI_INSTRUCTIONS,
                 model="claude-haiku-4-5",
-                temperature=0.7,
+                # Slightly above the sibling presets' 0.0: a prose rewrite reads
+                # more naturally with a little sampling variety than with greedy
+                # decoding. Kept well below #485's original 0.7 to limit
+                # malformed-JSON retries and cross-block style drift.
+                temperature=0.3,
+                # Doubled from the SimpleLLMJudgeConfig default (4096) because a
+                # full-block rewrite is roughly as long as the input. If a single
+                # block's rewrite still exceeds this, the judge response is
+                # truncated and fails to parse — SimpleLLMPolicy then takes the
+                # on_error="pass" path, preserving the original block unchanged.
                 max_tokens=8192,
                 on_error="pass",
                 auth_provider="user_credentials",

--- a/src/luthien_proxy/policy_types.py
+++ b/src/luthien_proxy/policy_types.py
@@ -34,6 +34,7 @@ REGISTERED_BUILTINS: tuple[str, ...] = (
     "luthien_proxy.policies.presets.block_dangerous_commands:BlockDangerousCommandsPolicy",
     "luthien_proxy.policies.presets.block_sensitive_file_writes:BlockSensitiveFileWritesPolicy",
     "luthien_proxy.policies.presets.block_web_requests:BlockWebRequestsPolicy",
+    "luthien_proxy.policies.presets.deai:DeAIPolicy",
     "luthien_proxy.policies.presets.no_apologies:NoApologiesPolicy",
     "luthien_proxy.policies.presets.no_yapping:NoYappingPolicy",
     "luthien_proxy.policies.presets.plain_dashes:PlainDashesPolicy",

--- a/tests/luthien_proxy/e2e_tests/test_mock_preset_policies.py
+++ b/tests/luthien_proxy/e2e_tests/test_mock_preset_policies.py
@@ -27,6 +27,7 @@ _PREFER_UV = "luthien_proxy.policies.presets.prefer_uv:PreferUvPolicy"
 _PLAIN_DASHES = "luthien_proxy.policies.presets.plain_dashes:PlainDashesPolicy"
 _BLOCK_DANGEROUS = "luthien_proxy.policies.presets.block_dangerous_commands:BlockDangerousCommandsPolicy"
 _NO_APOLOGIES = "luthien_proxy.policies.presets.no_apologies:NoApologiesPolicy"
+_DEAI = "luthien_proxy.policies.presets.deai:DeAIPolicy"
 _NO_YAPPING = "luthien_proxy.policies.presets.no_yapping:NoYappingPolicy"
 _BLOCK_WEB = "luthien_proxy.policies.presets.block_web_requests:BlockWebRequestsPolicy"
 _BLOCK_WRITES = "luthien_proxy.policies.presets.block_sensitive_file_writes:BlockSensitiveFileWritesPolicy"
@@ -183,6 +184,34 @@ async def test_no_apologies_removes_sorry(
 
     assert "apologize" not in turn.text.lower()
     assert "The fix is to use async." in turn.text
+
+
+# =============================================================================
+# DeAIPolicy
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_deai_rewrites_ai_patterns(
+    mock_anthropic: MockAnthropicServer,
+    gateway_healthy,
+    gateway_url,
+    api_key,
+    admin_api_key,
+):
+    """DeAIPolicy: judge rewrites text to remove AI writing patterns."""
+    mock_anthropic.enqueue(
+        text_response("This library serves as a testament to robust design and leverages a vibrant ecosystem.")
+    )
+    mock_anthropic.enqueue(_judge_replace_text("This library is well designed and has a large ecosystem."))
+
+    async with policy_context(_DEAI, {}, gateway_url=gateway_url, admin_api_key=admin_api_key):
+        session = ClaudeCodeSimulator(gateway_url, api_key)
+        turn = await session.send("Describe the library")
+
+    assert "testament" not in turn.text.lower()
+    assert "leverages" not in turn.text.lower()
+    assert "This library is well designed" in turn.text
 
 
 # =============================================================================

--- a/tests/luthien_proxy/e2e_tests/test_mock_preset_policies.py
+++ b/tests/luthien_proxy/e2e_tests/test_mock_preset_policies.py
@@ -214,6 +214,26 @@ async def test_deai_rewrites_ai_patterns(
     assert "This library is well designed" in turn.text
 
 
+@pytest.mark.asyncio
+async def test_deai_passes_natural_text(
+    mock_anthropic: MockAnthropicServer,
+    gateway_healthy,
+    gateway_url,
+    api_key,
+    admin_api_key,
+):
+    """DeAIPolicy: text that already reads naturally passes through unchanged."""
+    natural = "The cache holds 500 entries and evicts the oldest when full."
+    mock_anthropic.enqueue(text_response(natural))
+    mock_anthropic.enqueue(_judge_pass())
+
+    async with policy_context(_DEAI, {}, gateway_url=gateway_url, admin_api_key=admin_api_key):
+        session = ClaudeCodeSimulator(gateway_url, api_key)
+        turn = await session.send("Describe the cache")
+
+    assert turn.text == natural
+
+
 # =============================================================================
 # NoYappingPolicy
 # =============================================================================

--- a/tests/luthien_proxy/unit_tests/policies/presets/test_preset_policies.py
+++ b/tests/luthien_proxy/unit_tests/policies/presets/test_preset_policies.py
@@ -8,6 +8,7 @@ import pytest
 from luthien_proxy.policies.presets.block_dangerous_commands import BlockDangerousCommandsPolicy
 from luthien_proxy.policies.presets.block_sensitive_file_writes import BlockSensitiveFileWritesPolicy
 from luthien_proxy.policies.presets.block_web_requests import BlockWebRequestsPolicy
+from luthien_proxy.policies.presets.deai import DeAIPolicy
 from luthien_proxy.policies.presets.no_apologies import NoApologiesPolicy
 from luthien_proxy.policies.presets.no_yapping import NoYappingPolicy
 from luthien_proxy.policies.presets.plain_dashes import PlainDashesPolicy
@@ -21,6 +22,7 @@ ALL_PRESETS = [
     NoYappingPolicy,
     BlockWebRequestsPolicy,
     BlockSensitiveFileWritesPolicy,
+    DeAIPolicy,
 ]
 
 
@@ -59,6 +61,7 @@ def test_preset_class_refs_are_importable():
         ("luthien_proxy.policies.presets.no_yapping", "NoYappingPolicy"),
         ("luthien_proxy.policies.presets.block_web_requests", "BlockWebRequestsPolicy"),
         ("luthien_proxy.policies.presets.block_sensitive_file_writes", "BlockSensitiveFileWritesPolicy"),
+        ("luthien_proxy.policies.presets.deai", "DeAIPolicy"),
     ]
     for module_path, class_name in preset_modules:
         module = importlib.import_module(module_path)


### PR DESCRIPTION
## Summary

Reimplements the **De-AI policy** from #485 as a thin `SimpleLLMPolicy` preset, replacing #485's bespoke streaming machinery with the judge infrastructure that landed on `main` after #485 was opened.

#485 hand-rolled ~690 lines across `deai_policy.py` + `deai_utils.py`:
- a streaming buffer with paragraph-boundary chunk extraction
- per-chunk LiteLLM calls with retry/truncation handling
- manual delta emission and protocol-ordering flush logic
- per-chunk error fallback

All of that is now provided generically by `SimpleLLMPolicy` + `AnthropicMessageBuilder` + `JudgeOrchestrator`. So this port collapses the feature into a ~40-line zero-config preset that just supplies the 25-pattern de-AI prompt as judge `instructions` — exactly the pattern the sibling presets (`no_yapping`, `no_apologies`, `plain_dashes`) already use. De-AI is a comprehensive superset of those three.

## What's here

- `src/luthien_proxy/policies/presets/deai.py` — `DeAIPolicy(SimpleLLMPolicy)`, the 25 AI-writing-pattern instructions ported from #485's system prompt
- Registered in `policy_types.REGISTERED_BUILTINS` (shows in the policy catalog UI)
- Unit coverage via the shared preset parametrization
- Mock-e2e test mirroring the other rewrite presets

## Behavioral note (intentional simplification)

#485 chunked text at paragraph boundaries and humanized **incrementally** during streaming, to support indefinite-length output and dodge judge token limits. `SimpleLLMPolicy` instead buffers each text block, then judges/replaces it as a whole. For very long single text blocks this leans on the judge's `max_tokens` (preset to 8192) rather than per-paragraph chunking. This is the same trade-off every other `SimpleLLMPolicy` preset makes, and it's the reason the bespoke streaming code is no longer warranted.

## Test plan

- [x] `dev_checks.sh` — ruff + pyright (0 errors) + full unit suite (2694 passed)
- [x] `run_e2e.sh mock -k test_deai_rewrites_ai_patterns` — passes

Closes #485 (superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)