### PR TITLE
fix(ui): close stored-XSS class in admin UI static assets

### DIFF
--- a/changelog.d/fix-admin-ui-xss-class.md
+++ b/changelog.d/fix-admin-ui-xss-class.md
@@ -1,0 +1,19 @@
+---
+category: Fixes
+---
+
+**Fix stored-XSS class in admin UI static assets**: Attacker-influenced values
+(session_id, call_id, transaction_id, tool_call_id, model/endpoint, provider
+names) were interpolated into inline `onclick="...('${x}')"` JS strings and
+quoted HTML attributes, while the hand-rolled `escapeHtml` helpers did not
+escape `'` or `"`, allowing breakout and script execution.
+  - Migrated the genuinely attacker-controlled JS-string/event-handler sinks in
+    `history_list.html`, `diff_viewer.html`, `request_logs.html`, and
+    `inference_providers.html` to DOM construction (`createElement` /
+    `textContent` / `addEventListener` / `dataset`) — markup and quotes are
+    inert by construction, no new dependency.
+  - Hardened the retained `escapeHtml` helpers in `conversation_live.js` and
+    `diff_viewer.html` to escape all five HTML-significant characters so
+    attribute interpolation cannot break out.
+  - Added source-level regression guards in
+    `tests/luthien_proxy/unit_tests/ui/test_static_xss_guards.py`.

--- a/src/luthien_proxy/static/conversation_live.js
+++ b/src/luthien_proxy/static/conversation_live.js
@@ -1,8 +1,16 @@
+// Escape for safe interpolation into both HTML text *and* quoted attributes.
+// The previous textContent/innerHTML trick escaped <, >, & but NOT " or ',
+// so values interpolated into attribute contexts (e.g. data-tool-call-id="...")
+// could break out of the attribute. Several call_id / tool_call_id values here
+// are request/model-derived, making that a stored-XSS sink. Escape all five.
 function escapeHtml(str) {
     if (str === null || str === undefined) return '';
-    const div = document.createElement('div');
-    div.textContent = String(str);
-    return div.innerHTML;
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
 }
 
 function conversationViewer() {

--- a/src/luthien_proxy/static/diff_viewer.html
+++ b/src/luthien_proxy/static/diff_viewer.html
@@ -626,23 +626,45 @@
                 return;
             }
 
-            let html = '<div class="diff-section"><h2 class="section-title">Recent Calls</h2>';
+            // DOM construction: call_id is request-derived and was previously
+            // interpolated into both an inline onclick JS string and HTML text,
+            // a stored-XSS sink. Building nodes makes it inert by construction.
+            const section = document.createElement('div');
+            section.className = 'diff-section';
+            const title = document.createElement('h2');
+            title.className = 'section-title';
+            title.textContent = 'Recent Calls';
+            section.appendChild(title);
 
             calls.forEach(call => {
                 const timestamp = new Date(call.latest_timestamp).toLocaleString();
-                html += `
-                    <div class="message" style="cursor: pointer;" onclick="selectCall('${call.call_id}')">
-                        <div class="message-role">Call ID: ${call.call_id}</div>
-                        <div style="display: flex; justify-content: space-between; color: #888; font-size: 12px;">
-                            <span>${timestamp}</span>
-                            <span>${call.event_count} events</span>
-                        </div>
-                    </div>
-                `;
+
+                const card = document.createElement('div');
+                card.className = 'message';
+                card.style.cursor = 'pointer';
+                card.dataset.callId = call.call_id;
+                card.addEventListener('click', () => selectCall(call.call_id));
+
+                const role = document.createElement('div');
+                role.className = 'message-role';
+                role.textContent = 'Call ID: ' + call.call_id;
+
+                const sub = document.createElement('div');
+                sub.style.display = 'flex';
+                sub.style.justifyContent = 'space-between';
+                sub.style.color = '#888';
+                sub.style.fontSize = '12px';
+                const tsSpan = document.createElement('span');
+                tsSpan.textContent = timestamp;
+                const countSpan = document.createElement('span');
+                countSpan.textContent = call.event_count + ' events';
+                sub.append(tsSpan, countSpan);
+
+                card.append(role, sub);
+                section.appendChild(card);
             });
 
