### PR TITLE
fix(ui): credentials.html XSS sinks + harden XSS guards (follow-up to #781)

### DIFF
--- a/changelog.d/fix-admin-ui-xss-class.md
+++ b/changelog.d/fix-admin-ui-xss-class.md
@@ -2,20 +2,25 @@
 category: Fixes
 ---
 
-**Fix stored-XSS class in admin UI static assets**: Attacker-influenced values
-(session_id, call_id, transaction_id, tool_call_id, key_hash, credential/model/
-endpoint/provider names, server error messages) were interpolated into inline
-`onclick` JS strings and quoted HTML attributes — some via hand-rolled
-`escapeHtml` helpers that did not escape `'` or `"`, some (in `credentials.html`)
-via raw string concatenation with no escaping at all — allowing breakout and
-script execution.
-  - Migrated the genuinely attacker-controlled JS-string/event-handler sinks in
-    `history_list.html`, `diff_viewer.html`, `request_logs.html`,
-    `inference_providers.html`, and `credentials.html` to DOM construction
-    (`createElement` / `textContent` / `addEventListener` / `dataset`) — markup
-    and quotes are inert by construction, no new dependency.
-  - Hardened the retained `escapeHtml` helpers in `conversation_live.js` and
-    `diff_viewer.html` to escape all five HTML-significant characters so
-    attribute interpolation cannot break out.
+**Fix stored-XSS class in admin UI static assets**: A comprehensive sweep of
+`src/luthien_proxy/static/**`. Attacker-influenced values (session_id, call_id,
+transaction_id, tool_call_id, key_hash, credential/model/endpoint/provider
+names, full activity-stream event payloads, server error messages) were
+interpolated into inline `onclick` JS strings, quoted HTML attributes, or HTML
+text — some via hand-rolled escapers that did not escape `'`/`"`, some (in
+`credentials.html`) via raw string concatenation with no escaping at all, some
+(in `activity_monitor.js`) via `JSON.stringify(event)` straight into a `<pre>` —
+allowing breakout and script execution.
+  - Migrated the attacker-controlled JS-string / event-handler / HTML-text sinks
+    in `history_list.html`, `diff_viewer.html`, `request_logs.html`,
+    `inference_providers.html`, `credentials.html`, `config_dashboard.html`, and
+    `activity_monitor.js` to DOM construction (`createElement` / `textContent` /
+    `addEventListener` / `dataset`) — markup and quotes are inert by
+    construction, no new dependency.
+  - Hardened the retained escapers (`escapeHtml` in `conversation_live.js` /
+    `diff_viewer.html`, `esc` in `config_dashboard.html`) to escape all five
+    HTML-significant characters so attribute interpolation cannot break out.
+  - Converted `e.message` → `innerHTML` error sinks (unconstrained server text)
+    to `textContent` across the affected files.
   - Added source-level regression guards in
     `tests/luthien_proxy/unit_tests/ui/test_static_xss_guards.py`.

--- a/changelog.d/fix-admin-ui-xss-class.md
+++ b/changelog.d/fix-admin-ui-xss-class.md
@@ -3,15 +3,17 @@ category: Fixes
 ---
 
 **Fix stored-XSS class in admin UI static assets**: Attacker-influenced values
-(session_id, call_id, transaction_id, tool_call_id, model/endpoint, provider
-names) were interpolated into inline `onclick="...('${x}')"` JS strings and
-quoted HTML attributes, while the hand-rolled `escapeHtml` helpers did not
-escape `'` or `"`, allowing breakout and script execution.
+(session_id, call_id, transaction_id, tool_call_id, key_hash, credential/model/
+endpoint/provider names, server error messages) were interpolated into inline
+`onclick` JS strings and quoted HTML attributes — some via hand-rolled
+`escapeHtml` helpers that did not escape `'` or `"`, some (in `credentials.html`)
+via raw string concatenation with no escaping at all — allowing breakout and
+script execution.
   - Migrated the genuinely attacker-controlled JS-string/event-handler sinks in
-    `history_list.html`, `diff_viewer.html`, `request_logs.html`, and
-    `inference_providers.html` to DOM construction (`createElement` /
-    `textContent` / `addEventListener` / `dataset`) — markup and quotes are
-    inert by construction, no new dependency.
+    `history_list.html`, `diff_viewer.html`, `request_logs.html`,
+    `inference_providers.html`, and `credentials.html` to DOM construction
+    (`createElement` / `textContent` / `addEventListener` / `dataset`) — markup
+    and quotes are inert by construction, no new dependency.
   - Hardened the retained `escapeHtml` helpers in `conversation_live.js` and
     `diff_viewer.html` to escape all five HTML-significant characters so
     attribute interpolation cannot break out.

--- a/src/luthien_proxy/static/activity_monitor.js
+++ b/src/luthien_proxy/static/activity_monitor.js
@@ -109,17 +109,28 @@ function applyFilters() {
     });
 }
 
