### PR TITLE
feat(automated_maintenance): per-concern autofix PRs + per-concern dedup

### DIFF
--- a/changelog.d/autofix-per-concern.md
+++ b/changelog.d/autofix-per-concern.md
@@ -1,0 +1,8 @@
+---
+category: Features
+---
+
+**Automated maintenance autofix now opens one single-concern PR per failing check, with per-concern dedup** (`scripts/automated_maintenance/lib/autofix.sh`)
+  - Each failing check (concern) gets its own focused fix session and its own draft PR on `maint-fix/<concern>/<run_id>`, instead of one PR bundling every failure.
+  - Before attempting a concern, checks for an already-open autofix PR for that concern and skips it (no duplicate while a fix is in review); a novel concern still gets its own PR. Fails closed (skips) if the GitHub query errors.
+  - `results.json` `autofix` is now keyed by concern; the dashboard renders a pill/PR-link per concern and stays backward-compatible with the legacy single-object shape.

--- a/scripts/automated_maintenance/README.md
+++ b/scripts/automated_maintenance/README.md
@@ -244,6 +244,14 @@ Risks, in order:
    branch. The next run wipes the state-dir clone and starts fresh, so
    this self-heals.
 
+**On per-concern dedup**: the "skip a concern that already has an open PR"
+check queries `gh pr list` and is not atomic. Two maintenance runs firing
+close together (a manual rerun during the cron fire, or two hosts pointed at
+the same repo) could both query before either opens its PR, and both open a
+duplicate for the same concern. The single-host nightly-cron deployment this
+is built for doesn't hit that (the run lock in `automated_maintenance.sh`
+serializes runs on one host); it's a deliberate trade-off, not a guarantee.
+
 **On account scope**: `gh pr create` runs as whatever account `gh` is
 logged in as. If you enable autofix on a workstation, autofix PRs will
 be authored by your personal account, and the session can `gh` against

--- a/scripts/automated_maintenance/README.md
+++ b/scripts/automated_maintenance/README.md
@@ -22,14 +22,18 @@ On each scheduled run, the job:
    include it.
 4. Runs a doc-drift sweep via headless `claude` — finds stale references
    in markdown/config relative to current code.
-5. If anything failed and `AUTOFIX_ENABLED=true`, spawns a headless
-   `claude` session that tries to fix it and opens a draft PR.
+5. If anything failed and `AUTOFIX_ENABLED=true`, runs one headless
+   `claude` fix session **per failing concern** (each failing check is a
+   concern), and opens a separate single-concern draft PR for each on its
+   own branch `maint-fix/<concern>/<run_id>`. A concern that already has an
+   open autofix PR is skipped (no duplicate while a fix is in review); a
+   novel concern still gets its own PR.
 6. Renders/updates a static dashboard at `$MAINT_PUBLIC_DIR/index.html`.
 7. Tears down any docker compose stack the e2e tier brought up.
 
 A run that finds nothing wrong is silent (apart from the dashboard
 update). A run with failures leaves logs on disk and, if autofix is
-enabled, opens a PR.
+enabled, opens a draft PR per failing concern.
 
 ## Layout
 
@@ -60,7 +64,8 @@ $MAINT_STATE_DIR/
 │   ├── dev_checks.log
 │   ├── e2e_*.log
 │   ├── doc_drift.md               # only if drift found