-            html += '</div>';
-            container.innerHTML = html;
+            container.replaceChildren(section);
         }
 
         function selectCall(callId) {
@@ -650,13 +672,20 @@
             loadDiff();
         }
 
+        // Escapes <, >, &, " and ' so the result is safe in both HTML text and
+        // quoted-attribute contexts. (The old textContent/innerHTML form left
+        // quotes unescaped, which is unsafe the moment a value lands in an
+        // attribute.)
         function escapeHtml(text) {
             if (text === null || text === undefined) {
                 return '';
             }
-            const div = document.createElement('div');
-            div.textContent = String(text);
-            return div.innerHTML;
+            return String(text)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
         }
 
         function formatContent(content) {

--- a/src/luthien_proxy/static/history_list.html
+++ b/src/luthien_proxy/static/history_list.html
@@ -528,7 +528,10 @@
                 applyFilters();
 
             } catch (error) {
-                container.innerHTML = `<div class="error">Failed to load sessions: ${escapeHtml(error.message)}</div>`;
+                const errDiv = document.createElement('div');
+                errDiv.className = 'error';
+                errDiv.textContent = 'Failed to load sessions: ' + error.message;
+                container.replaceChildren(errDiv);
             }
         }
 
@@ -547,46 +550,78 @@
             // Group sessions by most recent date (last_timestamp)
             const grouped = groupByDate(sessions, today, yesterday);
 
-            let html = '';
+            // DOM construction (not HTML string interpolation): session_id was
+            // previously interpolated into an inline onclick JS string, where
+            // the escapeHtml helper does NOT escape quotes — a stored-XSS sink.
+            // preview_message is also request-derived. Building nodes and using
+            // textContent / addEventListener makes both inert by construction.
+            const frag = document.createDocumentFragment();
             for (const [dateKey, dateSessions] of Object.entries(grouped)) {
-                html += `<div class="date-header"><span class="date-pill">${dateKey}</span></div>`;
+                const dateHeader = document.createElement('div');
+                dateHeader.className = 'date-header';
+                const datePill = document.createElement('span');
+                datePill.className = 'date-pill';
+                datePill.textContent = dateKey;
+                dateHeader.appendChild(datePill);
+                frag.appendChild(dateHeader);
 
                 for (const session of dateSessions) {
                     const firstTime = new Date(session.first_timestamp);
                     const lastTime = new Date(session.last_timestamp);
                     const timeStr = formatTimeRange(firstTime, lastTime);
                     const messageCount = session.turn_count;
-
+                    const hasPreview = !!session.preview_message;
                     const previewText = session.preview_message || '(no message preview)';
 
-                    // Build meta line
-                    let metaParts = [`${messageCount} message${messageCount !== 1 ? 's' : ''}`];
+                    const card = document.createElement('div');
+                    card.className = 'session-card';
+                    card.dataset.sessionId = session.session_id;
+                    card.addEventListener('click', () => viewSession(session.session_id));
 
-                    // Policy interventions
-                    let interventionsHtml;
+                    const main = document.createElement('div');
+                    main.className = 'session-main';
+
+                    const preview = document.createElement('div');
+                    preview.className = hasPreview ? 'session-preview' : 'session-preview session-preview-empty';
+                    preview.textContent = previewText;
+
+                    const meta = document.createElement('div');
+                    meta.className = 'session-meta';
+                    meta.appendChild(document.createTextNode(
+                        `${messageCount} message${messageCount !== 1 ? 's' : ''} · `
+                    ));
+                    const interventions = document.createElement('span');
                     if (session.policy_interventions > 0) {
-                        interventionsHtml = `<span class="interventions-triggered">${session.policy_interventions} policy intervention${session.policy_interventions > 1 ? 's' : ''}</span>`;
+                        interventions.className = 'interventions-triggered';
+                        interventions.textContent =
+                            `${session.policy_interventions} policy intervention${session.policy_interventions > 1 ? 's' : ''}`;
                     } else {
-                        interventionsHtml = `<span class="interventions-none">no policies triggered</span>`;
+                        interventions.className = 'interventions-none';
+                        interventions.textContent = 'no policies triggered';
                     }
+                    meta.appendChild(interventions);
 
-                    const hasPreview = !!session.preview_message;
-                    html += `
-                        <div class="session-card" onclick="viewSession('${escapeHtml(session.session_id)}')">
-                            <div class="session-main">
-                                <div class="session-preview${hasPreview ? '' : ' session-preview-empty'}">${escapeHtml(previewText)}</div>
-                                <div class="session-meta">${metaParts.join(' · ')} · ${interventionsHtml}</div>
-                            </div>
-                            <div class="session-right">
-                                <div class="session-time">${timeStr}</div>
-                                <div class="session-arrow">→</div>
-                            </div>
-                        </div>
-                    `;
+                    main.append(preview, meta);
+
+                    const right = document.createElement('div');
+                    right.className = 'session-right';
+                    const timeEl = document.createElement('div');
+                    timeEl.className = 'session-time';
+                    // formatTimeRange may embed a <br> for multi-day ranges; the
+                    // values are all derived from Date objects (never user text),
+                    // so the limited static markup is safe to inject here.
+                    timeEl.innerHTML = timeStr;
+                    const arrow = document.createElement('div');
+                    arrow.className = 'session-arrow';
+                    arrow.textContent = '→';
+                    right.append(timeEl, arrow);
+
+                    card.append(main, right);
+                    frag.appendChild(card);
                 }
             }
 