-// Rebuild the filter dropdown dynamically
+// Rebuild the filter dropdown dynamically.
+//
+// DOM construction: `category` / `subtype` are derived from event_type (split
+// on '.'), which comes from the activity stream and is request-derived. They
+// were previously interpolated into innerHTML including id="" / value=""
+// attributes — same stored-XSS class. Build nodes; markup/quotes are inert.
 function rebuildFilterDropdown() {
-    typeFilterDropdownEl.innerHTML = '';
+    typeFilterDropdownEl.replaceChildren();
 
     // Add "Select All" option
     const selectAllDiv = document.createElement('div');
     selectAllDiv.className = 'filter-option';
-    selectAllDiv.innerHTML = `
-        <input type="checkbox" id="select-all-types" ${selectAllChecked ? 'checked' : ''}>
-        <label for="select-all-types"><strong>Select All</strong></label>
-    `;
+    const selectAllInput = document.createElement('input');
+    selectAllInput.type = 'checkbox';
+    selectAllInput.id = 'select-all-types';
+    selectAllInput.checked = selectAllChecked;
+    const selectAllLabel = document.createElement('label');
+    selectAllLabel.htmlFor = 'select-all-types';
+    const selectAllStrong = document.createElement('strong');
+    selectAllStrong.textContent = 'Select All';
+    selectAllLabel.appendChild(selectAllStrong);
+    selectAllDiv.append(selectAllInput, selectAllLabel);
     typeFilterDropdownEl.appendChild(selectAllDiv);
 
     // Add categories and subtypes
@@ -131,24 +142,34 @@ function rebuildFilterDropdown() {
         // Category header (clickable to toggle all in category)
         const categoryDiv = document.createElement('div');
         categoryDiv.className = 'filter-category';
-        categoryDiv.innerHTML = `
-            <div class="filter-option category-header" data-category="${category}">
-                <label><strong>${category}</strong> (${subtypes.length})</label>
-            </div>
-        `;
+        const headerOption = document.createElement('div');
+        headerOption.className = 'filter-option category-header';
+        headerOption.dataset.category = category;
+        const headerLabel = document.createElement('label');
+        const headerStrong = document.createElement('strong');
+        headerStrong.textContent = category;
+        headerLabel.append(headerStrong, document.createTextNode(` (${subtypes.length})`));
+        headerOption.appendChild(headerLabel);
+        categoryDiv.appendChild(headerOption);
         typeFilterDropdownEl.appendChild(categoryDiv);
 
         // Subtypes
         subtypes.forEach(subtype => {
             const fullType = `${category}.${subtype}`;
             const isSelected = selectedEventTypes.has(fullType);
+            const checkboxId = `type-${category}-${subtype}`;
 
             const subtypeDiv = document.createElement('div');
             subtypeDiv.className = 'filter-option filter-subtype';
-            subtypeDiv.innerHTML = `
-                <input type="checkbox" id="type-${category}-${subtype}" value="${fullType}" ${isSelected ? 'checked' : ''}>
-                <label for="type-${category}-${subtype}">${subtype}</label>
-            `;
+            const input = document.createElement('input');
+            input.type = 'checkbox';
+            input.id = checkboxId;
+            input.value = fullType;
+            input.checked = isSelected;
+            const label = document.createElement('label');
+            label.htmlFor = checkboxId;
+            label.textContent = subtype;
+            subtypeDiv.append(input, label);
             typeFilterDropdownEl.appendChild(subtypeDiv);
         });
     });
@@ -173,7 +194,15 @@ function updateTypeFilterLabel() {
     }
 }
 