-│   └── autofix_*                  # only if autofix ran
+│   └── autofix_*.<concern>.*      # per failing concern, only if autofix ran
+│                                  #   (brief, session.log, summary.md, pr_url.txt)
 ├── public/                        # dashboard, point your web server here
 └── logs/                          # scheduler stdout/stderr
 ```
@@ -211,9 +216,9 @@ systemctl --user disable --now luthien-automated-maintenance.timer
 
 ## Autofix safety notes
 
-When `AUTOFIX_ENABLED=true`, a failing check spawns a headless `claude`
-session with **broad permissions**: `--permission-mode bypassPermissions`
-and `--allowedTools "Read Edit Write Glob Grep Bash"`. The session can:
+When `AUTOFIX_ENABLED=true`, each failing concern spawns its own headless
+`claude` session with **broad permissions**: `--permission-mode bypassPermissions`
+and `--allowedTools "Read Edit Write Glob Grep Bash"`. Each session can:
 
 - Edit, create, and delete files anywhere the scheduler user can write
   (in practice: the state-dir clone, plus anything else the user has
@@ -221,11 +226,12 @@ and `--allowedTools "Read Edit Write Glob Grep Bash"`. The session can:
 - Run **arbitrary shell commands** as the scheduler user, with network
   access. The intended use is `git`, `pytest`, `ruff`, etc., but the
   session is not sandboxed beyond the user's filesystem permissions.
-- Hit external HTTP services and consume API tokens, capped per run by
-  `AUTOFIX_MAX_BUDGET_USD` and `AUTOFIX_TIMEOUT`.
+- Hit external HTTP services and consume API tokens. `AUTOFIX_MAX_BUDGET_USD`
+  and `AUTOFIX_TIMEOUT` cap each **per-concern** session, so worst-case spend
+  for a run scales with the number of failing concerns.
 
-It will NOT push directly — the orchestrator pushes the resulting branch
-and opens a **draft** PR for human review.
+It will NOT push directly — the orchestrator pushes each concern's branch
+and opens a single-concern **draft** PR for human review.
 
 Risks, in order:
 

--- a/scripts/automated_maintenance/README.md
+++ b/scripts/automated_maintenance/README.md
@@ -228,7 +228,10 @@ and `--allowedTools "Read Edit Write Glob Grep Bash"`. Each session can:
   session is not sandboxed beyond the user's filesystem permissions.
 - Hit external HTTP services and consume API tokens. `AUTOFIX_MAX_BUDGET_USD`
   and `AUTOFIX_TIMEOUT` cap each **per-concern** session, so worst-case spend
-  for a run scales with the number of failing concerns.
+  and wall-clock for a run scale with the number of failing concerns. With the
+  default 5 checks failing at `AUTOFIX_MAX_BUDGET_USD=5` / `AUTOFIX_TIMEOUT=1800`,
+  a single run can spend up to ~$25 and run ~2.5h serially — keep that in mind
+  when tuning those env vars.
 
 It will NOT push directly — the orchestrator pushes each concern's branch
 and opens a single-concern **draft** PR for human review.
@@ -251,6 +254,9 @@ the same repo) could both query before either opens its PR, and both open a
 duplicate for the same concern. The single-host nightly-cron deployment this
 is built for doesn't hit that (the run lock in `automated_maintenance.sh`
 serializes runs on one host); it's a deliberate trade-off, not a guarantee.
+The dedup is also age-blind: an open autofix PR for a concern suppresses new
+autofixes for that concern *indefinitely*, so a stale one languishing in
+review will keep blocking fresh fixes — close stale autofix PRs to unblock.
 
 **On account scope**: `gh pr create` runs as whatever account `gh` is
 logged in as. If you enable autofix on a workstation, autofix PRs will

--- a/scripts/automated_maintenance/lib/autofix.sh
+++ b/scripts/automated_maintenance/lib/autofix.sh
@@ -1,119 +1,126 @@
 #!/usr/bin/env bash
-# Autonomous fix attempt. Runs in MAINT_REPO_DIR on a fresh branch.
-# Spawns headless `claude` with a brief covering all failures. If the
-# session produces a non-empty diff, push branch + open draft PR.
+# Autonomous fix attempts, one per failing concern.
+#
+# Each failing check is a "concern" and gets its own focused fix attempt on
+# its own branch (maint-fix/<concern>/<run_id>) and, if it produces a diff,
+# its own single-concern draft PR. This keeps PRs reviewable and lets a
+# novel failure get its own PR even while another concern's fix is pending.
+#
+# Per-concern dedup: before attempting a concern, we check for an already-open
+# PR for that concern (branch maint-fix/<concern>/*). If one exists, we skip
+# the concern — don't stack a duplicate while a fix is in review. A different,
+# novel concern still gets its own PR.
 #
 # This is opt-in (AUTOFIX_ENABLED=true). It runs with broad permissions so
-# Claude can edit files and run tests; the assumption is that the fix
-# branch is reviewed by a human before merge.
+# Claude can edit files and run tests; fix branches are reviewed by a human
+# before merge (PRs open as drafts).
 #
 # Sourced by automated_maintenance.sh.
 
 set -euo pipefail
 
-# Build a markdown brief describing every failed check. Reads results.json
-# and concatenates the relevant log tails.
-_autofix_build_brief() {
-    local brief="$1"
-    python3 - "$MAINT_RUN_DIR" "$brief" <<'PY'
+# Build a focused brief for ONE concern. doc_drift pulls in its findings
+# report; every other check pulls in its log tail.
+_autofix_build_brief_for() {
+    local concern="$1" brief="$2"
+    python3 - "$MAINT_RUN_DIR" "$concern" "$brief" <<'PY'
 import json, pathlib, sys
 run_dir = pathlib.Path(sys.argv[1])
-brief_path = pathlib.Path(sys.argv[2])
+concern = sys.argv[2]
+brief_path = pathlib.Path(sys.argv[3])
 results = json.loads((run_dir / "results.json").read_text())
-lines = ["# Maintenance failures", ""]
-lines.append(f"Run: {results.get('run_id')}")
-lines.append("")
-for name, c in results.get("checks", {}).items():
-    if c.get("status") not in {"fail", "error"}:
-        continue
-    lines.append(f"## {name} ({c['status']}, exit {c.get('exit_code')})")
-    lines.append("")
+c = results.get("checks", {}).get(concern, {})
+lines = [
+    f"# Maintenance failure: {concern}",
+    "",
+    f"Run: {results.get('run_id')}",
+    "",
+    f"## {concern} ({c.get('status')}, exit {c.get('exit_code')})",
+    "",
+]
+if concern == "doc_drift":
+    drift = run_dir / (c.get("report") or "doc_drift.md")
+    if drift.exists():
+        lines.append(drift.read_text(errors="replace"))
+else:
     log = run_dir / c.get("log", "")
     if log.exists():
-        # errors="replace" mirrors dashboard.py — e2e logs sometimes have
-        # raw terminal escapes or non-UTF-8 bytes; one bad byte should
-        # not crash brief generation and silently skip the autofix.
+        # errors="replace": e2e logs sometimes carry raw terminal escapes or
+        # non-UTF-8 bytes; one bad byte must not crash brief generation.
         tail = log.read_text(errors="replace").splitlines()[-200:]
         lines.append("```")
         lines.extend(tail)
         lines.append("```")
-        lines.append("")
-# Doc drift findings, if any.
-drift = run_dir / "doc_drift.md"
-if drift.exists():
-    drift_text = drift.read_text(errors="replace")
-    if "No drift detected" not in drift_text:
-        lines.append("## doc_drift findings")
-        lines.append("")
-        lines.append(drift_text)
 brief_path.write_text("\n".join(lines))
 PY
 }
 
