### PR TITLE
docs: surface GitHub and feedback links in README setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Luthien sits in line as a transparent proxy. Every request and response flows th
 
 No Docker required. The install command at the top of this page installs [`uv`](https://docs.astral.sh/uv/) (if needed) and the Luthien CLI, sets up the gateway with SQLite, walks you through configuration, and starts the proxy.
 
-> :speech_balloon: **Luthien is in active development.** Once you're up and running, please tell us what's working and what isn't on the [feedback page](https://luthien.cc/feedback/). Star or watch the [GitHub repo](https://github.com/LuthienResearch/luthien-proxy) to follow updates and report issues.
+> :speech_balloon: **Luthien is in active development.** Want to try it and help us out in the process? The [feedback guide](https://luthien.cc/feedback/) explains what kind of feedback is most useful, so we can learn what worked and what didn't. Star or watch the [GitHub repo](https://github.com/LuthienResearch/luthien-proxy) to follow updates and report issues.
 
 > **Claude Pro/Max users**: You don't need an API key. Luthien passes your existing Claude subscription credentials through to the Anthropic API — no extra cost, no configuration needed.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Luthien catches the violation and auto-corrects. No human intervention needed.
 
 > :rotating_light: Luthien is in active development. [Star this repo](https://github.com/LuthienResearch/luthien-proxy) to follow updates, or [Watch > Releases](https://github.com/LuthienResearch/luthien-proxy/subscription) to get notified on new versions.
 >
-> Found a bug or have a question? [Open an issue](https://github.com/LuthienResearch/luthien-proxy/issues) or [send us feedback](https://luthien.cc/feedback/).
+> Want to try it and help us out in the process? The [feedback guide](https://luthien.cc/feedback/) explains what kind of feedback is most useful, so we can learn what worked and what didn't.
+>
+> Found a bug or have a question? [Open an issue](https://github.com/LuthienResearch/luthien-proxy/issues).
 
 ---
 
@@ -116,8 +118,6 @@ Luthien sits in line as a transparent proxy. Every request and response flows th
 ## Quick Start
 
 No Docker required. The install command at the top of this page installs [`uv`](https://docs.astral.sh/uv/) (if needed) and the Luthien CLI, sets up the gateway with SQLite, walks you through configuration, and starts the proxy.
-
-> :speech_balloon: **Luthien is in active development.** Want to try it and help us out in the process? The [feedback guide](https://luthien.cc/feedback/) explains what kind of feedback is most useful, so we can learn what worked and what didn't. Star or watch the [GitHub repo](https://github.com/LuthienResearch/luthien-proxy) to follow updates and report issues.
 
 > **Claude Pro/Max users**: You don't need an API key. Luthien passes your existing Claude subscription credentials through to the Anthropic API — no extra cost, no configuration needed.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Luthien catches the violation and auto-corrects. No human intervention needed.
 
 > :rotating_light: Luthien is in active development. [Star this repo](https://github.com/LuthienResearch/luthien-proxy) to follow updates, or [Watch > Releases](https://github.com/LuthienResearch/luthien-proxy/subscription) to get notified on new versions.
 >
-> Found a bug or have a question? [Open an issue](https://github.com/LuthienResearch/luthien-proxy/issues).
+> Found a bug or have a question? [Open an issue](https://github.com/LuthienResearch/luthien-proxy/issues) or [send us feedback](https://luthien.cc/feedback/).
 
 ---
 
@@ -116,6 +116,8 @@ Luthien sits in line as a transparent proxy. Every request and response flows th
 ## Quick Start
 
 No Docker required. The install command at the top of this page installs [`uv`](https://docs.astral.sh/uv/) (if needed) and the Luthien CLI, sets up the gateway with SQLite, walks you through configuration, and starts the proxy.
+
+> :speech_balloon: **Luthien is in active development.** Once you're up and running, please tell us what's working and what isn't on the [feedback page](https://luthien.cc/feedback/). Star or watch the [GitHub repo](https://github.com/LuthienResearch/luthien-proxy) to follow updates and report issues.
 
 > **Claude Pro/Max users**: You don't need an API key. Luthien passes your existing Claude subscription credentials through to the Anthropic API — no extra cost, no configuration needed.
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Luthien catches the violation and auto-corrects. No human intervention needed.
 
 > :rotating_light: Luthien is in active development. [Star this repo](https://github.com/LuthienResearch/luthien-proxy) to follow updates, or [Watch > Releases](https://github.com/LuthienResearch/luthien-proxy/subscription) to get notified on new versions.
 >
-> Want to try it and help us out in the process? The [feedback guide](https://luthien.cc/feedback/) explains what kind of feedback is most useful, so we can learn what worked and what didn't.
->
 > Found a bug or have a question? [Open an issue](https://github.com/LuthienResearch/luthien-proxy/issues).
+>
+> Want to try it and help us out in the process? The [feedback guide](https://luthien.cc/feedback/) explains what kind of feedback is most useful.
 
 ---
 

--- a/changelog.d/readme-github-feedback-links.md
+++ b/changelog.d/readme-github-feedback-links.md
@@ -1,0 +1,5 @@
+---
+category: Chores & Docs
+---
+
+**README: surface GitHub and feedback links in setup**: Added an active-development callout to Quick Start that points to the [feedback page](https://luthien.cc/feedback/) and the GitHub repo, and linked the feedback page from the active-development note.


### PR DESCRIPTION
## What

Surface the GitHub repo and the [feedback page](https://luthien.cc/feedback/) in the README setup instructions, with an active-development caveat.

- New callout in **Quick Start**: active-development note pointing readers to the feedback page and the GitHub repo once they're up and running.
- Added the feedback page link to the existing active-development note near the top.

## Why

Part of Scott's beta-funnel decision: keep Tally for inbound capture, protect the personal calendar link (not exposed anywhere), and make the GitHub link + feedback page prominent in the setup path so users can self-serve and tell us what's breaking during active development.

## Scope

Docs only. No code, no behavior change. Changelog fragment included (`Chores & Docs`).