-// Create event DOM element
+// Create event DOM element.
+//
+// DOM construction (not innerHTML): every value here comes from the activity
+// stream, which is derived from live request traffic — event_type,
+// transaction_id, and the full event payload are attacker-influenceable. The
+// previous innerHTML build interpolated `event_type` as HTML text and the whole
+// event via `JSON.stringify(event)` into a <pre> with NO escaping; JSON.stringify
+// does not escape <, >, so a payload containing "</pre><script>..." injected
+// script. Building nodes with textContent makes every field inert.
 function createEventElement(event) {
     const el = document.createElement('div');
     el.className = 'event';
@@ -184,25 +213,44 @@ function createEventElement(event) {
     const transactionId = event.transaction_id || callId;
     const timestamp = event.timestamp || new Date().toISOString();
 
-    el.innerHTML = `
-        <div class="event-header">
-            <div class="event-main">
-                <div class="event-type">${event.event_type || 'unknown'}</div>
-                <div class="event-meta">
-                    <span class="event-id">ID: ${transactionId.substring(0, 12)}...</span>
-                    <span class="event-time">${formatTime(timestamp)}</span>
-                </div>
-            </div>
-            <div class="expand-icon">▼</div>
-        </div>
-        <div class="event-payload">
-            <pre>${JSON.stringify(event, null, 2)}</pre>
-        </div>
-    `;
+    const headerDiv = document.createElement('div');
+    headerDiv.className = 'event-header';
+
+    const mainDiv = document.createElement('div');
+    mainDiv.className = 'event-main';
+
+    const typeDiv = document.createElement('div');
+    typeDiv.className = 'event-type';
+    typeDiv.textContent = event.event_type || 'unknown';
+
+    const metaDiv = document.createElement('div');
+    metaDiv.className = 'event-meta';
+    const idSpan = document.createElement('span');
+    idSpan.className = 'event-id';
+    idSpan.textContent = `ID: ${String(transactionId).substring(0, 12)}...`;
+    const timeSpan = document.createElement('span');
+    timeSpan.className = 'event-time';
+    timeSpan.textContent = formatTime(timestamp);
+    metaDiv.append(idSpan, timeSpan);
+
+    mainDiv.append(typeDiv, metaDiv);
+
+    const expandIcon = document.createElement('div');
+    expandIcon.className = 'expand-icon';
+    expandIcon.textContent = '▼';
+
+    headerDiv.append(mainDiv, expandIcon);
+
+    const payloadDiv = document.createElement('div');
+    payloadDiv.className = 'event-payload';
+    const pre = document.createElement('pre');
+    pre.textContent = JSON.stringify(event, null, 2);
+    payloadDiv.appendChild(pre);
+
+    el.append(headerDiv, payloadDiv);
 
     // Add click handler for expand/collapse
-    const header = el.querySelector('.event-header');
-    header.addEventListener('click', () => {
+    headerDiv.addEventListener('click', () => {
         el.classList.toggle('expanded');
     });
 
@@ -352,7 +400,10 @@ function connect() {
 
 // Clear events
 clearBtnEl.addEventListener('click', () => {
-    eventsEl.innerHTML = '<div class="empty-state">Events cleared. Waiting for new events...</div>';
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'Events cleared. Waiting for new events...';
+    eventsEl.replaceChildren(empty);
     allEvents = [];
     eventCount = 0;
     updateStatus(eventSource && eventSource.readyState === EventSource.OPEN);

--- a/src/luthien_proxy/static/config_dashboard.html
+++ b/src/luthien_proxy/static/config_dashboard.html
@@ -321,12 +321,24 @@
             if (type === 'success') setTimeout(() => { el.className = 'status-msg'; }, 3000);
         }
 
-        // HTML-escape anything that lands inside innerHTML. Config values come
-        // from the DB and are admin-writable, so we must not trust them as HTML.
+        // Escapes <, >, &, " and ' so the result is safe in HTML text and
+        // *quoted* HTML attribute contexts ONLY. NOT safe for: JS-string
+        // contexts (a value inside an inline event-handler's quoted argument),
+        // URL / javascript: contexts, or *unquoted* attributes — for those use
+        // DOM construction (createElement + textContent/dataset +
+        // addEventListener). The old textContent/innerHTML form left quotes
+        // unescaped, unsafe the moment a value lands in an attribute (this file
+        // interpolates esc() into value="", title="", data-field="").
+        // Config field metadata is dev-defined today, but "internally derived so
+        // it's fine" is exactly the assumption that rots — escape all five.
         function esc(s) {
-            const d = document.createElement('div');
-            d.textContent = s === null || s === undefined ? '' : String(s);
-            return d.innerHTML;
+            if (s === null || s === undefined) return '';
+            return String(s)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
         }
 
         // Store resolved field objects by name so edit handlers can look them
@@ -451,7 +463,13 @@
 
                 renderDashboard(configData.config, policyData);
             } catch (e) {
-                document.getElementById('content').innerHTML = `<div class="section" style="color:#f87171">Error: ${e.message}</div>`;
+                // e.message is unconstrained (server-returned text) — build the
+                // node and use textContent so it cannot inject markup.
+                const errDiv = document.createElement('div');
+                errDiv.className = 'section';
+                errDiv.style.color = '#f87171';
+                errDiv.textContent = 'Error: ' + e.message;
+                document.getElementById('content').replaceChildren(errDiv);
             }
         }
 

--- a/src/luthien_proxy/static/conversation_live.js
+++ b/src/luthien_proxy/static/conversation_live.js
@@ -1,8 +1,12 @@
-// Escape for safe interpolation into both HTML text *and* quoted attributes.
-// The previous textContent/innerHTML trick escaped <, >, & but NOT " or ',
-// so values interpolated into attribute contexts (e.g. data-tool-call-id="...")
-// could break out of the attribute. Several call_id / tool_call_id values here
-// are request/model-derived, making that a stored-XSS sink. Escape all five.
+// Escape for safe interpolation into HTML text and *quoted* HTML attribute
+// contexts ONLY. NOT safe for: JS-string contexts (a value placed inside an
+// inline event-handler's quoted argument), URL / javascript: contexts, or
+// *unquoted* attributes — for those use DOM construction (createElement +
+// textContent/dataset + addEventListener). The previous textContent/innerHTML
+// trick escaped <, >, & but NOT " or ', so values in attribute contexts (e.g.
+// data-tool-call-id="...") could break out. Several call_id / tool_call_id
+// values here are request/model-derived, making that a stored-XSS sink.
+// Escape all five.
 function escapeHtml(str) {
     if (str === null || str === undefined) return '';
     return String(str)

--- a/src/luthien_proxy/static/credentials.html
+++ b/src/luthien_proxy/static/credentials.html
@@ -730,7 +730,12 @@
             const loading = document.getElementById('srv-loading');
             const content = document.getElementById('srv-content');
             loading.style.display = 'block';
-            loading.innerHTML = '<span class="spinner">&#x23F3;</span> Loading credentials...';
+            // Static content, but build via DOM for consistency with the rest of
+            // the file (no innerHTML string-building anywhere).
+            const spinner = document.createElement('span');
+            spinner.className = 'spinner';
+            spinner.textContent = '⏳';
+            loading.replaceChildren(spinner, document.createTextNode(' Loading credentials...'));
             content.style.display = 'none';
             try {
                 const resp = await fetchApi('/credentials');

--- a/src/luthien_proxy/static/credentials.html
+++ b/src/luthien_proxy/static/credentials.html
@@ -552,8 +552,10 @@
                 document.getElementById('config-loading').style.display = 'none';
                 document.getElementById('config-form').style.display = 'block';
             } catch (e) {
-                document.getElementById('config-loading').innerHTML =
-                    '<span style="color: #fca5a5;">Failed to load config: ' + e.message + '</span>';
+                const errSpan = document.createElement('span');
+                errSpan.style.color = '#fca5a5';
+                errSpan.textContent = 'Failed to load config: ' + e.message;
+                document.getElementById('config-loading').replaceChildren(errSpan);
             }
         }
 
@@ -615,32 +617,76 @@
 
                 const content = document.getElementById('credentials-content');
                 if (data.count === 0) {
-                    content.innerHTML = '<div class="empty-state">No cached credentials</div>';
+                    const empty = document.createElement('div');
+                    empty.className = 'empty-state';
+                    empty.textContent = 'No cached credentials';
+                    content.replaceChildren(empty);
                 } else {
-                    let html = '<table class="credentials-table"><thead><tr>';
-                    html += '<th>Hash</th><th>Status</th><th>Validated At</th><th>Last Used</th><th></th>';
-                    html += '</tr></thead><tbody>';
+                    // DOM construction: key_hash flowed into an inline onclick JS
+                    // string, a title="" attribute, and cell text via raw string
+                    // concatenation with no escaping at all. It is SHA-256 hex
+                    // today (safe by character set), but that "internally derived
+                    // so it's fine" assumption is exactly what rotted elsewhere —
+                    // build nodes and wire the button via addEventListener +
+                    // dataset so it is inert regardless of value.
+                    const table = document.createElement('table');
+                    table.className = 'credentials-table';
+                    const thead = document.createElement('thead');
+                    const headRow = document.createElement('tr');
+                    for (const h of ['Hash', 'Status', 'Validated At', 'Last Used', '']) {
+                        const th = document.createElement('th');
+                        th.textContent = h;
+                        headRow.appendChild(th);
+                    }
+                    thead.appendChild(headRow);
+                    table.appendChild(thead);
+
+                    const tbody = document.createElement('tbody');
                     for (const cred of data.credentials) {
                         const shortHash = cred.key_hash.length > 16 ? cred.key_hash.substring(0, 16) + '...' : cred.key_hash;
-                        const badgeClass = cred.valid ? 'badge-valid' : 'badge-invalid';
-                        const badgeText = cred.valid ? 'Valid' : 'Invalid';
-                        html += '<tr>';
-                        html += '<td class="mono" title="' + cred.key_hash + '">' + shortHash + '</td>';
-                        html += '<td><span class="' + badgeClass + '">' + badgeText + '</span></td>';
-                        html += '<td>' + formatTimestamp(cred.validated_at) + '</td>';
-                        html += '<td>' + formatTimestamp(cred.last_used_at) + '</td>';
-                        html += '<td><button class="danger" onclick="invalidateOne(\'' + cred.key_hash + '\')">Invalidate</button></td>';
-                        html += '</tr>';
+                        const row = document.createElement('tr');
+
+                        const hashTd = document.createElement('td');
+                        hashTd.className = 'mono';
+                        hashTd.title = cred.key_hash;
+                        hashTd.textContent = shortHash;
+
+                        const statusTd = document.createElement('td');
+                        const badge = document.createElement('span');
+                        badge.className = cred.valid ? 'badge-valid' : 'badge-invalid';
+                        badge.textContent = cred.valid ? 'Valid' : 'Invalid';
+                        statusTd.appendChild(badge);
+
+                        const validatedTd = document.createElement('td');
+                        validatedTd.textContent = formatTimestamp(cred.validated_at);
+
+                        const lastUsedTd = document.createElement('td');
+                        lastUsedTd.textContent = formatTimestamp(cred.last_used_at);
+
+                        const actionTd = document.createElement('td');
+                        const btn = document.createElement('button');
+                        btn.className = 'danger';
+                        btn.textContent = 'Invalidate';
+                        btn.dataset.keyHash = cred.key_hash;
+                        btn.addEventListener('click', () => invalidateOne(cred.key_hash));
+                        actionTd.appendChild(btn);
+
+                        row.append(hashTd, statusTd, validatedTd, lastUsedTd, actionTd);
+                        tbody.appendChild(row);
                     }
-                    html += '</tbody></table>';
-                    content.innerHTML = html;
+                    table.appendChild(tbody);
+                    content.replaceChildren(table);
                 }
 
                 document.getElementById('credentials-loading').style.display = 'none';
                 content.style.display = 'block';
             } catch (e) {
-                document.getElementById('credentials-loading').innerHTML =
-                    '<span style="color: #fca5a5;">Failed to load credentials: ' + e.message + '</span>';
+                // e.message is unconstrained (server-returned text), so this is a
+                // genuine sink — build the node and use textContent.
+                const errSpan = document.createElement('span');
+                errSpan.style.color = '#fca5a5';
+                errSpan.textContent = 'Failed to load credentials: ' + e.message;
+                document.getElementById('credentials-loading').replaceChildren(errSpan);
             }
         }
 
@@ -680,15 +726,6 @@
 
         // === Server Credentials ===
 
-        // HTML-escape user-controlled strings before injecting into innerHTML.
-        // Credential names are admin-provisioned and validated against a strict
-        // regex on the server, but we still escape defensively.
-        function escHtml(s) {
-            const d = document.createElement('div');
-            d.textContent = s === null || s === undefined ? '' : String(s);
-            return d.innerHTML;
-        }
-
         async function loadServerCredentials() {
             const loading = document.getElementById('srv-loading');
             const content = document.getElementById('srv-content');
@@ -704,28 +741,60 @@
                     data.count + ' server credential' + (data.count !== 1 ? 's' : '');
 
                 if (data.count === 0) {
-                    content.innerHTML = '<div class="empty-state">No server credentials stored</div>';
+                    const empty = document.createElement('div');
+                    empty.className = 'empty-state';
+                    empty.textContent = 'No server credentials stored';
+                    content.replaceChildren(empty);
                 } else {
-                    let html = '<table class="credentials-table"><thead><tr>';
-                    html += '<th>Name</th><th></th>';
-                    html += '</tr></thead><tbody>';
-                    for (const name of data.credentials) {
-                        html += '<tr>';
-                        html += '<td class="mono">' + escHtml(name) + '</td>';
-                        html += '<td style="text-align:right;">'
-                            + '<button class="danger" data-action="srv-delete" data-name="'
-                            + escHtml(name) + '">Delete</button></td>';
-                        html += '</tr>';
+                    // DOM construction: credential names are server-validated
+                    // against a strict regex, but were interpolated into a
+                    // data-name="" attribute via a quote-unsafe escaper. Build
+                    // nodes and set the name via dataset/textContent so it is
+                    // inert. The existing delegated click listener reads
+                    // data-name unchanged.
+                    const table = document.createElement('table');
+                    table.className = 'credentials-table';
+                    const thead = document.createElement('thead');
+                    const headRow = document.createElement('tr');
+                    for (const h of ['Name', '']) {
+                        const th = document.createElement('th');
+                        th.textContent = h;
+                        headRow.appendChild(th);
                     }
-                    html += '</tbody></table>';
-                    content.innerHTML = html;
+                    thead.appendChild(headRow);
+                    table.appendChild(thead);
+
+                    const tbody = document.createElement('tbody');
+                    for (const name of data.credentials) {
+                        const row = document.createElement('tr');
+
+                        const nameTd = document.createElement('td');
+                        nameTd.className = 'mono';
+                        nameTd.textContent = name;
+
+                        const actionTd = document.createElement('td');
+                        actionTd.style.textAlign = 'right';
+                        const btn = document.createElement('button');
+                        btn.className = 'danger';
+                        btn.dataset.action = 'srv-delete';
+                        btn.dataset.name = name;
+                        btn.textContent = 'Delete';
+                        actionTd.appendChild(btn);
+
+                        row.append(nameTd, actionTd);
+                        tbody.appendChild(row);
+                    }
+                    table.appendChild(tbody);
+                    content.replaceChildren(table);
                 }
 
                 loading.style.display = 'none';
                 content.style.display = 'block';
             } catch (e) {
-                loading.innerHTML = '<span style="color: #fca5a5;">Failed to load server credentials: '
-                    + escHtml(e.message) + '</span>';
+                const errSpan = document.createElement('span');
+                errSpan.style.color = '#fca5a5';
+                errSpan.textContent = 'Failed to load server credentials: ' + e.message;
+                loading.replaceChildren(errSpan);
             }
         }
 

--- a/src/luthien_proxy/static/diff_viewer.html
+++ b/src/luthien_proxy/static/diff_viewer.html
@@ -672,10 +672,13 @@
             loadDiff();
         }
 
-        // Escapes <, >, &, " and ' so the result is safe in both HTML text and
-        // quoted-attribute contexts. (The old textContent/innerHTML form left
-        // quotes unescaped, which is unsafe the moment a value lands in an
-        // attribute.)
+        // Escapes <, >, &, " and ' so the result is safe in HTML text and
+        // *quoted* HTML attribute contexts ONLY. NOT safe for: JS-string
+        // contexts (a value placed inside an inline event-handler's quoted
+        // argument), URL / javascript: contexts, or *unquoted* attributes — for
+        // those use DOM construction (createElement + textContent/dataset +
+        // addEventListener). (The old textContent/innerHTML form left quotes
+        // unescaped, unsafe the moment a value lands in an attribute.)
         function escapeHtml(text) {
             if (text === null || text === undefined) {
                 return '';

--- a/src/luthien_proxy/static/diff_viewer.html
+++ b/src/luthien_proxy/static/diff_viewer.html
@@ -407,7 +407,11 @@
                 renderDiff(data);
             } catch (error) {
                 diffContainer.innerHTML = '';
-                errorContainer.innerHTML = `<div class="error">Failed to load diff: ${error.message}</div>`;
+                // error.message is unconstrained server/network text — textContent.
+                const errDiv = document.createElement('div');
+                errDiv.className = 'error';
+                errDiv.textContent = 'Failed to load diff: ' + error.message;
+                errorContainer.replaceChildren(errDiv);
             }
         }
 
@@ -614,7 +618,10 @@
                 renderRecentCalls(data.calls);
             } catch (error) {
                 diffContainer.innerHTML = '';
-                errorContainer.innerHTML = `<div class="error">Failed to load recent calls: ${error.message}</div>`;
+                const errDiv = document.createElement('div');
+                errDiv.className = 'error';
+                errDiv.textContent = 'Failed to load recent calls: ' + error.message;
+                errorContainer.replaceChildren(errDiv);
             }
         }
 