-_run_autofix() {
+# Echo the URL of an already-open autofix PR for this concern, if any.
+# rc 0 + URL on stdout when one exists; rc 1 when none; rc 2 when the GitHub
+# query itself failed (caller fails closed rather than risk a duplicate).
+_autofix_open_pr_for() {
+    local concern="$1" url
+    url="$(gh pr list \
+        --repo "$(git -C "${MAINT_REPO_DIR}" remote get-url origin)" \
+        --state open \
+        --search "head:${AUTOFIX_BRANCH_PREFIX}/${concern}/" \
+        --json url --jq '.[0].url // empty' 2>/dev/null)" || return 2
+    [[ -n "${url}" ]] || return 1
+    echo "${url}"
+    return 0
+}
+
+# Attempt a fix for a single concern. Returns:
+#   0   opened a draft PR
+#   65  session produced no diff
+#   2   touched forbidden paths (refused to push)
+#   *   other error
+# Writes the PR url (on success) to autofix_pr_url.<concern>.txt.
+_run_autofix_concern() {
+    local concern="$1"
     cd "${MAINT_REPO_DIR}"
-    if ! command -v claude >/dev/null 2>&1; then
-        echo "claude CLI not on PATH — skipping autofix" >&2
-        return 64
-    fi
-    if ! command -v gh >/dev/null 2>&1; then
-        echo "gh CLI not on PATH — skipping autofix" >&2
-        return 64
-    fi
 
-    local brief="${MAINT_RUN_DIR}/autofix_brief.md"
-    _autofix_build_brief "${brief}"
+    local brief="${MAINT_RUN_DIR}/autofix_brief.${concern}.md"
+    _autofix_build_brief_for "${concern}" "${brief}"
 
-    # Branch name is unique per run (second-resolution timestamp), so a
-    # fresh branch is guaranteed — plain `git push -u` below, no need
-    # for `--force-with-lease`.
-    local branch="${AUTOFIX_BRANCH_PREFIX}/${MAINT_RUN_ID}"
+    local branch="${AUTOFIX_BRANCH_PREFIX}/${concern}/${MAINT_RUN_ID}"
     git checkout -B "${branch}" "origin/${MAINT_REPO_BRANCH}"
-    # Set the repo-level git identity so commits made by the headless
-    # `claude` session below get attributed to the bot, not whoever's
-    # global git config the scheduler user inherits. The orchestrator's
-    # fallback commit (further below) inherits the same identity, so
-    # we don't need to also pass `-c user.email=...` to that `git commit`.
     git config user.email nightly-autofix@users.noreply.github.com
     git config user.name "nightly-autofix"
 
     local prompt
     prompt="$(cat <<EOF
 You are an autonomous fix bot for luthien-proxy. The automated maintenance
-job ran and failures are described in autofix_brief.md (in the run
-directory: ${MAINT_RUN_DIR}).
+job found a problem with the "${concern}" check. It is described in
+${brief} (in the run directory: ${MAINT_RUN_DIR}).
+
+Fix ONLY the ${concern} concern in this session — nothing else. A separate
+session handles each other concern, so do not range beyond this one.
 
 Your task:
-1. Read autofix_brief.md and identify root causes.
+1. Read the brief and identify the root cause(s) of the ${concern} failure.
 2. Make minimal, targeted fixes. Do not refactor.
-3. After each edit, run the relevant check locally to confirm the fix.
-   Match the maintenance run's invocation exactly (the orchestrator runs these
-   with --fresh):
+3. Verify locally where it makes sense. Match the maintenance run's
+   invocation (the orchestrator runs these with --fresh):
      - dev_checks → ./scripts/dev_checks.sh
      - e2e_sqlite → ./scripts/run_e2e.sh sqlite --fresh --no-log
      - e2e_mock  → ./scripts/run_e2e.sh mock --fresh --no-log
-     - doc_drift findings → edit the stale reference, no test needed
+     - doc_drift → edit the stale reference to match the code; no test needed
 4. Commit each logical fix separately with a clear message.
-5. Stop when you've addressed everything you can. Don't speculate or
-   guess if you can't figure something out — leave it for a human.
+5. Stop when you've addressed what you can. Don't speculate or guess; leave
+   anything uncertain for a human.
 
 Constraints (enforced post-session, not just policy):
-- Do not edit migrations/, *.env*, or scripts/automated_maintenance/. The orchestrator
-  refuses to push a diff that touches any of these paths.
+- Do not edit migrations/, *.env*, or scripts/automated_maintenance/. The
+  orchestrator refuses to push a diff that touches any of these paths.
 - Do not push or open PRs yourself; the orchestrator does that.
-- Do not run e2e_real (ANTHROPIC_API_KEY is unset in this subshell so
-  it physically can't authenticate).
+- Do not run e2e_real (ANTHROPIC_API_KEY is unset so it can't authenticate).
 
-When done, write a summary to ${MAINT_RUN_DIR}/autofix_summary.md
-listing what you fixed, what you couldn't fix, and why.
+When done, write a summary to ${MAINT_RUN_DIR}/autofix_summary.${concern}.md
+listing what you fixed, what you couldn't, and why.
 EOF
 )"
 
-    # AUTOFIX_MAX_BUDGET_USD caps API spend per attempt. Prompt via stdin
-    # — variadic --allowedTools would otherwise eat it. ANTHROPIC_API_KEY
-    # is unset in this subshell so the session can't hit the real
-    # Anthropic API (e.g. via ./scripts/run_e2e.sh real). The prompt
-    # also asks Claude not to, but the env strip enforces it.
     (
         unset ANTHROPIC_API_KEY
         printf '%s' "${prompt}" | maint_timeout "${AUTOFIX_TIMEOUT}" \
@@ -122,32 +129,22 @@ EOF
                 --permission-mode bypassPermissions \
                 --max-budget-usd "${AUTOFIX_MAX_BUDGET_USD}" \
                 --allowedTools "Read Edit Write Glob Grep Bash" \
-            > "${MAINT_RUN_DIR}/autofix_session.log" 2>&1
+            > "${MAINT_RUN_DIR}/autofix_session.${concern}.log" 2>&1
     ) || true
 
-    # Did anything change? Stage everything first so untracked-but-new
-    # files don't silently vanish on push. `git diff` alone misses
-    # untracked files; `git status --porcelain` catches them.
+    # No change? Nothing to push. `git status --porcelain` catches untracked
+    # files that `git diff` alone misses.
     if [[ -z "$(git status --porcelain)" ]] && \
        git diff --quiet "origin/${MAINT_REPO_BRANCH}" -- .; then
-        echo "autofix produced no diff"
-        # Distinct sentinel: rc=65 means "no diff", not just "something
-        # in this subshell exited 1". Avoids miscategorizing a git/curl
-        # failure under `set -e` as "no diff" in the status mapping.
+        echo "autofix(${concern}) produced no diff"
         return 65
     fi
-    # Commit anything the session forgot to commit (e.g. created files
-    # but never `git add`'d them).
     if [[ -n "$(git status --porcelain)" ]]; then
         git add -A
-        git commit -m "autofix: capture uncommitted changes from session"
+        git commit -m "autofix(${concern}): capture uncommitted changes from session"
     fi
 
-    # Forbidden-paths gate: refuse to push diffs that touch sensitive
-    # areas. The prompt asks Claude to avoid these; this is the
-    # enforcement. Logic + unit-test matrix in path_gate.py.
-    # Read changed paths into an array. `mapfile` would be cleaner but
-    # macOS ships bash 3.2 which lacks it; this loop is portable.
+    # Forbidden-paths gate (logic + tests in path_gate.py).
     local changed_paths=()
     while IFS= read -r line; do
         [[ -n "${line}" ]] && changed_paths+=("${line}")
@@ -156,17 +153,13 @@ EOF
         local gate_out gate_rc=0
         gate_out="$(python3 "${MAINT_DIR}/lib/path_gate.py" "${changed_paths[@]}")" || gate_rc=$?
         case "${gate_rc}" in
-            0)
-                ;;  # all paths safe
+            0) ;;
             2)
-                echo "autofix touched forbidden paths — refusing to push:"
+                echo "autofix(${concern}) touched forbidden paths — refusing to push:"
                 while IFS= read -r line; do echo "  ${line}"; done <<< "${gate_out}"
                 return 2
                 ;;
             *)
-                # Fail-closed on any unexpected non-zero (python crash,
-                # unicode error, missing helper). We'd rather refuse to
-                # push than push something we couldn't classify.
                 echo "path_gate.py exited unexpectedly (rc=${gate_rc}) — refusing to push:"
                 echo "${gate_out}"
                 return 2
@@ -174,25 +167,15 @@ EOF
         esac
     fi
 
-    # Push and open a draft PR.
     git push -u origin "${branch}"
-    # Compute the failed-checks summary via argv (not interpolation) so
-    # state-dir paths with shell metacharacters don't break the python
-    # invocation.
-    local failed_checks
-    failed_checks="$(python3 - "${MAINT_RUN_DIR}/results.json" <<'PY'
-import json, pathlib, sys
-r = json.loads(pathlib.Path(sys.argv[1]).read_text())
-print(", ".join(n for n, c in r["checks"].items() if c["status"] in {"fail", "error"}))
-PY
-)"
     local pr_body
     pr_body="$(cat <<EOF
-Automated fix attempt from maintenance run ${MAINT_RUN_ID}.
+Automated fix attempt for the **${concern}** check, from maintenance run ${MAINT_RUN_ID}.
 
-**Failed checks:** ${failed_checks}
+This PR addresses a single concern (${concern}). Other failing checks, if any,
+get their own PRs.
 
