### PR TITLE
Judge client: cached HTTP client + skip retries on permanent failures

### DIFF
--- a/changelog.d/judge-client-cache-and-fail-fast.md
+++ b/changelog.d/judge-client-cache-and-fail-fast.md
@@ -1,0 +1,7 @@
+---
+category: Fixes
+---
+
+**Judge client: cached HTTP client + skip retries on permanent failures**
+  - `DirectApiProvider` now reuses a cached HTTP client for stable-credential judge calls (via `anthropic_client_cache`) instead of building and closing a fresh client on every call. A judge that fires on every tool call in an agent loop no longer pays connection-pool init/teardown each time. Per-user passthrough (with `credential_override`) still builds and closes a fresh client per call.
+  - `call_simple_llm_judge` no longer retries permanent failures: a rejected credential (`InferenceInvalidCredentialError`, 401/403) fails fast instead of burning `max_retries * retry_delay` seconds and hammering the upstream. Transient errors and parse failures still retry.

--- a/src/luthien_proxy/inference/direct_api.py
+++ b/src/luthien_proxy/inference/direct_api.py
@@ -45,6 +45,7 @@ from luthien_proxy.inference.base import (
     extract_schema,
     validate_schema,
 )
+from luthien_proxy.llm import anthropic_client_cache
 from luthien_proxy.llm.anthropic_client import AnthropicClient
 from luthien_proxy.llm.types.anthropic import AnthropicRequest
 
@@ -133,15 +134,23 @@ class DirectApiProvider(InferenceProvider):
             schema=schema,
         )
 
-        client = _build_client(credential, self._api_base)
+        # Stable-credential calls (no override) reuse a cached client keyed
+        # by credential + base URL, so a judge that fires on every tool call
+        # doesn't pay pool init/teardown each time. Per-user passthrough
+        # (credential_override set) builds a fresh client and closes it,
+        # since those credentials vary per request and shouldn't accumulate
+        # in the shared cache.
+        is_passthrough = credential_override is not None
+        if is_passthrough:
+            client = _build_client(credential, self._api_base)
+        else:
+            client = await _cached_client(credential, self._api_base)
         try:
             try:
                 response = await client.complete(request)
             finally:
-                # The client wraps a fresh AsyncAnthropic built per call
-                # (credential varies by request). Close its pool so we don't
-                # leak file descriptors when many judge calls run in a row.
-                await client.close()
+                if is_passthrough:
+                    await client.close()
         except anthropic.AuthenticationError as exc:
             raise InferenceInvalidCredentialError(
                 f"{self.name}: credential rejected by backend: {exc}",
@@ -184,15 +193,31 @@ class DirectApiProvider(InferenceProvider):
 
 
 def _build_client(credential: Credential, api_base: str | None) -> AnthropicClient:
-    """Build an `AnthropicClient` for a single request.
+    """Build a fresh `AnthropicClient` for a single passthrough request.
 
-    The Anthropic SDK client is keyed by credential, so we can't share one
-    instance across requests with different `credential_override` values.
-    Building per-call is cheap (httpx.AsyncClient pool init only).
+    Used for `credential_override` (per-user passthrough) calls, where the
+    credential varies per request and the client should not be cached. The
+    caller is responsible for closing it. Stable-credential calls go through
+    `_cached_client` instead.
     """
     if credential.credential_type == CredentialType.AUTH_TOKEN:
         return AnthropicClient(auth_token=credential.value, base_url=api_base)
     return AnthropicClient(api_key=credential.value, base_url=api_base)
+
+
+async def _cached_client(credential: Credential, api_base: str | None) -> AnthropicClient:
+    """Return a cached `AnthropicClient` for a stable server credential.
+
+    Delegates to the shared `anthropic_client_cache`, which keys on a hash
+    of the credential value + auth type + base URL. Because the cache owns
+    the client lifecycle (LRU eviction + shutdown close), callers must NOT
+    close the returned client.
+    """
+    return await anthropic_client_cache.get_client(
+        credential.value,
+        auth_type=credential.credential_type.value,
+        base_url=api_base,
+    )
 
 
 def _build_request(

--- a/src/luthien_proxy/policies/simple_llm_utils.py
+++ b/src/luthien_proxy/policies/simple_llm_utils.py
@@ -21,6 +21,8 @@ from pydantic import BaseModel, Field
 
 from luthien_proxy.policies.tool_call_judge_utils import parse_judge_response
 
+from luthien_proxy.inference.base import InferenceInvalidCredentialError
+
 if TYPE_CHECKING:
     from luthien_proxy.credentials.credential import Credential
     from luthien_proxy.inference.base import InferenceProvider
@@ -211,6 +213,13 @@ async def call_simple_llm_judge(
     Retries up to `config.max_retries` times with `config.retry_delay`
     seconds between attempts. The last exception propagates on final
     failure.
+
+    Permanent failures are not retried: a rejected credential
+    (`InferenceInvalidCredentialError`, i.e. 401/403) will never succeed on
+    retry, so it re-raises immediately rather than burning
+    `max_retries * retry_delay` seconds and hammering the upstream.
+    Transient errors (timeouts, connection errors) and parse failures still
+    retry, since a fresh call may produce valid output next time.
     """
     prompt = build_judge_prompt(config.instructions, current_block, previous_blocks)
 
@@ -228,9 +237,14 @@ async def call_simple_llm_judge(
                 credential_override=credential_override,
             )
             return parse_judge_action(result.text)
+        except InferenceInvalidCredentialError:
+            # Permanent: the credential is rejected and won't be accepted on
+            # retry. Fail fast instead of sleeping through every attempt.
+            logger.warning("SimpleLLM judge credential rejected; failing fast (no retry)")
+            raise
         except Exception as exc:  # noqa: BLE001
-            # Retry all errors — parse failures can succeed on retry if the
-            # model produces valid output next time.
+            # Retry transient/parse failures — a fresh call can succeed if
+            # the model produces valid output next time.
             last_exc = exc
             is_last_attempt = attempt == max_attempts - 1
             if is_last_attempt:

--- a/src/luthien_proxy/policies/simple_llm_utils.py
+++ b/src/luthien_proxy/policies/simple_llm_utils.py
@@ -19,9 +19,8 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
-from luthien_proxy.policies.tool_call_judge_utils import parse_judge_response
-
 from luthien_proxy.inference.base import InferenceInvalidCredentialError
+from luthien_proxy.policies.tool_call_judge_utils import parse_judge_response
 
 if TYPE_CHECKING:
     from luthien_proxy.credentials.credential import Credential

--- a/tests/luthien_proxy/unit_tests/inference/test_direct_api.py
+++ b/tests/luthien_proxy/unit_tests/inference/test_direct_api.py
@@ -27,7 +27,6 @@ from luthien_proxy.inference.base import (
 )
 from luthien_proxy.inference.direct_api import DirectApiProvider
 
-
 #: The genuine `_cached_client`, captured before any autouse patching so
 #: caching-specific tests can exercise the real cache path.
 _REAL_CACHED_CLIENT = direct_api._cached_client
@@ -50,6 +49,7 @@ def _cached_client_delegates_to_build(monkeypatch):
         return direct_api._build_client(credential, api_base)
 
     monkeypatch.setattr(direct_api, "_cached_client", _delegate)
+
 
 SIMPLE_SCHEMA = {
     "type": "object",

--- a/tests/luthien_proxy/unit_tests/inference/test_direct_api.py
+++ b/tests/luthien_proxy/unit_tests/inference/test_direct_api.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 
 from luthien_proxy.credentials.credential import Credential, CredentialType
+from luthien_proxy.inference import direct_api
 from luthien_proxy.inference.base import (
     MAX_SCHEMA_SERIALIZED_BYTES,
     InferenceInvalidCredentialError,
@@ -25,6 +26,30 @@ from luthien_proxy.inference.base import (
     InferenceTimeoutError,
 )
 from luthien_proxy.inference.direct_api import DirectApiProvider
+
+
+#: The genuine `_cached_client`, captured before any autouse patching so
+#: caching-specific tests can exercise the real cache path.
+_REAL_CACHED_CLIENT = direct_api._cached_client
+
+
+@pytest.fixture(autouse=True)
+def _cached_client_delegates_to_build(monkeypatch):
+    """Route the stable-credential cache lookup through `_build_client`.
+
+    The bulk of the suite patches `_build_client` (the per-call passthrough
+    constructor) and exercises the no-override path. With client caching,
+    that path now calls `_cached_client`. To keep those request-shape and
+    error-translation tests focused on translation (not caching), make the
+    real `_cached_client` defer to whatever `_build_client` currently is.
+    Tests that specifically pin caching behavior call `_REAL_CACHED_CLIENT`
+    directly and bypass this delegation.
+    """
+
+    async def _delegate(credential, api_base):
+        return direct_api._build_client(credential, api_base)
+
+    monkeypatch.setattr(direct_api, "_cached_client", _delegate)
 
 SIMPLE_SCHEMA = {
     "type": "object",
@@ -139,6 +164,64 @@ class TestCredentialSelection:
                 credential_override=user_cred,
             )
         assert mock_build.call_args.args[0] is user_cred
+
+
+class TestClientLifecycle:
+    """Stable credentials reuse a cached client; passthrough builds + closes."""
+
+    @pytest.mark.asyncio
+    async def test_stable_credential_reuses_cached_client(self):
+        """Repeated no-override calls fetch from the cache and never close it."""
+        client = _mock_client(_text_response("ok"))
+        cached = AsyncMock(return_value=client)
+        provider = _provider()
+        with (
+            patch("luthien_proxy.inference.direct_api._cached_client", new=cached),
+            patch("luthien_proxy.inference.direct_api._build_client") as mock_build,
+        ):
+            for _ in range(3):
+                await provider.complete(messages=[{"role": "user", "content": "hi"}])
+
+        # All three calls went through the cache, not the per-call builder.
+        assert cached.await_count == 3
+        mock_build.assert_not_called()
+        # The cache owns the client lifecycle — provider must not close it.
+        client.close.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stable_credential_passes_credential_and_base_to_cache(self):
+        """The cache is keyed by the configured server credential + api_base."""
+        server_cred = _api_key_cred("sk-ant-SERVER")
+        provider = DirectApiProvider(
+            name="judge",
+            credential=server_cred,
+            default_model="claude-sonnet-4-6",
+            api_base="https://judge.example",
+        )
+        cached = AsyncMock(return_value=_mock_client(_text_response("ok")))
+        with patch("luthien_proxy.inference.direct_api._cached_client", new=cached):
+            await provider.complete(messages=[{"role": "user", "content": "hi"}])
+
+        assert cached.await_args.args == (server_cred, "https://judge.example")
+
+    @pytest.mark.asyncio
+    async def test_passthrough_builds_and_closes_per_call(self):
+        """Override calls build a fresh client and close it (no cache use)."""
+        user_cred = _oauth_cred("sk-ant-oat01-USER")
+        client = _mock_client(_text_response("ok"))
+        cached = AsyncMock()
+        with (
+            patch("luthien_proxy.inference.direct_api._cached_client", new=cached),
+            patch("luthien_proxy.inference.direct_api._build_client", return_value=client) as mock_build,
+        ):
+            await _provider().complete(
+                messages=[{"role": "user", "content": "hi"}],
+                credential_override=user_cred,
+            )
+
+        mock_build.assert_called_once()
+        cached.assert_not_awaited()
+        client.close.assert_awaited_once()
 
 
 class TestRequestShape:
@@ -435,6 +518,43 @@ class TestMultiBlockContent:
                     ],
                 )
         mock_build.assert_not_called()
+
+
+class TestCachedClientIdentity:
+    """`_cached_client` returns the same instance for a repeated credential."""
+
+    @pytest.mark.asyncio
+    async def test_repeated_stable_credential_returns_same_client(self):
+        """Two lookups with the same credential + base reuse one client."""
+        from luthien_proxy.llm import anthropic_client_cache
+
+        anthropic_client_cache.clear()
+        try:
+            with patch.object(anthropic_client_cache, "AnthropicClient") as mock_cls:
+                mock_cls.side_effect = lambda **_: MagicMock()
+                cred = _api_key_cred("sk-ant-STABLE")
+                first = await _REAL_CACHED_CLIENT(cred, "https://judge.example")
+                second = await _REAL_CACHED_CLIENT(cred, "https://judge.example")
+            assert first is second
+            assert mock_cls.call_count == 1
+        finally:
+            anthropic_client_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_distinct_credentials_get_distinct_clients(self):
+        """Different credential values yield different cached clients."""
+        from luthien_proxy.llm import anthropic_client_cache
+
+        anthropic_client_cache.clear()
+        try:
+            with patch.object(anthropic_client_cache, "AnthropicClient") as mock_cls:
+                mock_cls.side_effect = lambda **_: MagicMock()
+                first = await _REAL_CACHED_CLIENT(_api_key_cred("sk-ant-A"), None)
+                second = await _REAL_CACHED_CLIENT(_api_key_cred("sk-ant-B"), None)
+            assert first is not second
+            assert mock_cls.call_count == 2
+        finally:
+            anthropic_client_cache.clear()
 
 
 class TestStructuredTextConsistency:

--- a/tests/luthien_proxy/unit_tests/policies/test_simple_llm_utils.py
+++ b/tests/luthien_proxy/unit_tests/policies/test_simple_llm_utils.py
@@ -13,7 +13,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from luthien_proxy.inference.base import InferenceResult
+from luthien_proxy.inference.base import (
+    InferenceInvalidCredentialError,
+    InferenceProviderError,
+    InferenceResult,
+    InferenceTimeoutError,
+)
 from luthien_proxy.policies.simple_llm_utils import (
     BlockDescriptor,
     SimpleLLMJudgeConfig,
@@ -394,6 +399,52 @@ class TestCallSimpleLLMJudge:
             provider=provider,
         )
         assert result.action == "pass"
+
+    @pytest.mark.asyncio
+    async def test_invalid_credential_fails_fast_without_retry(self):
+        """A rejected credential (401/403) is permanent → no retry, raised immediately."""
+        config = SimpleLLMJudgeConfig(
+            instructions="Be safe",
+            model="test-model",
+            max_retries=2,
+            retry_delay=5,  # would be a long wait if it (wrongly) retried
+        )
+        provider = _mock_provider_raising(InferenceInvalidCredentialError("rejected"))
+        with pytest.raises(InferenceInvalidCredentialError):
+            await call_simple_llm_judge(
+                config=config,
+                current_block=BlockDescriptor(type="text", content="hello"),
+                previous_blocks=(),
+                provider=provider,
+            )
+        assert provider.complete.call_count == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            InferenceTimeoutError("slow"),
+            InferenceProviderError("5xx"),
+            RuntimeError("boom"),
+        ],
+    )
+    async def test_transient_errors_still_retry(self, exc):
+        """Timeouts, provider errors, and generic failures retry up to max_retries."""
+        config = SimpleLLMJudgeConfig(
+            instructions="Be safe",
+            model="test-model",
+            max_retries=2,
+            retry_delay=0,
+        )
+        provider = _mock_provider_raising(exc)
+        with pytest.raises(type(exc)):
+            await call_simple_llm_judge(
+                config=config,
+                current_block=BlockDescriptor(type="text", content="hello"),
+                previous_blocks=(),
+                provider=provider,
+            )
+        assert provider.complete.call_count == 3  # 1 initial + 2 retries
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two small judge-client improvements, one commit per card.