--- a/src/luthien_proxy/static/history_list.html
+++ b/src/luthien_proxy/static/history_list.html
@@ -539,7 +539,10 @@
             const container = document.getElementById('sessions-container');
 
             if (sessions.length === 0) {
-                container.innerHTML = '<div class="empty-state">No sessions found</div>';
+                const empty = document.createElement('div');
+                empty.className = 'empty-state';
+                empty.textContent = 'No sessions found';
+                container.replaceChildren(empty);
                 return;
             }
 

--- a/tests/luthien_proxy/unit_tests/ui/test_static_xss_guards.py
+++ b/tests/luthien_proxy/unit_tests/ui/test_static_xss_guards.py
@@ -1,12 +1,13 @@
 """Regression guards against the stored-XSS class in admin UI static assets.
 
 Background: the admin UI is vanilla JS served as static HTML. Several render
-paths used to build HTML by string interpolation and rely on a hand-rolled
-`escapeHtml` that escaped ``<``, ``>``, ``&`` but NOT ``'`` or ``"``. Any
-attacker-influenced value (session_id, call_id, transaction_id, tool_call_id,
-model/endpoint names — all request- or model-derived) interpolated into an
-inline ``onclick="...('${x}')"`` JS string or a quoted HTML attribute could
-break out and execute. See PR addressing this class.
+paths built HTML by string interpolation — some via a hand-rolled `escapeHtml`
+that escaped ``<``, ``>``, ``&`` but NOT ``'`` or ``"``, some (credentials.html)
+via raw concatenation with no escaper at all. Any attacker-influenced value
+(session_id, call_id, transaction_id, tool_call_id, key_hash, credential/model/
+endpoint/provider names, server error messages — all request-, model-, or
+server-derived) interpolated into an inline ``onclick`` JS string or a quoted
+HTML attribute could break out and execute.
 
 The fix:
   * Genuinely attacker-controlled JS-string / event-handler sinks were rewritten
@@ -17,8 +18,8 @@ The fix:
     escape quotes so attribute interpolation cannot break out.
 
 These tests are deliberately source-text assertions (the repo has no JS test
-runtime). They are not a substitute for a real DOM test, but they pin the two
-concrete regressions that already bit this codebase twice.
+runtime). They are not a substitute for a real DOM test, but they pin the
+concrete regressions that already bit this codebase repeatedly.
 """
 
 from __future__ import annotations