-See \`autofix_summary.md\` and \`autofix_session.log\` in
+See \`autofix_summary.${concern}.md\` and \`autofix_session.${concern}.log\` in
 \`${MAINT_STATE_DIR}/runs/${MAINT_RUN_ID}/\` for details.
 
 **Review carefully** — these changes are not human-authored.
@@ -201,21 +184,41 @@ See \`autofix_summary.md\` and \`autofix_session.log\` in
 *Posted by automated autofix*
 EOF
 )"
-    # If `gh pr create` fails (rate limit, auth, transient error), the
-    # branch we just pushed has no PR pointing at it. Clean up the
-    # remote ref so we don't accumulate orphans.
     local pr_url pr_rc=0
     pr_url="$(gh pr create --draft --base "${MAINT_REPO_BRANCH}" \
-        --title "maint-fix: ${MAINT_RUN_ID}" \
+        --title "maint-fix(${concern}): ${MAINT_RUN_ID}" \
         --body "${pr_body}")" || pr_rc=$?
     if [[ ${pr_rc} -ne 0 ]]; then
         echo "gh pr create failed (rc=${pr_rc}) — deleting orphan remote branch"
         git push origin --delete "${branch}" >/dev/null 2>&1 || true
         return "${pr_rc}"
     fi
-    echo "${pr_url}" > "${MAINT_RUN_DIR}/autofix_pr_url.txt"
-    echo "opened: ${pr_url}"
+    echo "${pr_url}" > "${MAINT_RUN_DIR}/autofix_pr_url.${concern}.txt"
+    echo "autofix(${concern}) opened: ${pr_url}"
     return 0
+}
+
+# Record one concern's autofix outcome into results.json under
+# .autofix.<concern>. Keeps each concern's status/pr independent.
+_autofix_record() {
+    local concern="$1" status="$2" duration="$3" rc="$4" pr_url="${5:-}" existing_pr="${6:-}"
+    python3 - "$MAINT_RUN_DIR" "$concern" "$status" "$duration" "$rc" "$pr_url" "$existing_pr" <<'PY'
+import json, pathlib, sys
+run_dir, concern, status, duration, rc, pr_url, existing_pr = sys.argv[1:8]
+p = pathlib.Path(run_dir, "results.json")
+data = json.loads(p.read_text())
+af = data.get("autofix")
+if not isinstance(af, dict):
+    af = {}
+entry = {"status": status, "duration_s": int(duration), "exit_code": int(rc)}
+if pr_url:
+    entry["pr_url"] = pr_url
+if existing_pr:
+    entry["existing_pr"] = existing_pr
+af[concern] = entry
+data["autofix"] = af
+p.write_text(json.dumps(data, indent=2) + "\n")
+PY
 }
 
 maint_run_autofix() {
@@ -223,52 +226,68 @@ maint_run_autofix() {
         echo "[maint] autofix disabled, skipping" >&2
         return 0
     fi
-    # Only run if at least one check failed. Pass path via argv (not
-    # shell interpolation) so state-dir paths with metacharacters
-    # don't break the python literal.
-    local any_fail
-    any_fail="$(python3 - "${MAINT_RUN_DIR}/results.json" <<'PY'
+    if ! command -v claude >/dev/null 2>&1; then
+        echo "[maint] claude CLI not on PATH — skipping autofix" >&2
+        return 0
+    fi
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "[maint] gh CLI not on PATH — skipping autofix" >&2
+        return 0
+    fi
+
+    # Concerns = failing checks, in declared order.
+    local concerns=()
+    while IFS= read -r line; do
+        [[ -n "${line}" ]] && concerns+=("${line}")
+    done < <(python3 - "${MAINT_RUN_DIR}/results.json" <<'PY'
 import json, pathlib, sys
 r = json.loads(pathlib.Path(sys.argv[1]).read_text())
-print(any(c.get("status") in {"fail", "error"} for c in r.get("checks", {}).values()))
+for name, c in r.get("checks", {}).items():
+    if c.get("status") in {"fail", "error"}:
+        print(name)
 PY
-)"
-    if [[ "${any_fail}" != "True" ]]; then
+)
+    if [[ ${#concerns[@]} -eq 0 ]]; then
         echo "[maint] all checks passed, no autofix needed" >&2
         return 0
     fi
 
-    local log_path="${MAINT_RUN_DIR}/autofix.log"
-    local started ended duration rc=0
-    echo "[maint] >>> autofix" >&2
-    started="$(date +%s)"
-    ( _run_autofix ) >"${log_path}" 2>&1 || rc=$?
-    ended="$(date +%s)"
-    duration=$((ended - started))
-    local status
-    case "${rc}" in
-        0) status="opened_pr" ;;
-        65) status="no_diff" ;;
-        2) status="forbidden_paths" ;;
-        64) status="skip" ;;
-        124) status="timeout" ;;
-        *) status="error" ;;
-    esac
-    local pr_url=""
-    [[ -f "${MAINT_RUN_DIR}/autofix_pr_url.txt" ]] && \
-        pr_url="$(cat "${MAINT_RUN_DIR}/autofix_pr_url.txt")"
-    python3 - "$MAINT_RUN_DIR" "$status" "$duration" "$rc" "$pr_url" <<'PY'
-import json, pathlib, sys
-run_dir, status, duration, rc, pr_url = sys.argv[1:6]
-p = pathlib.Path(run_dir, "results.json")
-data = json.loads(p.read_text())
-data["autofix"] = {
-    "status": status,
-    "duration_s": int(duration),
-    "exit_code": int(rc),
-    "pr_url": pr_url or None,
-}
-p.write_text(json.dumps(data, indent=2) + "\n")
-PY
-    echo "[maint] <<< autofix ${status} (${duration}s, rc=${rc})" >&2
+    local concern
+    for concern in "${concerns[@]}"; do
+        echo "[maint] >>> autofix(${concern})" >&2
+
+        # Per-concern dedup: skip if an open PR already covers this concern.
+        local existing="" pr_rc=0
+        existing="$(_autofix_open_pr_for "${concern}")" || pr_rc=$?
+        if [[ ${pr_rc} -eq 0 ]]; then
+            echo "[maint] <<< autofix(${concern}) skipped — open PR: ${existing}" >&2
+            _autofix_record "${concern}" "skipped_existing_pr" 0 0 "" "${existing}"
+            continue
+        elif [[ ${pr_rc} -eq 2 ]]; then
+            # Couldn't query GitHub — fail closed (don't risk a duplicate).
+            echo "[maint] <<< autofix(${concern}) skipped — could not query open PRs" >&2
+            _autofix_record "${concern}" "skipped_query_failed" 0 0 "" ""
+            continue
+        fi
+
+        local started ended duration rc=0
+        started="$(date +%s)"
+        ( _run_autofix_concern "${concern}" ) \
+            > "${MAINT_RUN_DIR}/autofix.${concern}.log" 2>&1 || rc=$?
+        ended="$(date +%s)"
+        duration=$((ended - started))
+        local status
+        case "${rc}" in
+            0) status="opened_pr" ;;
+            65) status="no_diff" ;;
+            2) status="forbidden_paths" ;;
+            124) status="timeout" ;;
+            *) status="error" ;;
+        esac
+        local pr_url=""
+        [[ -f "${MAINT_RUN_DIR}/autofix_pr_url.${concern}.txt" ]] && \
+            pr_url="$(cat "${MAINT_RUN_DIR}/autofix_pr_url.${concern}.txt")"
+        _autofix_record "${concern}" "${status}" "${duration}" "${rc}" "${pr_url}" ""
+        echo "[maint] <<< autofix(${concern}) ${status} (${duration}s, rc=${rc})" >&2
+    done
 }

--- a/scripts/automated_maintenance/lib/autofix.sh
+++ b/scripts/automated_maintenance/lib/autofix.sh
@@ -92,8 +92,12 @@ _run_autofix_concern() {
 
     local branch="${AUTOFIX_BRANCH_PREFIX}/${concern}/${MAINT_RUN_ID}"
     git checkout -B "${branch}" "origin/${MAINT_REPO_BRANCH}"
-    git config user.email nightly-autofix@users.noreply.github.com
-    git config user.name "nightly-autofix"
+    # `checkout -B` only resets tracked files. Concerns run serially in the
+    # same clone, so without this any untracked leftovers from the previous
+    # concern's session (scratch files Claude wrote but never `git add`ed)
+    # would survive and get swept into THIS concern's `git add -A` below —
+    # contaminating its diff and possibly its forbidden-paths verdict.
+    git clean -fdx
 
     local prompt
     prompt="$(cat <<EOF
@@ -267,6 +271,11 @@ PY
         echo "[maint] all checks passed, no autofix needed" >&2
         return 0
     fi
+
+    # Repo-local commit identity for the autofix branches — set once for the
+    # clone rather than per concern.
+    git -C "${MAINT_REPO_DIR}" config user.email nightly-autofix@users.noreply.github.com
+    git -C "${MAINT_REPO_DIR}" config user.name "nightly-autofix"
 
     local concern
     for concern in "${concerns[@]}"; do

--- a/scripts/automated_maintenance/lib/autofix.sh
+++ b/scripts/automated_maintenance/lib/autofix.sh
@@ -71,17 +71,20 @@ _autofix_open_pr_for() {
         --repo "$(git -C "${MAINT_REPO_DIR}" remote get-url origin)" \
         --state open \
         --search "head:${AUTOFIX_BRANCH_PREFIX}/${concern}/" \
-        --json url --jq '.[0].url // empty' 2>/dev/null)" || return 2
+        --json url --jq '.[0].url // empty' \
+        2>"${MAINT_RUN_DIR}/autofix_pr_query.${concern}.err")" || return 2
     [[ -n "${url}" ]] || return 1
     echo "${url}"
     return 0
 }
 
 # Attempt a fix for a single concern. Returns:
-#   0   opened a draft PR
-#   65  session produced no diff
-#   2   touched forbidden paths (refused to push)
-#   *   other error
+#   0    opened a draft PR
+#   65   session produced no diff
+#   2    touched forbidden paths (refused to push)
+#   66   path_gate.py crashed (couldn't classify the diff — refused to push)
+#   124  session timed out
+#   *    other error
 # Writes the PR url (on success) to autofix_pr_url.<concern>.txt.
 _run_autofix_concern() {
     local concern="$1"
@@ -180,9 +183,14 @@ EOF
                 return 2
                 ;;
             *)
+                # Distinct from the forbidden-paths `2` above: a crash means
+                # we couldn't classify the diff at all. Same fail-closed
+                # outcome (don't push), but record it as its own status so the
+                # dashboard doesn't mislabel a path_gate bug as a real
+                # forbidden-paths violation.
                 echo "path_gate.py exited unexpectedly (rc=${gate_rc}) — refusing to push:"
                 echo "${gate_out}"
-                return 2
+                return 66
                 ;;
         esac
     fi
@@ -255,7 +263,12 @@ maint_run_autofix() {
         return 0
     fi
 
-    # Concerns = failing checks, in declared order.
+    # Concerns = failing checks, in declared order. NOTE: a concern name (a
+    # check name from checks.sh / doc_drift.sh) is now load-bearing — it's
+    # interpolated into branch names, the `gh pr list --search head:` dedup
+    # query, and per-concern artifact filenames. Keep check names to
+    # [A-Za-z0-9_-] and prefix-distinct (see _autofix_open_pr_for) or those
+    # surfaces break. They're internal tokens, so we don't validate at runtime.
     local concerns=()
     while IFS= read -r line; do
         [[ -n "${line}" ]] && concerns+=("${line}")
@@ -302,14 +315,15 @@ PY
         ended="$(date +%s)"
         duration=$((ended - started))
         local status
-        # rc=2 here can only mean forbidden_paths: the other rc=2 source
-        # (_autofix_open_pr_for query failure) takes the early `continue`
-        # above and never reaches _run_autofix_concern. Keep that early-out
-        # if refactoring, or this mapping becomes ambiguous.
+        # rc=2 here means forbidden_paths only. The other potential rc=2
+        # sources are disambiguated: _autofix_open_pr_for's query failure takes
+        # the early `continue` above, and a path_gate.py crash returns 66 (not
+        # 2). Preserve both if refactoring, or this mapping becomes ambiguous.
         case "${rc}" in
             0) status="opened_pr" ;;
             65) status="no_diff" ;;
             2) status="forbidden_paths" ;;
+            66) status="path_gate_error" ;;
             124) status="timeout" ;;
             *) status="error" ;;
         esac

--- a/scripts/automated_maintenance/lib/autofix.sh
+++ b/scripts/automated_maintenance/lib/autofix.sh
@@ -58,6 +58,13 @@ PY
 # Echo the URL of an already-open autofix PR for this concern, if any.
 # rc 0 + URL on stdout when one exists; rc 1 when none; rc 2 when the GitHub
 # query itself failed (caller fails closed rather than risk a duplicate).
+#
+# Dedup correctness depends on the trailing `/`: `head:` matches by prefix, so
+# `head:maint-fix/<concern>/` matches `maint-fix/<concern>/<run_id>` but not a
+# concern whose name extends this one. This holds only while no concern name
+# is a prefix of another. Today's concerns (the check names: dev_checks,
+# e2e_sqlite, e2e_mock, e2e_real, doc_drift) are all prefix-distinct; keep it
+# that way, or this dedup could match across concerns.
 _autofix_open_pr_for() {
     local concern="$1" url
     url="$(gh pr list \
@@ -121,6 +128,7 @@ listing what you fixed, what you couldn't, and why.
 EOF
 )"
 
+    local sess_rc=0
     (
         unset ANTHROPIC_API_KEY
         printf '%s' "${prompt}" | maint_timeout "${AUTOFIX_TIMEOUT}" \
@@ -130,7 +138,15 @@ EOF
                 --max-budget-usd "${AUTOFIX_MAX_BUDGET_USD}" \
                 --allowedTools "Read Edit Write Glob Grep Bash" \
             > "${MAINT_RUN_DIR}/autofix_session.${concern}.log" 2>&1
-    ) || true
+    ) || sess_rc=$?
+    # A timed-out session (gtimeout → 124) was killed mid-edit; don't push its
+    # partial, unreviewed work as if it were a finished fix. Other nonzero
+    # exits are tolerated — `claude` may exit nonzero yet still have produced a
+    # complete, valid diff, so we fall through to the diff check below.
+    if [[ ${sess_rc} -eq 124 ]]; then
+        echo "autofix(${concern}) timed out after ${AUTOFIX_TIMEOUT}s — not pushing partial work"
+        return 124
+    fi
 
     # No change? Nothing to push. `git status --porcelain` catches untracked
     # files that `git diff` alone misses.
@@ -277,6 +293,10 @@ PY
         ended="$(date +%s)"
         duration=$((ended - started))
         local status
+        # rc=2 here can only mean forbidden_paths: the other rc=2 source
+        # (_autofix_open_pr_for query failure) takes the early `continue`
+        # above and never reaches _run_autofix_concern. Keep that early-out
+        # if refactoring, or this mapping becomes ambiguous.
         case "${rc}" in
             0) status="opened_pr" ;;
             65) status="no_diff" ;;

--- a/scripts/automated_maintenance/lib/dashboard.py
+++ b/scripts/automated_maintenance/lib/dashboard.py
@@ -22,10 +22,10 @@ from pathlib import Path
 #   - check statuses (`pass`, `fail`, `skip`, `error`) come from
 #     `maint_run_check` in `checks.sh` and `maint_run_doc_drift` in
 #     `doc_drift.sh` (`status` field in `results.json`).
-#   - autofix statuses (`opened_pr`, `no_diff`, `forbidden_paths`, `timeout`,
-#     `error`, `skipped_existing_pr`, `skipped_query_failed`) come from
-#     `maint_run_autofix` in `autofix.sh` (per-concern under `autofix.<concern>`
-#     in `results.json`).
+#   - autofix statuses (`opened_pr`, `no_diff`, `forbidden_paths`,
+#     `path_gate_error`, `timeout`, `error`, `skipped_existing_pr`,
+#     `skipped_query_failed`) come from `maint_run_autofix` in `autofix.sh`
+#     (per-concern under `autofix.<concern>` in `results.json`).
 # If you add a new status on either side, also add it here — unmapped
 # statuses fall through to the grey `unknown` color silently.
 STATUS_COLOR = {
@@ -40,6 +40,7 @@ STATUS_COLOR = {
     "forbidden_paths": "#c53030",
     "skipped_existing_pr": "#718096",  # benign: a fix is already in review
     "skipped_query_failed": "#dd6b20",  # operational: couldn't reach GitHub
+    "path_gate_error": "#dd6b20",  # operational: path_gate.py couldn't classify
 }
 
 CSS = """

--- a/scripts/automated_maintenance/lib/dashboard.py
+++ b/scripts/automated_maintenance/lib/dashboard.py
@@ -22,9 +22,10 @@ from pathlib import Path
 #   - check statuses (`pass`, `fail`, `skip`, `error`) come from
 #     `maint_run_check` in `checks.sh` and `maint_run_doc_drift` in
 #     `doc_drift.sh` (`status` field in `results.json`).
-#   - autofix statuses (`opened_pr`, `no_diff`, `forbidden_paths`,
-#     `timeout`, `skip`, `error`) come from `maint_run_autofix` in
-#     `autofix.sh` (`autofix.status` in `results.json`).
+#   - autofix statuses (`opened_pr`, `no_diff`, `forbidden_paths`, `timeout`,
+#     `error`, `skipped_existing_pr`, `skipped_query_failed`) come from
+#     `maint_run_autofix` in `autofix.sh` (per-concern under `autofix.<concern>`
+#     in `results.json`).
 # If you add a new status on either side, also add it here — unmapped
 # statuses fall through to the grey `unknown` color silently.
 STATUS_COLOR = {
@@ -37,6 +38,8 @@ STATUS_COLOR = {
     "no_diff": "#718096",
     "timeout": "#dd6b20",
     "forbidden_paths": "#c53030",
+    "skipped_existing_pr": "#718096",  # benign: a fix is already in review
+    "skipped_query_failed": "#dd6b20",  # operational: couldn't reach GitHub
 }
 
 CSS = """
@@ -113,9 +116,13 @@ def autofix_items(autofix: dict | None) -> list[tuple[str, dict]]:
     """
     if not isinstance(autofix, dict) or not autofix:
         return []
-    if "status" in autofix:  # legacy single-object shape
-        return [("autofix", autofix)]
-    return list(autofix.items())
+    # Per-concern shape: every value is itself a dict (the concern's entry).
+    # Legacy single-object shape ({"status": ..., "pr_url": ...}) has scalar
+    # values — discriminate on that rather than a magic key name, so a future
+    # concern literally named "status" can't be misread as legacy.
+    if all(isinstance(v, dict) for v in autofix.values()):
+        return list(autofix.items())
+    return [("autofix", autofix)]
 
 
 def load_runs(runs_dir: Path) -> list[dict]:

--- a/scripts/automated_maintenance/lib/dashboard.py
+++ b/scripts/automated_maintenance/lib/dashboard.py
@@ -104,6 +104,20 @@ def read_log_tail(path: Path, max_bytes: int = _LOG_TAIL_BYTES) -> str:
         return f.read().decode("utf-8", errors="replace")
 
 
+def autofix_items(autofix: dict | None) -> list[tuple[str, dict]]:
+    """Normalize the results.json `autofix` field to a list of (concern, entry).
+
+    Current shape is per-concern: ``{"doc_drift": {...}, "dev_checks": {...}}``.
+    The legacy shape was a single object (``{"status": ..., "pr_url": ...}``);
+    map it to one ``("autofix", entry)`` pair so old runs still render.
+    """
+    if not isinstance(autofix, dict) or not autofix:
+        return []
+    if "status" in autofix:  # legacy single-object shape
+        return [("autofix", autofix)]
+    return list(autofix.items())
+
+
 def load_runs(runs_dir: Path) -> list[dict]:
     runs = []
     if not runs_dir.exists():
@@ -130,12 +144,14 @@ def render_index(runs: list[dict]) -> str:
         check_pills = " ".join(
             f'<span title="{html.escape(n)}">{pill(c.get("status", "unknown"))}</span>' for n, c in checks.items()
         )
-        autofix = r.get("autofix") or {}
-        af_html = ""
-        if autofix:
-            af_html = pill(autofix.get("status", "unknown"))
-            if autofix.get("pr_url"):
-                af_html = f'<a href="{html.escape(autofix["pr_url"])}">{af_html}</a>'
+        af_parts = []
+        for cname, a in autofix_items(r.get("autofix")):
+            p = pill(a.get("status", "unknown"))
+            link = a.get("pr_url") or a.get("existing_pr")
+            if link:
+                p = f'<a href="{html.escape(link)}">{p}</a>'
+            af_parts.append(f'<span title="{html.escape(cname)}">{p}</span>')
+        af_html = " ".join(af_parts)
         rows.append(
             f"""<tr>
               <td><a class="run-link" href="runs/{html.escape(rid)}.html">{html.escape(rid)}</a></td>
@@ -202,24 +218,28 @@ def render_run(r: dict) -> str:
             </section>"""
         )
 
-    autofix = r.get("autofix") or {}
-    af_section = ""
-    if autofix:
-        af_log = r["_dir"] / "autofix_session.log"
-        af_log_text = read_log_tail(af_log)
-        af_summary = r["_dir"] / "autofix_summary.md"
+    af_blocks = []
+    for cname, a in autofix_items(r.get("autofix")):
+        # Per-concern artifacts use a .<concern> suffix; the legacy single
+        # object used unsuffixed names.
+        suffix = "" if cname == "autofix" else f".{cname}"
+        af_log = r["_dir"] / f"autofix_session{suffix}.log"
+        af_log_text = read_log_tail(af_log) if af_log.exists() else ""
+        af_summary = r["_dir"] / f"autofix_summary{suffix}.md"
         af_summary_text = af_summary.read_text() if af_summary.exists() else ""
-        pr = autofix.get("pr_url")
-        pr_link = f'<p>PR: <a href="{html.escape(pr)}">{html.escape(pr)}</a></p>' if pr else ""
-        af_section = f"""<section>
-          <h2>autofix {pill(autofix.get("status", "unknown"))}</h2>
-          <p class="check-meta">duration {autofix.get("duration_s", "?")}s
-             · exit {autofix.get("exit_code", "?")}</p>
+        link = a.get("pr_url") or a.get("existing_pr")
+        pr_link = f'<p>PR: <a href="{html.escape(link)}">{html.escape(link)}</a></p>' if link else ""
+        af_blocks.append(
+            f"""<section>
+          <h2>autofix · {html.escape(cname)} {pill(a.get("status", "unknown"))}</h2>
+          <p class="check-meta">duration {a.get("duration_s", "?")}s
+             · exit {a.get("exit_code", "?")}</p>
           {pr_link}
           {f"<details open><summary>Summary</summary><pre>{html.escape(af_summary_text)}</pre></details>" if af_summary_text else ""}
-          <details><summary>Session log ({len(af_log_text)} chars, tail)</summary>
-          <pre>{html.escape(af_log_text)}</pre></details>
+          {f"<details><summary>Session log ({len(af_log_text)} chars, tail)</summary><pre>{html.escape(af_log_text)}</pre></details>" if af_log_text else ""}
         </section>"""
+        )
+    af_section = "".join(af_blocks)
 
     return f"""<!doctype html>
 <html><head>

--- a/tests/luthien_proxy/unit_tests/automated_maintenance/test_dashboard.py
+++ b/tests/luthien_proxy/unit_tests/automated_maintenance/test_dashboard.py
@@ -185,7 +185,7 @@ def test_render_run_legacy_autofix_section(tmp_path):
     assert "https://x/pr/legacy" in html_out
 
 
-@pytest.mark.parametrize("status", ["skipped_existing_pr", "skipped_query_failed"])
+@pytest.mark.parametrize("status", ["skipped_existing_pr", "skipped_query_failed", "path_gate_error"])
 def test_new_autofix_statuses_have_distinct_colors(status):
     """New autofix statuses are mapped — they must not fall through to grey unknown."""
     assert status in dashboard.STATUS_COLOR

--- a/tests/luthien_proxy/unit_tests/automated_maintenance/test_dashboard.py
+++ b/tests/luthien_proxy/unit_tests/automated_maintenance/test_dashboard.py
@@ -91,6 +91,49 @@ def test_render_index_includes_run_pills_and_links(tmp_path):
     assert "opened_pr" in html_out
 
 
+def test_autofix_items_normalizes_shapes():
+    # Legacy single-object → one ("autofix", entry) pair.
+    legacy = {"status": "opened_pr", "pr_url": "u"}
+    assert dashboard.autofix_items(legacy) == [("autofix", legacy)]
+    # Per-concern dict → one pair per concern.
+    per_concern = {
+        "doc_drift": {"status": "opened_pr", "pr_url": "u1"},
+        "dev_checks": {"status": "skipped_existing_pr", "existing_pr": "u2"},
+    }
+    assert dashboard.autofix_items(per_concern) == list(per_concern.items())
+    # Empty / missing → no items.
+    assert dashboard.autofix_items(None) == []
+    assert dashboard.autofix_items({}) == []
+
+
+def test_render_index_per_concern_autofix(tmp_path):
+    _write_run(
+        tmp_path,
+        "2026-05-09-080000",
+        overall="fail",
+        checks={
+            "doc_drift": {"status": "fail", "log": "d.log", "duration_s": 5, "exit_code": 1},
+            "dev_checks": {"status": "fail", "log": "c.log", "duration_s": 9, "exit_code": 1},
+        },
+        autofix={
+            "doc_drift": {"status": "opened_pr", "duration_s": 80, "exit_code": 0, "pr_url": "https://x/pr/1"},
+            "dev_checks": {
+                "status": "skipped_existing_pr",
+                "duration_s": 0,
+                "exit_code": 0,
+                "existing_pr": "https://x/pr/2",
+            },
+        },
+    )
+    runs = dashboard.load_runs(tmp_path)
+    html_out = dashboard.render_index(runs)
+    # Both concerns' statuses and their distinct PR links are surfaced.
+    assert "opened_pr" in html_out
+    assert "skipped_existing_pr" in html_out
+    assert "https://x/pr/1" in html_out
+    assert "https://x/pr/2" in html_out
+
+
 def test_render_run_uses_report_field_for_link(tmp_path):
     run = _write_run(
         tmp_path,

--- a/tests/luthien_proxy/unit_tests/automated_maintenance/test_dashboard.py
+++ b/tests/luthien_proxy/unit_tests/automated_maintenance/test_dashboard.py
@@ -104,6 +104,11 @@ def test_autofix_items_normalizes_shapes():
     # Empty / missing → no items.
     assert dashboard.autofix_items(None) == []
     assert dashboard.autofix_items({}) == []
+    # Edge case the discriminator exists for: a concern literally named
+    # "status" whose value is a dict → per-concern (NOT legacy), because the
+    # discriminator keys on value type, not the key name.
+    concern_named_status = {"status": {"status": "opened_pr", "pr_url": "u"}}
+    assert dashboard.autofix_items(concern_named_status) == [("status", {"status": "opened_pr", "pr_url": "u"})]
 
 
 def test_render_index_per_concern_autofix(tmp_path):
@@ -145,7 +150,12 @@ def test_render_run_per_concern_autofix_sections(tmp_path):
         },
         autofix={
             "doc_drift": {"status": "opened_pr", "duration_s": 80, "exit_code": 0, "pr_url": "https://x/pr/1"},
-            "dev_checks": {"status": "skipped_existing_pr", "duration_s": 0, "exit_code": 0, "existing_pr": "https://x/pr/2"},
+            "dev_checks": {
+                "status": "skipped_existing_pr",
+                "duration_s": 0,
+                "exit_code": 0,
+                "existing_pr": "https://x/pr/2",
+            },
         },
     )
     (run / "autofix_session.doc_drift.log").write_text("DOC DRIFT SESSION LOG")

--- a/tests/luthien_proxy/unit_tests/automated_maintenance/test_dashboard.py
+++ b/tests/luthien_proxy/unit_tests/automated_maintenance/test_dashboard.py
@@ -134,6 +134,55 @@ def test_render_index_per_concern_autofix(tmp_path):
     assert "https://x/pr/2" in html_out
 
 
+def test_render_run_per_concern_autofix_sections(tmp_path):
+    """Each concern's session log maps via its `.<concern>` suffix on disk."""
+    run = _write_run(
+        tmp_path,
+        "2026-05-09-080000",
+        checks={
+            "doc_drift": {"status": "fail", "log": "doc_drift.log", "duration_s": 5, "exit_code": 1},
+            "dev_checks": {"status": "fail", "log": "dev_checks.log", "duration_s": 9, "exit_code": 1},
+        },
+        autofix={
+            "doc_drift": {"status": "opened_pr", "duration_s": 80, "exit_code": 0, "pr_url": "https://x/pr/1"},
+            "dev_checks": {"status": "skipped_existing_pr", "duration_s": 0, "exit_code": 0, "existing_pr": "https://x/pr/2"},
+        },
+    )
+    (run / "autofix_session.doc_drift.log").write_text("DOC DRIFT SESSION LOG")
+    (run / "autofix_session.dev_checks.log").write_text("DEV CHECKS SESSION LOG")
+    runs = dashboard.load_runs(tmp_path)
+    html_out = dashboard.render_run(runs[0])
+    # Both concerns render their own section, log, and PR link.
+    assert "DOC DRIFT SESSION LOG" in html_out
+    assert "DEV CHECKS SESSION LOG" in html_out
+    assert "https://x/pr/1" in html_out
+    assert "https://x/pr/2" in html_out
+    assert "skipped_existing_pr" in html_out
+
+
+def test_render_run_legacy_autofix_section(tmp_path):
+    """Legacy single-object autofix reads the unsuffixed autofix_session.log."""
+    run = _write_run(
+        tmp_path,
+        "2026-05-09-080000",
+        checks={"doc_drift": {"status": "fail", "log": "d.log", "duration_s": 5, "exit_code": 1}},
+        autofix={"status": "opened_pr", "duration_s": 80, "exit_code": 0, "pr_url": "https://x/pr/legacy"},
+    )
+    (run / "autofix_session.log").write_text("LEGACY SESSION LOG")
+    runs = dashboard.load_runs(tmp_path)
+    html_out = dashboard.render_run(runs[0])
+    assert "LEGACY SESSION LOG" in html_out
+    assert "https://x/pr/legacy" in html_out
+
+
+@pytest.mark.parametrize("status", ["skipped_existing_pr", "skipped_query_failed"])
+def test_new_autofix_statuses_have_distinct_colors(status):
+    """New autofix statuses are mapped — they must not fall through to grey unknown."""
+    assert status in dashboard.STATUS_COLOR
+    assert dashboard.STATUS_COLOR[status] != dashboard.STATUS_COLOR["unknown"]
+    assert dashboard.STATUS_COLOR[status] in dashboard.pill(status)
+
+
 def test_render_run_uses_report_field_for_link(tmp_path):
     run = _write_run(
         tmp_path,


### PR DESCRIPTION
## Summary

Autofix previously bundled **every** failing check into one multi-concern PR, and had no dedup — so a persistently-failing check (e.g. doc_drift) would open a near-duplicate PR every night. This reworks it to honor "one PR = one concern" and "novel issues get their own PR."

Each failing check is a **concern**. Per run, for each failing concern:
- Run a focused fix session (brief scoped to just that check) on its own branch `maint-fix/<concern>/<run_id>`.
- Open a **single-concern** draft PR titled `maint-fix(<concern>): <run_id>`.
- **Dedup per concern:** if an autofix PR for that concern is already open (`head:maint-fix/<concern>/`), skip it — no duplicate while a fix is in review. A *different*, novel concern still gets its own PR.
- **Fail closed:** if the GitHub query errors, skip the concern rather than risk a duplicate submission.

## Changes

- `lib/autofix.sh` — rewritten: `maint_run_autofix` loops over failing concerns; `_run_autofix_concern` does the focused session + single-concern PR; `_autofix_open_pr_for` is the per-concern dedup check; `_autofix_record` writes per-concern results. Forbidden-path gate, budget/timeout caps, identity, and orphan-branch cleanup all preserved (now per concern).
- `lib/dashboard.py` — `results.json.autofix` is now keyed by concern; renders a pill + PR link per concern. `autofix_items()` normalizes and stays backward-compatible with the legacy single-object shape.
- `test_dashboard.py` — tests for the normalizer + per-concern index rendering.
- `README.md` — autofix section updated to per-concern (incl. that worst-case spend scales with failing-concern count, since the budget cap is per session).

## Schema change

`results.json` `autofix` goes from a single object to a dict keyed by concern:
```json
"autofix": {
  "doc_drift":  {"status": "opened_pr", "exit_code": 0, "duration_s": 80, "pr_url": "..."},
  "dev_checks": {"status": "skipped_existing_pr", "existing_pr": "..."}
}
```
Both `dashboard.py` and the clai reporter handle old + new shapes.

## Test / validation

- `uv run pytest tests/luthien_proxy/unit_tests/automated_maintenance/` → all pass
- `shellcheck lib/autofix.sh` → clean
- `./scripts/dev_checks.sh` → green
- The *current* (pre-this-PR) autofix was validated end-to-end tonight: it opened #789 fixing 5 doc-drift findings. This PR changes how that PR would be structured (per-concern) going forward.

## Deploy note

Branch scheme changes to `maint-fix/<concern>/<run_id>`. PR #789 (old scheme `maint-fix/<run_id>`) won't be recognized by the new per-concern dedup, so **merge or close #789 before this deploys** to avoid one cross-scheme doc_drift duplicate.

## Notes / possible follow-ups

- "Concern" granularity is **per failing check** (doc_drift = one PR for all stale-doc fixes). If a doc_drift PR proves too broad, it could later be split per-finding.
- Per-concern sessions run serially, each with its own `AUTOFIX_MAX_BUDGET_USD`/`AUTOFIX_TIMEOUT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)