## Card 1 — Reuse a cached HTTP client for stable-credential judge calls ([MPWayW4R](https://trello.com/c/MPWayW4R))

`DirectApiProvider.complete()` built a fresh `AnthropicClient` (and its httpx connection pool) and closed it on **every** call. For a stable server credential (no `credential_override`), a judge that fires on every tool call in a long agent loop paid pool init/teardown each time.

Now the stable-credential path routes through the existing `anthropic_client_cache.get_client()` (keyed by hashed credential + auth type + base URL), reusing one warm client across calls. The cache owns the lifecycle (LRU eviction + shutdown close via `close_all()`), so the provider does **not** close it.

The per-user passthrough path (`credential_override` set) is unchanged: it still builds and closes a fresh client per call, since those credentials vary per request and must not accumulate in the shared cache.

## Card 2 — Don't retry permanent failures in `call_simple_llm_judge` ([YYqNNZQv](https://trello.com/c/YYqNNZQv))

The judge retry loop wrapped `provider.complete()` in a broad `except Exception` that retried every error, including a rejected credential. With defaults (`max_retries=2`, `retry_delay=0.5`) a misconfigured credential added ~1s of pointless latency per request before failing anyway, and hammered the upstream with doomed retries.

Now `InferenceInvalidCredentialError` (401/403 — permanent) re-raises immediately. Transient errors (timeouts, connection errors) and parse failures still retry as before.

## Tests

Card 1 (`tests/.../inference/test_direct_api.py`):
- `test_stable_credential_reuses_cached_client` — 3 no-override calls all go through the cache, builder never called, client never closed.
- `test_stable_credential_passes_credential_and_base_to_cache` — cache keyed by configured credential + api_base.
- `test_passthrough_builds_and_closes_per_call` — override builds fresh + closes, cache untouched.
- `test_repeated_stable_credential_returns_same_client` / `test_distinct_credentials_get_distinct_clients` — real cache identity (same credential -> same instance, only one client constructed).

Card 2 (`tests/.../policies/test_simple_llm_utils.py`):
- `test_invalid_credential_fails_fast_without_retry` — `InferenceInvalidCredentialError` raised, `call_count == 1`.
- `test_transient_errors_still_retry` (parametrized: timeout / provider error / generic) — `call_count == 3`.

`scripts/dev_checks.sh`: passing clean (format + lint + pyright + pytest), working tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)