@@ -36,6 +37,7 @@ DOM_MIGRATED_FILES = [
     "diff_viewer.html",
     "request_logs.html",
     "inference_providers.html",
+    "credentials.html",
 ]
 
 # Files that retain a hand-rolled escapeHtml used in attribute contexts; those
@@ -46,13 +48,33 @@ QUOTE_SAFE_ESCAPER_FILES = [
 ]
 
 # Matches an inline event-handler attribute (onclick=, onchange=, ...) whose
-# value contains a JS string literal built from a template-literal placeholder,
-# e.g.  onclick="viewSession('${escapeHtml(session.session_id)}')"
-# This is the exact stored-XSS pattern we removed; escapeHtml does not escape
-# the surrounding single quotes, so the placeholder can break out of the JS
-# string. New occurrences should use addEventListener instead.
+# value opens a JS string literal that is then filled with a dynamic value —
+# the exact stored-XSS class we removed, because the surrounding JS quotes are
+# not escaped by any HTML escaper, so the value can break out of the string.
+#
+# Two concrete dynamic shapes are caught after the opening JS quote (' or "):
+#   * template-literal interpolation:  onclick="f('${x}')"
+#   * string concatenation:            onclick="f('" + x + "')"
+#                                      onclick='f(\'' + x + '\')'
+# Both forms appeared in this codebase (the latter in credentials.html, which
+# had no escapeHtml at all, so an escapeHtml-name grep would not surface it).
+#
+# Coverage caveats (deliberately documented rather than over-claimed):
+#   * `[^)]*?` skips any *preceding* literal args up to the first dynamic JS
+#     quote, so multi-arg shapes like onclick="f(1, '${x}')" are caught — but
+#     only the FIRST dynamic string in the handler. A handler whose first arg is
+#     a safe constant string and whose SECOND arg is dynamic via a different
+#     delimiter could slip past; in practice handlers in this repo take the
+#     dynamic id first, so this is an accepted gap, not full coverage.
+#   * It detects the *opening* unsafe construction; it does not parse JS, so it
+#     cannot prove the value is attacker-influenced — it flags the dangerous
+#     idiom regardless and expects addEventListener instead.
 _INLINE_HANDLER_JS_STRING = re.compile(
-    r"""on\w+\s*=\s*["'][^"']*\(\s*\\?['"]\$\{""",
+    r"""on\w+\s*=\s*["']"""  # event-handler attribute opens (HTML quote)
+    r"""[^)]*?\("""  # up to and including the call's opening paren
+    r"""[^)]*?"""  # any preceding literal args
+    r"""(?:\\?['"])"""  # the opening quote of a JS string arg (maybe \-escaped)
+    r"""(?:\$\{|"\s*\+|'\s*\+|\\?['"]\s*\+)""",  # ${...} OR a concat seam ("+ / '+)
     re.IGNORECASE,
 )
 
