### PR TITLE
Polish: policy_types module nits (acronym name split + migration import comment)

### DIFF
--- a/changelog.d/policy-types-nits.md
+++ b/changelog.d/policy-types-nits.md
@@ -1,0 +1,8 @@
+---
+category: Fixes
+---
+
+**`derive_builtin_name` splits acronym-then-word boundaries**: a policy class
+name like `HTTPSRedirectPolicy` now derives to `https-redirect` instead of
+`httpsredirect`. No-op for current `REGISTERED_BUILTINS`; only affects future
+acronym-prefixed names.

--- a/src/luthien_proxy/policy_types.py
+++ b/src/luthien_proxy/policy_types.py
@@ -51,17 +51,22 @@ def derive_builtin_name(class_name: str) -> str:
 
     Algorithm:
     1. Drop trailing 'Policy' if present
-    2. Insert '-' between any lowercase followed by uppercase
-    3. Lowercase
+    2. Insert '-' between an acronym run and a following word (e.g. HTTPSRedirect -> HTTPS-Redirect)
+    3. Insert '-' between any lowercase followed by uppercase
+    4. Lowercase
 
-    Examples: SimpleLLMPolicy -> simple-llm, NoOpPolicy -> no-op, LLMPolicy -> llm.
+    Examples: SimpleLLMPolicy -> simple-llm, NoOpPolicy -> no-op, LLMPolicy -> llm,
+    HTTPSRedirectPolicy -> https-redirect.
     """
     # Drop 'Policy' suffix if present
     if class_name.endswith("Policy"):
         class_name = class_name[:-6]
 
+    # Split an uppercase acronym run from a following word: HTTPSRedirect -> HTTPS-Redirect
+    kebab = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1-\2", class_name)
+
     # Insert '-' between lowercase and uppercase
-    kebab = re.sub(r"([a-z])([A-Z])", r"\1-\2", class_name)
+    kebab = re.sub(r"([a-z])([A-Z])", r"\1-\2", kebab)
 
     # Lowercase
     return kebab.lower()

--- a/tests/luthien_proxy/integration_tests/test_policy_type_sync.py
+++ b/tests/luthien_proxy/integration_tests/test_policy_type_sync.py
@@ -20,6 +20,10 @@ import pytest
 from luthien_proxy.policy_core.base_policy import BasePolicy
 from luthien_proxy.policy_types import REGISTERED_BUILTINS, sync_policy_types
 from luthien_proxy.utils.db import DatabasePool
+
+# Importing the private _apply_sqlite_migrations is intentional coupling: the fixture
+# applies migrations the same way production does, so the test exercises the real schema
+# setup path rather than a divergent copy.
 from luthien_proxy.utils.migration_check import _apply_sqlite_migrations
 
 

--- a/tests/luthien_proxy/unit_tests/test_policy_types.py
+++ b/tests/luthien_proxy/unit_tests/test_policy_types.py
@@ -33,6 +33,8 @@ class TestDeriveBuiltinName:
             ("TextModifierPolicy", "text-modifier"),
             ("LLMPolicy", "llm"),
             ("HTTPSPolicy", "https"),
+            # Acronym run followed by a word splits at the boundary.
+            ("HTTPSRedirectPolicy", "https-redirect"),
         ],
     )
     def test_converts_pascal_to_kebab(self, class_name: str, expected: str) -> None:


### PR DESCRIPTION
Two tiny follow-ups from PR #606 (Trello card 69eaf5f4).

## Changes

1. **`derive_builtin_name` acronym-then-word splitting.** Added a leading regex pass `r"([A-Z]+)([A-Z][a-z])"` (applied before the existing lowercase/uppercase boundary pass) so an acronym run followed by a word splits at the boundary: `HTTPSRedirectPolicy` -> `https-redirect` instead of `httpsredirect`. Verified this is a no-op for every current `REGISTERED_BUILTINS` name; it only affects future acronym-prefixed names. Unit test added covering `HTTPSRedirectPolicy` -> `https-redirect` (existing CamelCase coverage retained).

2. **Coupling comment** on the private `_apply_sqlite_migrations` import in `tests/luthien_proxy/integration_tests/test_policy_type_sync.py`, noting it is intentional coupling for fixture parity with production migration application.

**Not done:** card item 2 (batch-UPDATE optimization) — the card says skip it unless the allowlist grows.

## Verification

`scripts/dev_checks.sh` passes on the committed tree: shellcheck, ruff format, ruff lint (incl. E/F/I/D gating), pyright (0 errors), full unit test suite, and the post-run clean-tree gate.

---
*Posted by Claude Code (Opus 4.8)*