### PR TITLE
fix(automated_maintenance): stray-brace default dropped every check result

### DIFF
--- a/changelog.d/fix-maint-record-brace.md
+++ b/changelog.d/fix-maint-record-brace.md
@@ -1,0 +1,7 @@
+---
+category: Fixes
+---
+
+**Automated maintenance: fix stray-brace bug that silently dropped every check result** (`scripts/automated_maintenance/lib/config.sh`)
+  - `maint_record_check`'s `extra="${4:-{}}"` default parsed as `${4:-{}` plus a literal `}`, appending a stray brace to every payload. `json.loads(extra)` then failed with "Extra data", so no check was ever recorded — every run produced `checks: {}` and `overall: unknown`, leaving the dashboard blank.
+  - Added a subprocess-driven regression test (`test_record_check.py`) that exercises the real bash function.

--- a/scripts/automated_maintenance/lib/config.sh
+++ b/scripts/automated_maintenance/lib/config.sh
@@ -101,7 +101,14 @@ maint_timeout() {
 # Usage: maint_record_check <name> <status> <log_relpath> [extra_json]
 # status: pass|fail|skip|error
 maint_record_check() {
-    local name="$1" status="$2" log="$3" extra="${4:-{}}"
+    # NOTE: do not collapse the `extra` default into `${4:-{}}` — bash parses
+    # that as `${4:-{}` plus a literal `}`, appending a stray brace to any
+    # value (every value passed here ends in `}`). That made `json.loads(extra)`
+    # below fail with "Extra data" and silently dropped every check from
+    # results.json (checks: {}, overall: unknown).
+    local name="$1" status="$2" log="$3"
+    local extra="${4:-}"
+    [[ -n "${extra}" ]] || extra='{}'
     local results="${MAINT_RUN_DIR}/results.json"
     python3 - "$results" "$name" "$status" "$log" "$extra" <<'PY'
 import json, sys, pathlib

--- a/tests/luthien_proxy/unit_tests/automated_maintenance/test_record_check.py
+++ b/tests/luthien_proxy/unit_tests/automated_maintenance/test_record_check.py
@@ -1,0 +1,95 @@
+"""Unit tests for the `maint_record_check` bash helper (`lib/config.sh`).
+
+`maint_record_check` is bash, and the bug it regression-guards is a
+bash-parsing bug (`${4:-{}}` appends a stray `}`), so these tests must
+exercise the real shell function via subprocess — a pure-Python test of
+the embedded snippet would not reproduce it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from tests.luthien_proxy.unit_tests.automated_maintenance.conftest import (
+    AUTOMATED_MAINTENANCE_LIB,
+)
+
+_CONFIG_SH = AUTOMATED_MAINTENANCE_LIB / "config.sh"
+
+
+def _run_record_check(run_dir: Path, *args: str) -> subprocess.CompletedProcess:
+    """Source config.sh and invoke maint_record_check with the given args.
+
+    Seeds a valid results.json first, the way maint_start_run would.
+    """
+    (run_dir / "results.json").write_text('{"run_id":"t","checks":{},"autofix":null}\n')
+    quoted = " ".join(f"'{a}'" for a in args)
+    script = f'set -euo pipefail; source "{_CONFIG_SH}"; maint_record_check {quoted}'
+    return subprocess.run(
+        ["bash", "-c", script],
+        env={"MAINT_RUN_DIR": str(run_dir), "HOME": str(run_dir), "PATH": _path()},
+        capture_output=True,
+        text=True,
+    )
+
+
+def _path() -> str:
+    import os
+
+    return os.environ.get("PATH", "/usr/bin:/bin")
+
+
+def _checks(run_dir: Path) -> dict:
+    return json.loads((run_dir / "results.json").read_text())["checks"]
+
+
+def test_records_check_with_extra_json(tmp_path):
+    """A check with an extra payload lands in results.json with parsed fields.
+
+    Regression: `${4:-{}}` appended a stray `}` to the extra arg, so
+    `json.loads(extra)` raised and the check was silently dropped, leaving
+    `checks: {}`.
+    """
+    proc = _run_record_check(
+        tmp_path, "dev_checks", "pass", "dev_checks.log", '{"duration_s":24,"exit_code":0}'
+    )
+    assert proc.returncode == 0, proc.stderr
+    checks = _checks(tmp_path)
+    assert "dev_checks" in checks
+    assert checks["dev_checks"]["status"] == "pass"
+    assert checks["dev_checks"]["log"] == "dev_checks.log"
+    assert checks["dev_checks"]["duration_s"] == 24
+    assert checks["dev_checks"]["exit_code"] == 0
+
+
+def test_records_check_with_nested_brace_payload(tmp_path):
+    """A richer extra payload (doc_drift-style, more braces) is parsed intact."""
+    proc = _run_record_check(
+        tmp_path,
+        "doc_drift",
+        "fail",
+        "doc_drift.log",
+        '{"duration_s":96,"exit_code":1,"report":"doc_drift.md"}',
+    )
+    assert proc.returncode == 0, proc.stderr
+    checks = _checks(tmp_path)
+    assert checks["doc_drift"]["report"] == "doc_drift.md"
+    assert checks["doc_drift"]["exit_code"] == 1
+
+
+def test_records_check_without_extra_defaults_to_empty_object(tmp_path):
+    """Omitting the extra arg records the check with no extra fields (no crash)."""
+    proc = _run_record_check(tmp_path, "e2e_sqlite", "pass", "e2e_sqlite.log")
+    assert proc.returncode == 0, proc.stderr
+    checks = _checks(tmp_path)
+    assert checks["e2e_sqlite"]["status"] == "pass"
+    # Only the two baseline keys; the default extra is an empty object.
+    assert set(checks["e2e_sqlite"]) == {"status", "log"}
+
+
+@pytest.mark.skipif(not _CONFIG_SH.exists(), reason="config.sh not present")
+def test_config_sh_exists():
+    assert _CONFIG_SH.is_file()

--- a/tests/luthien_proxy/unit_tests/automated_maintenance/test_record_check.py
+++ b/tests/luthien_proxy/unit_tests/automated_maintenance/test_record_check.py
@@ -53,9 +53,7 @@ def test_records_check_with_extra_json(tmp_path):
     `json.loads(extra)` raised and the check was silently dropped, leaving
     `checks: {}`.
     """
-    proc = _run_record_check(
-        tmp_path, "dev_checks", "pass", "dev_checks.log", '{"duration_s":24,"exit_code":0}'
-    )
+    proc = _run_record_check(tmp_path, "dev_checks", "pass", "dev_checks.log", '{"duration_s":24,"exit_code":0}')
     assert proc.returncode == 0, proc.stderr
     checks = _checks(tmp_path)
     assert "dev_checks" in checks


### PR DESCRIPTION
## Summary

The `automated_maintenance` nightly harness (merged in #745) recorded **none** of its check results. Every run produced `checks: {}` / `overall: unknown` and a blank dashboard, even though the checks themselves ran. Found while doing the first real deploy + smoke test.

## Root cause

`maint_record_check` (lib/config.sh) used:

```bash
local name="$1" status="$2" log="$3" extra="${4:-{}}"
```

Bash parses `${4:-{}}` as `${4:-{}` (parameter expansion with default value `{`) **followed by a literal `}`**. So the trailing `}` is appended to whatever `$4` expands to. Every caller passes a JSON object that ends in `}` (e.g. `{"duration_s":24,"exit_code":0}`), so `extra` became `{...}}` — and the embedded `json.loads(extra)` raised:

```
json.decoder.JSONDecodeError: Extra data: line 1 column 32 (char 31)
```

The `maint_record_check` call runs inside the check loop under `|| true` (so one bad check never aborts the run), which swallowed the failure. Result: checks executed, statuses never persisted.

```
$ x='{"a":1}'; set -- 1 2 3 "$x"; v="${4:-{}}"; echo "$v"
{"a":1}}        # <-- stray trailing brace
```

## Fix

Split the default off the multi-`local` assignment and use an unambiguous form:

```bash
local name="$1" status="$2" log="$3"
local extra="${4:-}"
[[ -n "${extra}" ]] || extra='{}'
```

## Test

Added `tests/luthien_proxy/unit_tests/automated_maintenance/test_record_check.py`. The bug is bash-parse-specific, so the test drives the **real** shell function via subprocess. Verified it fails against the old `${4:-{}}` form and passes against the fix.

- `uv run pytest tests/luthien_proxy/unit_tests/automated_maintenance/` -> 70 passed
- `shellcheck lib/config.sh` -> clean

---

## COE (Correction of Errors)

**What broke:** All check results silently dropped from `results.json`; dashboard blank since the feature merged (#745, May 11). No crash — the run exited 0.

**Why it wasn't caught earlier:**
1. The feature was merged but **never deployed or run end-to-end** until tonight, so the symptom never appeared.
2. Existing unit tests covered the Python pieces (`dashboard.py`, `path_gate.py`) but **not** the bash result-recording path.
3. The failure mode is silent-by-design: `|| true` in the check loop (correct, so one failing check doesn't abort the run) also swallowed the *recording* failure.

**What else this class of bug could affect:** Any `${var:-{...}}` brace-in-default expansion in shell. Swept the maintenance tree — `maint_record_check` was the only instance.

**Durable fixes:**
- Regression test now exercises the real bash function via subprocess (this PR).
- Follow-up recommendation: have `maint_finish_run` treat `overall: unknown` (no checks recorded) as a notifier-flagged non-success, so a future "records nothing" regression is loud not silent. Separate PR (one concern).

**Separately discovered (not fixed here):** the doc-drift sweep correctly flagged 4 real doc-drift items (dev-README.md references nonexistent `orchestration/` and `streaming/` packages; README.md stale `GATEWAY_HOST`). Doc fixes for their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)