@@ -121,3 +143,28 @@ def test_inference_providers_uses_dom_construction_for_provider_name() -> None:
     assert "deleteProvider(\\'" not in source
     assert "addEventListener('click', () => editProvider(" in source
     assert "addEventListener('click', () => deleteProvider(" in source
+
+
+def test_credentials_uses_dom_construction_for_key_hash() -> None:
+    """key_hash must be wired via addEventListener + dataset, not concat onclick.
+
+    credentials.html built HTML by raw string concatenation with no escaper at
+    all — onclick="invalidateOne('" + cred.key_hash + "')" plus key_hash in a
+    title="" attribute. Both must be gone.
+    """
+    source = _read("credentials.html")
+    assert "invalidateOne(\\'" not in source
+    assert "onclick=" not in source, "credentials.html must not use inline onclick handlers."
+    assert "addEventListener('click', () => invalidateOne(" in source
+
+
+def test_inline_handler_guard_catches_concat_shape() -> None:
+    """The widened guard must catch the string-concat onclick shape, not just ${...}.
+
+    Self-test: the credentials.html-style concat sink and the multi-arg
+    template-literal shape must both match; a delegated/static handler must not.
+    """
+    assert _INLINE_HANDLER_JS_STRING.search('onclick="invalidateOne(\'" + cred.key_hash + "\')"')
+    assert _INLINE_HANDLER_JS_STRING.search("onclick=\"foo(1, '${x}')\"")
+    assert not _INLINE_HANDLER_JS_STRING.search('onclick="closeDetail()"')
+    assert not _INLINE_HANDLER_JS_STRING.search('data-action="srv-delete" data-name="x"')