-            container.innerHTML = html;
+            container.replaceChildren(frag);
         }
 
         function groupByDate(sessions, today, yesterday) {
@@ -680,12 +715,6 @@
 
                 return `${startDay} ${startMonth} ${startDateNum} ${startTime} -<br>${endDay} ${endMonth} ${endDateNum} ${endTime}`;
             }
-        }
-
-        function escapeHtml(str) {
-            const div = document.createElement('div');
-            div.textContent = str;
-            return div.innerHTML;
         }
 
         loadSessions();

--- a/src/luthien_proxy/static/inference_providers.html
+++ b/src/luthien_proxy/static/inference_providers.html
@@ -361,12 +361,6 @@
             setTimeout(() => { el.className = 'status-message'; }, 5000);
         }
 
-        function escapeHtml(s) {
-            return String(s).replace(/[&<>"']/g, c => ({
-                '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
-            })[c]);
-        }
-
         // Known backend types learned from the last list response.
         // Used so the create/edit dropdown reflects what the gateway can
         // actually construct (not a hardcoded JS constant).
@@ -374,9 +368,6 @@
 
         // Last-seen list, keyed by name. Lets `editProvider(name)` look up
         // the row without embedding JSON in the HTML.
-        // TODO(post-merge): refactor row buttons to `addEventListener` +
-        // dataset; inline `onclick` works today because `escapeHtml` covers
-        // the name regex but is still the wrong idiom.
         const providersByName = Object.create(null);
 
         function populateBackendDropdown(types, selected) {
@@ -457,39 +448,100 @@
 
                 const content = document.getElementById('providers-content');
                 if (data.count === 0) {
-                    content.innerHTML = '<div class="empty-state">No providers configured</div>';
+                    const empty = document.createElement('div');
+                    empty.className = 'empty-state';
+                    empty.textContent = 'No providers configured';
+                    content.replaceChildren(empty);
                 } else {
-                    let html = '<table class="providers-table"><thead><tr>';
-                    html += '<th>Name</th><th>Backend</th><th>Credential</th><th>Default model</th><th>Config</th><th></th>';
-                    html += '</tr></thead><tbody>';
-                    for (const p of data.providers) {
-                        const backendLabel = p.known_backend
-                            ? escapeHtml(p.backend_type)
-                            : escapeHtml(p.backend_type) + ' <span style="color:#fca5a5;font-size:11px;border:1px solid #f87171;padding:1px 4px;border-radius:3px">unknown</span>';
-                        const editAttrs = p.known_backend
-                            ? ''
-                            : ' disabled title="Backend type is not registered in this build — edit would coerce it to a registered type."';
-                        html += '<tr>';
-                        html += '<td class="mono">' + escapeHtml(p.name) + '</td>';
-                        html += '<td>' + backendLabel + '</td>';
-                        html += '<td>' + (p.credential_name ? escapeHtml(p.credential_name) : '<span style="color:#666">—</span>') + '</td>';
-                        html += '<td class="mono">' + escapeHtml(p.default_model) + '</td>';
-                        html += '<td class="mono">' + escapeHtml(JSON.stringify(p.config)) + '</td>';
-                        html += '<td><div class="button-row">';
-                        html += '<button onclick="editProvider(\'' + escapeHtml(p.name) + '\')"' + editAttrs + '>Edit</button>';
-                        html += '<button class="danger" onclick="deleteProvider(\'' + escapeHtml(p.name) + '\')">Delete</button>';
-                        html += '</div></td>';
-                        html += '</tr>';
+                    // DOM construction: provider name/backend_type/credential/
+                    // model/config are config-derived strings; previously they
+                    // were interpolated into inline `onclick` JS strings and HTML
+                    // (same XSS class). Build nodes, wire buttons via
+                    // addEventListener + dataset — inert by construction.
+                    const table = document.createElement('table');
+                    table.className = 'providers-table';
+                    const thead = document.createElement('thead');
+                    const headRow = document.createElement('tr');
+                    for (const h of ['Name', 'Backend', 'Credential', 'Default model', 'Config', '']) {
+                        const th = document.createElement('th');
+                        th.textContent = h;
+                        headRow.appendChild(th);
                     }
-                    html += '</tbody></table>';
-                    content.innerHTML = html;
+                    thead.appendChild(headRow);
+                    table.appendChild(thead);
+
+                    const tbody = document.createElement('tbody');
+                    for (const p of data.providers) {
+                        const row = document.createElement('tr');
+
+                        const nameTd = document.createElement('td');
+                        nameTd.className = 'mono';
+                        nameTd.textContent = p.name;
+
+                        const backendTd = document.createElement('td');
+                        backendTd.textContent = p.backend_type;
+                        if (!p.known_backend) {
+                            const unknown = document.createElement('span');
+                            unknown.textContent = 'unknown';
+                            unknown.style.color = '#fca5a5';
+                            unknown.style.fontSize = '11px';
+                            unknown.style.border = '1px solid #f87171';
+                            unknown.style.padding = '1px 4px';
+                            unknown.style.borderRadius = '3px';
+                            backendTd.append(document.createTextNode(' '), unknown);
+                        }
+
+                        const credTd = document.createElement('td');
+                        if (p.credential_name) {
+                            credTd.textContent = p.credential_name;
+                        } else {
+                            const dash = document.createElement('span');
+                            dash.style.color = '#666';
+                            dash.textContent = '—';
+                            credTd.appendChild(dash);
+                        }
+
+                        const modelTd = document.createElement('td');
+                        modelTd.className = 'mono';
+                        modelTd.textContent = p.default_model;
+
+                        const configTd = document.createElement('td');
+                        configTd.className = 'mono';
+                        configTd.textContent = JSON.stringify(p.config);
+
+                        const actionTd = document.createElement('td');
+                        const buttonRow = document.createElement('div');
+                        buttonRow.className = 'button-row';
+                        const editBtn = document.createElement('button');
+                        editBtn.textContent = 'Edit';
+                        editBtn.dataset.providerName = p.name;
+                        if (!p.known_backend) {
+                            editBtn.disabled = true;
+                            editBtn.title = 'Backend type is not registered in this build — edit would coerce it to a registered type.';
+                        }
+                        editBtn.addEventListener('click', () => editProvider(p.name));
+                        const delBtn = document.createElement('button');
+                        delBtn.className = 'danger';
+                        delBtn.textContent = 'Delete';
+                        delBtn.dataset.providerName = p.name;
+                        delBtn.addEventListener('click', () => deleteProvider(p.name));
+                        buttonRow.append(editBtn, delBtn);
+                        actionTd.appendChild(buttonRow);
+
+                        row.append(nameTd, backendTd, credTd, modelTd, configTd, actionTd);
+                        tbody.appendChild(row);
+                    }
+                    table.appendChild(tbody);
+                    content.replaceChildren(table);
                 }
 
                 document.getElementById('providers-loading').style.display = 'none';
                 content.style.display = 'block';
             } catch (e) {
-                document.getElementById('providers-loading').innerHTML =
-                    '<span style="color: #fca5a5;">Failed to load providers: ' + escapeHtml(e.message) + '</span>';
+                const errSpan = document.createElement('span');
+                errSpan.style.color = '#fca5a5';
+                errSpan.textContent = 'Failed to load providers: ' + e.message;
+                document.getElementById('providers-loading').replaceChildren(errSpan);
             }
         }
 

