### PR TITLE
maint-fix(doc_drift): 2026-05-30-043001

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -118,7 +118,7 @@ All live in `src/luthien_proxy/policies/`:
 |--------|--------------|
 | `noop_policy.NoOpPolicy` | Pass-through. Default. |
 | `all_caps_policy.AllCapsPolicy` | Uppercases all text content (uses `TextModifierPolicy`). |
-| `string_replacement_policy.StringReplacementPolicy` | Regex-based text substitution. |
+| `string_replacement_policy.StringReplacementPolicy` | Literal string find-and-replace (optional case-insensitive matching). |
 | `simple_llm_policy.SimpleLLMPolicy` | Calls a judge LLM to rewrite or approve responses. |
 | `tool_call_judge_policy.ToolCallJudgePolicy` | Uses a judge LLM to allow/block tool calls; persists decisions to `conversation_judge_decisions`. |
 | `debug_logging_policy.DebugLoggingPolicy` | Writes request/response payloads to `debug_logs` for inspection. |

--- a/changelog.d/maint-fix-doc-drift-2026-05-30.md
+++ b/changelog.d/maint-fix-doc-drift-2026-05-30.md
@@ -1,0 +1,6 @@
+---
+category: Chores & Docs
+pr: 792
+---
+
+**ARCHITECTURE.md doc-drift fix**: Corrected the StringReplacementPolicy description from "Regex-based text substitution" to literal string find-and-replace, matching the code and README.md


### PR DESCRIPTION
Automated fix attempt for the **doc_drift** check, from maintenance run 2026-05-30-043001.

This PR addresses a single concern (doc_drift). Other failing checks, if any,
get their own PRs.

See `autofix_summary.doc_drift.md` and `autofix_session.doc_drift.log` in
`/Users/jai/.luthien/automated_maintenance/runs/2026-05-30-043001/` for details.

**Review carefully** — these changes are not human-authored.

---
*Posted by automated autofix*