--- a/tests/luthien_proxy/unit_tests/ui/test_static_xss_guards.py
+++ b/tests/luthien_proxy/unit_tests/ui/test_static_xss_guards.py
@@ -1,21 +1,33 @@
 """Regression guards against the stored-XSS class in admin UI static assets.
 
 Background: the admin UI is vanilla JS served as static HTML. Several render
-paths built HTML by string interpolation — some via a hand-rolled `escapeHtml`
-that escaped ``<``, ``>``, ``&`` but NOT ``'`` or ``"``, some (credentials.html)
-via raw concatenation with no escaper at all. Any attacker-influenced value
-(session_id, call_id, transaction_id, tool_call_id, key_hash, credential/model/
-endpoint/provider names, server error messages — all request-, model-, or
-server-derived) interpolated into an inline ``onclick`` JS string or a quoted
-HTML attribute could break out and execute.
+paths built HTML by string interpolation — some via a hand-rolled escaper
+(``escapeHtml`` / ``esc``) that escaped ``<``, ``>``, ``&`` but NOT ``'`` or
+``"``, some (credentials.html) via raw concatenation with no escaper at all,
+some (activity_monitor.js) via ``JSON.stringify(event)`` straight into a
+``<pre>`` with no escaping. Any attacker-influenced value (session_id, call_id,
+transaction_id, tool_call_id, key_hash, credential/model/endpoint/provider
+names, full activity-stream event payloads, server error messages — all
+request-, model-, or server-derived) interpolated into an inline ``onclick`` JS
+string, a quoted HTML attribute, or HTML text could break out and execute.
 
-The fix:
-  * Genuinely attacker-controlled JS-string / event-handler sinks were rewritten
-    using DOM construction (``createElement`` / ``textContent`` /
+The fix (a comprehensive sweep of ``src/luthien_proxy/static/**``):
+  * Genuinely attacker-controlled JS-string / event-handler / HTML-text sinks
+    were rewritten using DOM construction (``createElement`` / ``textContent`` /
     ``addEventListener`` / ``dataset``) so quotes and markup are inert by
     construction — the browser-native, zero-dependency safe answer.
-  * The remaining hand-rolled ``escapeHtml`` helpers were hardened to also
+  * The remaining hand-rolled escapers (``escapeHtml`` in conversation_live.js /
+    diff_viewer.html, ``esc`` in config_dashboard.html) were hardened to also
     escape quotes so attribute interpolation cannot break out.
+  * Error-message ``catch`` blocks that injected ``e.message`` into innerHTML
+    were converted to textContent (server-returned text is unconstrained).
+
+Files reviewed and found already-safe (NOT in the guard list): policy_config.js
+and form_renderer.js use a quote-correct ``esc()`` and only interpolate
+internally-computed schema paths into inline handlers (deferred, like the CSP
+backstop); nav.js is full DOM construction; client_setup.html escapes its one
+server-injected value server-side; index.html / *.html shells carry no dynamic
+JS.
 
 These tests are deliberately source-text assertions (the repo has no JS test
 runtime). They are not a substitute for a real DOM test, but they pin the
@@ -38,13 +50,17 @@ DOM_MIGRATED_FILES = [
     "request_logs.html",
     "inference_providers.html",
     "credentials.html",
+    "config_dashboard.html",
+    "activity_monitor.js",
 ]
 
-# Files that retain a hand-rolled escapeHtml used in attribute contexts; those
-# escapers must cover quotes.
+# Files that retain a hand-rolled HTML escaper (escapeHtml / esc) used in
+# attribute contexts; those escapers must cover quotes. Each entry is
+# (filename, helper_name).
 QUOTE_SAFE_ESCAPER_FILES = [
-    "conversation_live.js",
-    "diff_viewer.html",
+    ("conversation_live.js", "escapeHtml"),
+    ("diff_viewer.html", "escapeHtml"),
+    ("config_dashboard.html", "esc"),
 ]
 
 # Matches an inline event-handler attribute (onclick=, onchange=, ...) whose
@@ -66,6 +82,13 @@ QUOTE_SAFE_ESCAPER_FILES = [
 #     a safe constant string and whose SECOND arg is dynamic via a different
 #     delimiter could slip past; in practice handlers in this repo take the
 #     dynamic id first, so this is an accepted gap, not full coverage.
+#     TODO: the regex matches the first JS-quoted token after `(`. It does NOT
+#     catch a *constant* first quoted arg followed by a *dynamic* second arg,
+#     e.g. onclick="f('static', '${x}')" — the `[^)]*?` would consume the static
+#     arg but the engine anchors on the first quote it finds, so the second
+#     dynamic quote is not re-examined. If a handler of that shape is ever added,
+#     widen this to scan every JS-string arg, or (better) ban inline handlers
+#     outright once a CSP forbids them (see the CSP Trello card).
 #   * It detects the *opening* unsafe construction; it does not parse JS, so it
 #     cannot prove the value is attacker-influenced — it flags the dangerous
 #     idiom regardless and expects addEventListener instead.
@@ -77,6 +100,13 @@ _INLINE_HANDLER_JS_STRING = re.compile(
     r"""(?:\$\{|"\s*\+|'\s*\+|\\?['"]\s*\+)""",  # ${...} OR a concat seam ("+ / '+)
     re.IGNORECASE,
 )
+
+
+# Matches an actual inline event-handler *attribute* (onclick=, onchange=, ...
+# followed by a quote opening the attribute value). Scoped deliberately so it
+# does not fire on the substring "onclick" appearing in a comment, a CSS class,
+# or prose — only on real attribute usage.
+_INLINE_HANDLER_ATTR = re.compile(r"""\bon\w+\s*=\s*["']""", re.IGNORECASE)
 
 
 def _read(name: str) -> str:
@@ -98,17 +128,17 @@ def test_no_inline_handler_js_string_interpolation(filename: str) -> None:
     )
 
 
-@pytest.mark.parametrize("filename", QUOTE_SAFE_ESCAPER_FILES)
-def test_escapehtml_escapes_quotes(filename: str) -> None:
-    """Any retained hand-rolled escapeHtml must escape both single and double quotes.
+@pytest.mark.parametrize(("filename", "helper"), QUOTE_SAFE_ESCAPER_FILES)
+def test_escaper_escapes_quotes(filename: str, helper: str) -> None:
+    """Any retained hand-rolled HTML escaper must escape both single and double quotes.
 
     The old textContent/innerHTML trick left quotes unescaped, so a value placed
     in a quoted attribute could break out. Assert the source escapes them.
     """
     source = _read(filename)
-    assert "escapeHtml" in source, f"{filename} no longer defines escapeHtml; update this guard."
-    assert "&quot;" in source, f"{filename}'s escapeHtml must escape double quotes (&quot;)."
-    assert "&#39;" in source or "&apos;" in source, f"{filename}'s escapeHtml must escape single quotes (&#39;)."
+    assert helper in source, f"{filename} no longer defines {helper}; update this guard."
+    assert "&quot;" in source, f"{filename}'s {helper} must escape double quotes (&quot;)."
+    assert "&#39;" in source or "&apos;" in source, f"{filename}'s {helper} must escape single quotes (&#39;)."
 
 
 def test_history_list_uses_dom_construction_for_session_id() -> None:
@@ -154,8 +184,32 @@ def test_credentials_uses_dom_construction_for_key_hash() -> None:
     """
     source = _read("credentials.html")
     assert "invalidateOne(\\'" not in source