--- a/src/luthien_proxy/static/request_logs.html
+++ b/src/luthien_proxy/static/request_logs.html
@@ -207,20 +207,50 @@ async function loadLogs() {
         return;
     }
 
-    body.innerHTML = data.logs.map(log => {
+    // Build rows via DOM construction (not HTML string interpolation): all
+    // request-derived fields (transaction_id, endpoint, model, direction) are
+    // assigned as text/dataset, so quotes and markup are inert by construction.
+    body.replaceChildren(...data.logs.map(log => {
         const time = new Date(log.started_at).toLocaleTimeString();
         const statusClass = (log.response_status && log.response_status < 400) ? 'status-ok' : 'status-err';
         const dur = log.duration_ms != null ? log.duration_ms.toFixed(0) + 'ms' : '-';
-        return `<tr onclick="showTransaction('${log.transaction_id}')">
-            <td class="mono">${time}</td>
-            <td><span class="badge ${log.direction}">${log.direction}</span></td>
-            <td class="mono">${log.endpoint || '-'}</td>
-            <td>${log.model || '-'}</td>
-            <td class="${statusClass}">${log.response_status || '-'}</td>
-            <td class="mono">${dur}</td>
-            <td>${log.is_streaming ? 'Yes' : 'No'}</td>
-        </tr>`;
-    }).join('');
+
+        const tr = document.createElement('tr');
+        tr.dataset.transactionId = log.transaction_id;
+        tr.addEventListener('click', () => showTransaction(log.transaction_id));
+
+        const timeTd = document.createElement('td');
+        timeTd.className = 'mono';
+        timeTd.textContent = time;
+
+        const dirTd = document.createElement('td');
+        const dirBadge = document.createElement('span');
+        dirBadge.className = 'badge';
+        if (log.direction) dirBadge.classList.add(log.direction);
+        dirBadge.textContent = log.direction;
+        dirTd.appendChild(dirBadge);
+
+        const epTd = document.createElement('td');
+        epTd.className = 'mono';
+        epTd.textContent = log.endpoint || '-';
+
+        const modelTd = document.createElement('td');
+        modelTd.textContent = log.model || '-';
+
+        const statusTd = document.createElement('td');
+        statusTd.className = statusClass;
+        statusTd.textContent = log.response_status || '-';
+
+        const durTd = document.createElement('td');
+        durTd.className = 'mono';
+        durTd.textContent = dur;
+
+        const streamTd = document.createElement('td');
+        streamTd.textContent = log.is_streaming ? 'Yes' : 'No';
+
+        tr.append(timeTd, dirTd, epTd, modelTd, statusTd, durTd, streamTd);
+        return tr;
+    }));
 }
 
 function updatePagination() {
@@ -254,10 +284,23 @@ async function showTransaction(txnId) {
     if (!data) { document.getElementById('detail-content').textContent = 'Failed to load'; return; }
 
     const meta = document.getElementById('detail-meta');
-    meta.innerHTML = `
-        <div class="meta-item"><label>Transaction:</label> <span class="mono">${data.transaction_id}</span></div>
-        <div class="meta-item"><label>Session:</label> <span class="mono">${data.session_id || 'none'}</span></div>
-    `;
+    // DOM construction: transaction_id / session_id are request-derived; assign
+    // as textContent so they cannot inject markup.
+    const makeMetaItem = (labelText, valueText) => {
+        const item = document.createElement('div');
+        item.className = 'meta-item';
+        const label = document.createElement('label');
+        label.textContent = labelText;
+        const value = document.createElement('span');
+        value.className = 'mono';
+        value.textContent = valueText;
+        item.append(label, document.createTextNode(' '), value);
+        return item;
+    };
+    meta.replaceChildren(
+        makeMetaItem('Transaction:', data.transaction_id),
+        makeMetaItem('Session:', data.session_id || 'none'),
+    );
 
     const tabs = [];
     if (data.inbound) {

--- a/tests/luthien_proxy/unit_tests/ui/test_static_xss_guards.py
+++ b/tests/luthien_proxy/unit_tests/ui/test_static_xss_guards.py
@@ -1,0 +1,123 @@
+"""Regression guards against the stored-XSS class in admin UI static assets.
+
+Background: the admin UI is vanilla JS served as static HTML. Several render
+paths used to build HTML by string interpolation and rely on a hand-rolled
+`escapeHtml` that escaped ``<``, ``>``, ``&`` but NOT ``'`` or ``"``. Any
+attacker-influenced value (session_id, call_id, transaction_id, tool_call_id,
+model/endpoint names — all request- or model-derived) interpolated into an
+inline ``onclick="...('${x}')"`` JS string or a quoted HTML attribute could
+break out and execute. See PR addressing this class.
+
+The fix:
+  * Genuinely attacker-controlled JS-string / event-handler sinks were rewritten
+    using DOM construction (``createElement`` / ``textContent`` /
+    ``addEventListener`` / ``dataset``) so quotes and markup are inert by
+    construction — the browser-native, zero-dependency safe answer.
+  * The remaining hand-rolled ``escapeHtml`` helpers were hardened to also
+    escape quotes so attribute interpolation cannot break out.
+
+These tests are deliberately source-text assertions (the repo has no JS test
+runtime). They are not a substitute for a real DOM test, but they pin the two
+concrete regressions that already bit this codebase twice.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+STATIC_DIR = Path(__file__).resolve().parents[4] / "src" / "luthien_proxy" / "static"
+
+# Files whose attacker-influenced render paths were migrated to DOM construction.
+DOM_MIGRATED_FILES = [
+    "history_list.html",
+    "diff_viewer.html",
+    "request_logs.html",
+    "inference_providers.html",
+]
+
+# Files that retain a hand-rolled escapeHtml used in attribute contexts; those
+# escapers must cover quotes.
+QUOTE_SAFE_ESCAPER_FILES = [
+    "conversation_live.js",
+    "diff_viewer.html",
+]
+
+# Matches an inline event-handler attribute (onclick=, onchange=, ...) whose
+# value contains a JS string literal built from a template-literal placeholder,
+# e.g.  onclick="viewSession('${escapeHtml(session.session_id)}')"
+# This is the exact stored-XSS pattern we removed; escapeHtml does not escape
+# the surrounding single quotes, so the placeholder can break out of the JS
+# string. New occurrences should use addEventListener instead.
+_INLINE_HANDLER_JS_STRING = re.compile(
+    r"""on\w+\s*=\s*["'][^"']*\(\s*\\?['"]\$\{""",
+    re.IGNORECASE,
+)
+
+
+def _read(name: str) -> str:
+    return (STATIC_DIR / name).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("filename", DOM_MIGRATED_FILES)
+def test_no_inline_handler_js_string_interpolation(filename: str) -> None:
+    """No inline on*-handler should interpolate a template placeholder into a JS string.
+
+    That pattern is unsafe with any HTML-only escaper. Event wiring must go
+    through addEventListener so the value is passed as data, never parsed.
+    """
+    source = _read(filename)
+    matches = _INLINE_HANDLER_JS_STRING.findall(source)
+    assert not matches, (
+        f"{filename} contains inline-handler JS-string interpolation (stored-XSS class): "
+        f"{matches}. Use addEventListener + dataset instead."
+    )
+
+
+@pytest.mark.parametrize("filename", QUOTE_SAFE_ESCAPER_FILES)
+def test_escapehtml_escapes_quotes(filename: str) -> None:
+    """Any retained hand-rolled escapeHtml must escape both single and double quotes.
+
+    The old textContent/innerHTML trick left quotes unescaped, so a value placed
+    in a quoted attribute could break out. Assert the source escapes them.
+    """
+    source = _read(filename)
+    assert "escapeHtml" in source, f"{filename} no longer defines escapeHtml; update this guard."
+    assert "&quot;" in source, f"{filename}'s escapeHtml must escape double quotes (&quot;)."
+    assert "&#39;" in source or "&apos;" in source, f"{filename}'s escapeHtml must escape single quotes (&#39;)."
+
+
+def test_history_list_uses_dom_construction_for_session_id() -> None:
+    """The session_id sink in history_list.html must be wired via addEventListener.
+
+    This is the #780 / pre-existing history_list sink. It must not appear in an
+    inline onclick JS string anymore.
+    """
+    source = _read("history_list.html")
+    assert "viewSession('${" not in source
+    assert "addEventListener('click', () => viewSession(" in source
+
+
+def test_request_logs_uses_dom_construction_for_transaction_id() -> None:
+    """transaction_id must be wired via addEventListener, not an inline onclick string."""
+    source = _read("request_logs.html")
+    assert "showTransaction('${" not in source
+    assert "addEventListener('click', () => showTransaction(" in source
+
+
+def test_diff_viewer_uses_dom_construction_for_call_id() -> None:
+    """call_id must be wired via addEventListener, not an inline onclick string."""
+    source = _read("diff_viewer.html")
+    assert "selectCall('${" not in source
+    assert "addEventListener('click', () => selectCall(" in source
+
+
+def test_inference_providers_uses_dom_construction_for_provider_name() -> None:
+    """Provider-name edit/delete buttons must be wired via addEventListener."""
+    source = _read("inference_providers.html")
+    assert "editProvider(\\'" not in source
+    assert "deleteProvider(\\'" not in source
+    assert "addEventListener('click', () => editProvider(" in source
+    assert "addEventListener('click', () => deleteProvider(" in source


### PR DESCRIPTION
## Root cause

The admin UI is vanilla JS served as static HTML (no bundler, no framework — Alpine.js is vendored for nav only). Several render paths built HTML by string interpolation and relied on hand-rolled `escapeHtml` helpers shaped like:

```js
function escapeHtml(str) { const div = document.createElement('div'); div.textContent = str; return div.innerHTML; }
```

That escapes `<`, `>`, `&` but **not** `'` or `"`. So any attacker-influenced value interpolated into an inline `onclick="...('${escapeHtml(x)}')"` JS string, or into a quoted HTML attribute, can break out and execute. The interpolated values are request/model-derived: `session_id`, `call_id`, `transaction_id`, `tool_call_id`, model/endpoint names, provider names.

This is a recurring class, not a one-off — #780 and #752 each tripped the same pattern, plus a pre-existing `session_id` sink in `history_list.html`.

## Standard solution chosen — and why

**DOM construction** (`createElement` / `textContent` / `setAttribute` / `addEventListener` + `dataset`) for the genuinely attacker-controlled JS-string and event-handler sinks. This is the browser-native, zero-dependency safe answer: quotes and markup become inert *by construction* because values are assigned as data/text, never parsed as HTML or JS. It's also already the established pattern in this repo — `nav.js`'s `createBadgeElement` builds its nodes exactly this way.

For the two large template-literal render files that aren't worth a full rewrite in a bug-fix PR (`conversation_live.js`, `diff_viewer.html`), I **hardened the existing `escapeHtml`** to escape all five HTML-significant characters, closing their attribute-interpolation sinks.

**What I rejected:**
- *A new bespoke escaper as the strategy* — the maintainer explicitly flagged "we shouldn't have to roll our own," and an escaper is the fragile approach (context-sensitive: an HTML-text escaper is wrong in attribute/JS-string contexts). DOM construction removes the context-sensitivity entirely.
- *A small auto-escaping templating/sanitizer library (e.g. DOMPurify, lit-html)* — the templating volume is small and localized to a handful of render functions. Adding a JS dependency to a repo with no `package.json` / no bundler / no JS toolchain violates the repo's KISS / no-unnecessary-deps norms. The cost isn't justified.

The dependency tradeoff: DOM construction is more verbose than template literals, but it's stdlib, it matches existing code, and it's the only option that makes the sink safe regardless of context.

## Files / sinks fixed

DOM-construction migration (attacker-controlled JS-string / event-handler sinks):
- `history_list.html` — `viewSession('${escapeHtml(session.session_id)}')` onclick + preview/meta rendering; broken `escapeHtml` removed (now unused).
- `diff_viewer.html` — `selectCall('${call.call_id}')` onclick (was **unescaped**) + recent-calls card text.
- `request_logs.html` — `showTransaction('${log.transaction_id}')` onclick (was **unescaped**) + log rows (endpoint/model/direction) + transaction/session detail meta.
- `inference_providers.html` — `editProvider('...')` / `deleteProvider('...')` inline onclicks → `addEventListener` + `dataset`; resolves the file's own `TODO(post-merge)` about this exact idiom; its (correct) `escapeHtml` removed (now unused).

Escaper hardening (attribute-interpolation sinks in large template-literal files):
- `conversation_live.js` — `escapeHtml` now escapes `"`/`'`; closes the `data-tool-call-id="${escapeHtml(...)}"` attribute breakout.
- `diff_viewer.html` — `escapeHtml` hardened for defense-in-depth (its remaining uses are HTML-text, already safe).

Tests:
- `tests/luthien_proxy/unit_tests/ui/test_static_xss_guards.py` — source-level regression guards: no inline-handler JS-string interpolation in the migrated files, retained escapers escape both quote characters, and each specific sink is wired via `addEventListener`. (The repo has no JS runtime, so these are source-text assertions — see "Not runtime-verified" below.)

## Out of scope (deliberately)

`policy_config.js` / `form_renderer.js` also use inline `onclick="window.moveSubPolicy('${safePath}', ...)"`. I left these: `safePath` goes through the file's `esc()` which **does** escape quotes, and `path` is an internally-computed JSON-schema field path (derived from the policy config schema, not from request traffic) — not attacker-influenced. Migrating them to `addEventListener` for consistency is a reasonable follow-up but isn't part of this XSS-class fix.

## Relationship to #780 / #752

- **#780** (user differentiation) is in flight touching `history_list.html` and adding a local quote-hardening to that file's `escapeHtml`. This PR is built on current `main`, **not** #780, and addresses the root cause class-wide — it may supersede #780's local hardening. Whichever merges second should reconcile `history_list.html` (this PR removes that file's `escapeHtml` entirely in favor of DOM construction, so #780's local hardening of it becomes moot).
- **#752** (cursor pagination) flagged an XSS in `fragments/sessions.html`. That fragment file does **not exist on current `main`** (neither does #780's `user_id` UI sink) — so it's not in this PR's tree. The pattern it represents is exactly what this PR eliminates; when #752 lands, its `sessions.html` should use DOM construction for `session_id` rather than `escapeHtml`-into-onclick.

## CSP backstop (noted, not implemented)

A Content-Security-Policy header on the admin UI routes (`src/luthien_proxy/ui/routes.py`) would be a strong defense-in-depth backstop. It's **not** implemented here because every admin page uses inline `<script>` blocks and inline event handlers (Alpine's `x-data`/`@change`, the policy-config inline onclicks). A meaningful `script-src 'self'` CSP would break all of them and requires either per-page nonces or moving all inline JS to external files — a substantial, separate refactor that doesn't belong in a focused bug-fix PR. Recommended as a follow-up.

## One PR = One Concern / COE

Strictly the XSS-class fix; no feature changes. This is a bug fix and warrants a COE-style note (root cause: context-insensitive hand-rolled escaper + string-interpolated HTML; the recurrence across #780/#752 is the signal that the *pattern*, not any single sink, is the defect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
