### PR TITLE
maint-fix(doc_drift): 2026-05-29-043000

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,7 +126,7 @@ All live in `src/luthien_proxy/policies/`:
 | `dogfood_safety_policy.DogfoodSafetyPolicy` | Safety rails used when the gateway is dogfooding itself. |
 | `multi_serial_policy.MultiSerialPolicy` | Runs multiple policies sequentially; drives composition via `policy_composition.compose_policy`. |
 | `onboarding_policy.OnboardingPolicy` / `hackathon_onboarding_policy.HackathonOnboardingPolicy` | Welcome-and-guide policies used during first-run flows. |
-| `hackathon_policy_template.HackathonPolicyTemplate` | Template scaffolding for hackathon participants. |
+| `hackathon_policy_template.HackathonPolicy` | Template scaffolding for hackathon participants. |
 | `sample_pydantic_policy.SamplePydanticPolicy` | Example showing Pydantic-model-based config. |
 | `simple_noop_policy.SimpleNoOpPolicy` | `SimplePolicy` demo passthrough. |
 | `presets/` | Ready-made presets (`block_dangerous_commands`, `block_sensitive_file_writes`, `block_web_requests`, `no_apologies`, `no_yapping`, `plain_dashes`, `prefer_uv`). |
@@ -287,7 +287,7 @@ All policies inherit from `BasePolicy`. It provides:
 - `active_policy_names()` returning this policy's leaf names (multi-policies recurse; `NoOpPolicy` returns `[]`).
 - `get_config()` auto-extracts configuration from Pydantic-model instance attributes.
 - `freeze_configured_state()` — load-time check that rejects mutable container attributes on the instance (policies are singletons shared across concurrent requests).
-- Policies that make their own backend calls (judges) declare an `auth_provider` in config (`user_credentials`, `{"server_key": ...}`, or `{"user_then_server": ...}`) and resolve it via `CredentialManager.resolve(provider, context)` at call time.
+- Policies that make their own backend calls (judges) declare an `inference_provider` in config (`user_credentials`, `{"provider": ...}`, or `{"user_then_provider": ...}`) and resolve it via `resolve_inference_provider(ref, context, registry)` (`inference/dispatch.py`) at call time.
 
 ### AnthropicExecutionInterface
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Luthien catches the violation and auto-corrects. No human intervention needed.
 policy:
   class: "luthien_proxy.policies.simple_llm_policy:SimpleLLMPolicy"
   config:
-    model: "anthropic/claude-haiku-4-5-20251001"
+    model: "claude-haiku-4-5-20251001"
     instructions: |
       Review each response from Claude against these two checks:
       1. Did Claude do what the user asked? Flag responses that drop
@@ -216,12 +216,12 @@ POLICY_CONFIG=./config/policy_config.yaml
 
 ```bash
 # Configuration for judge-based policies (ToolCallJudgePolicy)
-LLM_JUDGE_MODEL=anthropic/claude-haiku-4-5-20251001   # Model for judge
+LLM_JUDGE_MODEL=claude-haiku-4-5-20251001   # Model for judge
 ```
 
 Judge credentials are no longer configured via env — each judge policy declares an
-`auth_provider` in its YAML config (`user_credentials`, `{"server_key": <name>}`, or
-`{"user_then_server": <name>}`).
+`inference_provider` in its YAML config (`user_credentials`, `{"provider": <name>}`, or
+`{"user_then_provider": <name>}`).
 
 See `.env.example` for all available options and defaults.
 
@@ -235,7 +235,7 @@ Example policy configuration:
 policy:
   class: "luthien_proxy.policies.tool_call_judge_policy:ToolCallJudgePolicy"
   config:
-    model: "anthropic/claude-haiku-4-5-20251001"  # swap for a larger model if needed
+    model: "claude-haiku-4-5-20251001"  # swap for a larger model if needed
     probability_threshold: 0.6  # block when judge LLM's subjective risk score >= 0.6 (higher = more permissive)
     temperature: 0.0
     max_tokens: 256


### PR DESCRIPTION
Automated fix attempt for the **doc_drift** check, from maintenance run 2026-05-29-043000.

This PR addresses a single concern (doc_drift). Other failing checks, if any,
get their own PRs.

See `autofix_summary.doc_drift.md` and `autofix_session.doc_drift.log` in
`/Users/jai/.luthien/automated_maintenance/runs/2026-05-29-043000/` for details.

**Review carefully** — these changes are not human-authored.

---
*Posted by automated autofix*