-    assert "onclick=" not in source, "credentials.html must not use inline onclick handlers."
+    # Scoped to real attribute usage (not a whole-file "onclick=" substring,
+    # which would also match comments/CSS/prose).
+    assert not _INLINE_HANDLER_ATTR.search(source), (
+        "credentials.html must not use inline on*= handlers; wire via addEventListener."
+    )
     assert "addEventListener('click', () => invalidateOne(" in source
+
+
+def test_activity_monitor_uses_dom_construction_for_event_payload() -> None:
+    """The activity stream is request-derived; event_type and the full event
+    payload must be rendered via DOM construction (textContent), not innerHTML.
+
+    The prior code did `JSON.stringify(event)` into a <pre> via innerHTML with no
+    escaping — a quote/markup-bearing payload field could break out.
+    """
+    source = _read("activity_monitor.js")
+    assert "pre.textContent = JSON.stringify(event" in source
+    assert "<pre>${JSON.stringify(event" not in source
+    assert not _INLINE_HANDLER_ATTR.search(source)
+
+
+def test_config_dashboard_error_uses_textcontent() -> None:
+    """The e.message catch sink in config_dashboard.html must use textContent."""
+    source = _read("config_dashboard.html")
+    assert "Error: ${e.message}" not in source
+    assert "errDiv.textContent = 'Error: ' + e.message" in source
 
 
 def test_inline_handler_guard_catches_concat_shape() -> None:
@@ -168,3 +222,12 @@ def test_inline_handler_guard_catches_concat_shape() -> None:
     assert _INLINE_HANDLER_JS_STRING.search("onclick=\"foo(1, '${x}')\"")
     assert not _INLINE_HANDLER_JS_STRING.search('onclick="closeDetail()"')
     assert not _INLINE_HANDLER_JS_STRING.search('data-action="srv-delete" data-name="x"')
+
+
+def test_inline_handler_attr_regex_is_scoped() -> None:
+    """The attribute-usage regex must match real handlers, not incidental substrings."""
+    assert _INLINE_HANDLER_ATTR.search('<button onclick="f()">')
+    assert _INLINE_HANDLER_ATTR.search("<input oninput='g()'>")
+    # Should NOT match the bare word in a comment / class name / prose.
+    assert not _INLINE_HANDLER_ATTR.search("// no inline onclick here")
+    assert not _INLINE_HANDLER_ATTR.search('class="onclick-styled"')


### PR DESCRIPTION
Follow-up to **#781** (admin UI stored-XSS class fix), which merged before this bot-review round was addressed. Same concern, same DOM-construction approach; these are the review items that landed after #781 merged.

## What this adds

### `credentials.html` — the real gap #781 missed
The bot correctly flagged that `credentials.html` had the exact stored-XSS class #781 eliminates, but #781's sweep missed it because the file built HTML by **raw string concatenation with no `escapeHtml` at all** — so a grep for `escapeHtml(` never surfaced it. Migrated both credential tables to DOM construction:

- **Cached credentials:** `onclick="invalidateOne('" + cred.key_hash + "')"` (inline-onclick concat) → `addEventListener` + `dataset.keyHash`; `key_hash` also flowed into a `title="..."` attribute and cell text unescaped → `textContent`. `key_hash` is SHA-256 hex (safe by character set *today*), but that's exactly the "internally derived so it's fine" assumption that rotted in #780/#752 — migrated for real rather than carved out.
- **Server credentials:** credential `name` flowed into a `data-name="..."` attribute via a quote-unsafe escaper (`escHtml`), gated only by a server-side regex → DOM construction with `dataset.name`; the existing delegated click listener reads `data-name` unchanged. Removed the now-unused `escHtml`.
- **Error sinks:** the config / cached-credentials / server-credentials `catch` blocks injected `e.message` into `innerHTML`. `e.message` is unconstrained server-returned text (not character-set-limited like `key_hash`), so these are genuine sinks → `textContent`.

### Regression-guard hardening
- Widened `_INLINE_HANDLER_JS_STRING`: it previously used `[^"']*`, which stopped at the first quote — so it only caught `${...}` template-literal shapes and missed the string-concat form (`onclick="f('" + x + "')"`) that `credentials.html` actually used, plus multi-arg shapes. Now catches both, with its exact coverage **and accepted gaps documented in the comment** rather than over-claimed (it flags the dangerous *opening idiom*; it does not parse JS or prove attacker-influence). Added a self-test for the concat shape and a `credentials.html`-specific guard.
- Added context-limit header comments to the hardened `escapeHtml` helpers (`conversation_live.js`, `diff_viewer.html`): safe for HTML text and *quoted* attributes **only** — NOT JS-string, URL/`javascript:`, or unquoted-attribute contexts (use DOM construction there). Prevents the next maintainer from reaching for it in an `onclick`/`href` sink.
- `history_list.html` empty-state: `innerHTML='<div...>'` string literal → `replaceChildren` (consistency nit; trivial).

## Deferred (tracked, not in this PR)
- **CSP backstop** on the admin UI routes → Trello card created (https://trello.com/c/B8wobuI2). It's a separate refactor: every admin page uses inline `<script>` blocks and inline Alpine handlers, so a meaningful `script-src 'self'` CSP needs per-page nonces or extracting all inline JS to files.

## Out of scope (unchanged from #781's reasoning)
`policy_config.js` / `form_renderer.js` inline `onclick` handlers interpolate `safePath` (via a quote-escaping `esc()`) and `path` — an internally-computed JSON-schema field path, not request/attacker data. Left as-is, consistent with #781.

`./scripts/dev_checks.sh` green (ruff, pyright 0 errors, full unit suite incl. the 13 XSS guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
