### PR TITLE
PR #614 review follow-ups

### DIFF
--- a/changelog.d/pr614-review-followups.md
+++ b/changelog.d/pr614-review-followups.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**FTS backfill computes search text once per row**: The Postgres `014_add_session_search_fts.sql` backfill called `_extract_event_search_text(payload)` twice per row (once in the `UPDATE SET` clause, once in the `WHERE` filter), doubling the per-row work over the whole `conversation_events` table. It now computes the value once in a subquery and reuses it for both the tsvector and the NULL filter; results are unchanged. (PR #614 review follow-up, GH #763)

--- a/migrations/postgres/014_add_session_search_fts.sql
+++ b/migrations/postgres/014_add_session_search_fts.sql
@@ -49,10 +49,18 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 ALTER TABLE conversation_events
     ADD COLUMN IF NOT EXISTS search_vector TSVECTOR;
 
-UPDATE conversation_events
-SET search_vector = to_tsvector('english', COALESCE(_extract_event_search_text(payload), ''))
-WHERE event_type = 'transaction.request_recorded'
-  AND _extract_event_search_text(payload) IS NOT NULL;
+-- Backfill existing rows. Compute _extract_event_search_text(payload) ONCE per
+-- row via a subquery, then both set the tsvector and filter on the result --
+-- calling the function twice (once in SET, once in WHERE) doubled the work.
+UPDATE conversation_events AS ce
+SET search_vector = to_tsvector('english', extracted.search_text)
+FROM (
+    SELECT id, _extract_event_search_text(payload) AS search_text
+    FROM conversation_events
+    WHERE event_type = 'transaction.request_recorded'
+) AS extracted
+WHERE ce.id = extracted.id
+  AND extracted.search_text IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_conversation_events_search_vector
     ON conversation_events USING GIN (search_vector)

--- a/tests/luthien_proxy/unit_tests/utils/test_search.py
+++ b/tests/luthien_proxy/unit_tests/utils/test_search.py
@@ -40,6 +40,7 @@ def test_postgres_backfill_calls_extract_helper_once_per_row() -> None:
     update_sql = _postgres_fts_backfill_update()
     assert update_sql.count("_extract_event_search_text(") == 1
 
+
 REQUIRED_MIGRATIONS = (
     "003_add_conversation_tables.sql",
     "006_add_session_id.sql",

--- a/tests/luthien_proxy/unit_tests/utils/test_search.py
+++ b/tests/luthien_proxy/unit_tests/utils/test_search.py
@@ -12,6 +12,33 @@ from luthien_proxy.utils.db_sqlite import SqliteConnection
 from luthien_proxy.utils.search import session_fts_filter_sql
 
 MIGRATIONS_DIR = Path(__file__).resolve().parents[4] / "migrations" / "sqlite"
+POSTGRES_MIGRATIONS_DIR = Path(__file__).resolve().parents[4] / "migrations" / "postgres"
+
+
+def _postgres_fts_backfill_update() -> str:
+    """Return the backfill UPDATE statement from the Postgres FTS migration.
+
+    Naive `;`-splitting is unsafe here -- the migration contains `$$`-quoted
+    PL/pgSQL function bodies with embedded semicolons. Instead, slice from the
+    first top-level `UPDATE conversation_events` to its terminating `;`, which
+    sits outside any function body.
+    """
+    sql = (POSTGRES_MIGRATIONS_DIR / "014_add_session_search_fts.sql").read_text()
+    start = sql.index("UPDATE conversation_events")
+    end = sql.index(";", start)
+    return sql[start:end]
+
+
+def test_postgres_backfill_calls_extract_helper_once_per_row() -> None:
+    """The Postgres backfill must evaluate _extract_event_search_text once per row.
+
+    Regression guard for the PR #614 review finding: the original backfill called
+    `_extract_event_search_text(payload)` twice (once in SET, once in WHERE),
+    doubling the work. The corrected statement computes it once in a subquery and
+    reuses the result for both the value and the NULL filter.
+    """
+    update_sql = _postgres_fts_backfill_update()
+    assert update_sql.count("_extract_event_search_text(") == 1
 
 REQUIRED_MIGRATIONS = (
     "003_add_conversation_tables.sql",


### PR DESCRIPTION
## PR #614 review follow-ups

Three review follow-ups from PR #614. Investigated all three against the current
checkout; only one corresponds to live code. Details below.

### Fixes

#### FTS backfill computes search text once per row — card 6a0f94f1 (GH #763)
The Postgres backfill in `migrations/postgres/014_add_session_search_fts.sql`
called `_extract_event_search_text(payload)` **twice per row** — once in the
`UPDATE ... SET` clause and once in the `WHERE` filter — doubling the per-row
work across the whole `conversation_events` table on migration.

Fix: compute the value once in a subquery, then use it for both the tsvector and
the `IS NOT NULL` filter. Results are identical (only rows with non-NULL extracted
text get a `search_vector`). This mirrors the structure the SQLite-side backfill
already uses (which was correct — single-pass via a subquery — so no SQLite
change was needed).

Regression test (`tests/luthien_proxy/unit_tests/utils/test_search.py`):
asserts the backfill `UPDATE` evaluates the helper exactly once. Encodes the
issue's acceptance criterion directly. (A behavioral Postgres test would need a
real server — integration tier — so this is a content-level guard in the existing
unit suite.)

Note: the GH issue named "migration 016 ... or equivalent"; the equivalent in
this tree is `014_add_session_search_fts.sql` (migration 016 here is the
unrelated `016_replace_policy_definition_with_policy_type.sql`).

### Investigated, no change needed

#### Webhook sender per-attempt `httpx.AsyncClient` — card 6a0f94ee (GH #761)
**Already fixed on `main`.** `WebhookSender` constructs the `httpx.AsyncClient`
once in `__init__` and reuses `self._client` across every delivery attempt
(`_attempt_send` calls `self._client.post(...)`; no per-attempt construction).
The merged webhook changelog fragment (`webhook-event-export.md`, PR #741) even
documents "Singleton `httpx.AsyncClient`". Nothing to change.

#### Passthrough `agent` column length cap — card 6a125105 (GH #770)
**Not applicable to this checkout.** There is no `agent` column on `request_logs`
(migration 019 adds only `user_id`), no `x-luthien-agent` header is read anywhere
in the codebase, and `record_inbound_request` has no `agent` parameter. The code
the card describes does not exist here, so there was nothing to cap. If/when the
`agent` column lands, the cap should be added at write time in
`record_inbound_request` (truncate, with a warning log).

---
*Posted by Claude Code (Opus 4.8)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
