### PR TITLE
fix: emit clean client error instead of bricking the session when the streaming validator detects a corrupted outbound stream

### DIFF
--- a/changelog.d/clean-error-on-corrupted-stream.md
+++ b/changelog.d/clean-error-on-corrupted-stream.md
@@ -1,5 +1,6 @@
 ---
 category: Fixes
+pr: 800
 ---
 
 **Corrupted outbound streams now fail with a clean client error instead of bricking the session**: the streaming protocol validator is enforced per-event in the pipeline (previously log-and-warn after the fact). When an outbound event violates Anthropic streaming event ordering (e.g. content blocks after `message_delta`, the PR #356 bug class), the proxy withholds the corrupting event, emits a structured SSE `error` event the client can parse, and ends the stream. The turn fails cleanly and the session stays usable; previously the corrupted stream was forwarded, the client reconstructed a malformed assistant message, and every subsequent request in the session returned 400.

--- a/changelog.d/clean-error-on-corrupted-stream.md
+++ b/changelog.d/clean-error-on-corrupted-stream.md
@@ -1,0 +1,7 @@
+---
+category: Fixes
+---
+
+**Corrupted outbound streams now fail with a clean client error instead of bricking the session**: the streaming protocol validator is enforced per-event in the pipeline (previously log-and-warn after the fact). When an outbound event violates Anthropic streaming event ordering (e.g. content blocks after `message_delta`, the PR #356 bug class), the proxy withholds the corrupting event, emits a structured SSE `error` event the client can parse, and ends the stream. The turn fails cleanly and the session stays usable; previously the corrupted stream was forwarded, the client reconstructed a malformed assistant message, and every subsequent request in the session returned 400.
+  - End-of-stream rules (`message_stop` last, all blocks closed) remain advisory log-and-warn: they are only decidable after every event has already been forwarded.
+  - Recorded as a `streaming.protocol_violation` policy event with `aborted: true`.

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -58,7 +58,10 @@ from luthien_proxy.pipeline.session import (
     extract_user_id_from_authorization_header,
     extract_user_id_from_headers,
 )
-from luthien_proxy.pipeline.stream_protocol_validator import validate_anthropic_event_ordering
+from luthien_proxy.pipeline.stream_protocol_validator import (
+    StreamingProtocolValidator,
+    StreamViolation,
+)
 from luthien_proxy.pipeline.upstream_headers import expand_upstream_headers, merge_forwarded_headers
 from luthien_proxy.policy_core.anthropic_execution_interface import (
     AnthropicExecutionInterface,
@@ -739,8 +742,10 @@ async def _handle_execution_streaming(
             emitted_any = False
             stream_completed = False
             cancelled = False
+            protocol_aborted = False
             final_status = 200
             accumulated_events: list[MessageStreamEvent] = []
+            protocol_validator = StreamingProtocolValidator()
             with tracer.start_as_current_span("process_response") as response_span:
                 response_span.set_attribute("luthien.phase", "process_response")
                 response_span.set_attribute("luthien.streaming", True)
@@ -755,12 +760,64 @@ async def _handle_execution_streaming(
                                     "not full response objects."
                                 )
                             io.ensure_request_recorded()
-                            emitted_any = True
                             cast_emitted = cast(MessageStreamEvent, emitted)
+                            # Incremental protocol enforcement: check the event
+                            # BEFORE forwarding it. A corrupted outbound stream
+                            # (e.g. content blocks after message_delta, the
+                            # PR #356 bug class) must never reach the client —
+                            # the client would reconstruct a malformed assistant
+                            # message, resend it on every subsequent turn, and
+                            # brick the session with persistent 400s. Instead we
+                            # withhold the corrupting event, emit a structured
+                            # error event the client can parse, and end the
+                            # stream. The turn fails cleanly; the session
+                            # stays usable.
+                            violations = protocol_validator.observe(cast_emitted)
+                            if violations:
+                                protocol_aborted = True
+                                final_status = 500
+                                violation_details = [
+                                    {"rule": v.rule, "message": v.message, "event_index": v.event_index}
+                                    for v in violations
+                                ]
+                                logger.error(
+                                    "[%s] Streaming protocol violation detected mid-stream; "
+                                    "withholding corrupted event and emitting client error event: %s",
+                                    call_id,
+                                    violation_details,
+                                )
+                                policy_ctx.record_event(
+                                    "streaming.protocol_violation",
+                                    {
+                                        "summary": (
+                                            "Outbound stream violates Anthropic event ordering; "
+                                            "stream aborted with structured client error event"
+                                        ),
+                                        "violations": violation_details,
+                                        "aborted": True,
+                                    },
+                                )
+                                response_span.set_attribute("streaming.protocol_valid", False)
+                                yield _format_sse_event(_build_protocol_violation_error_event(violations, call_id))
+                                break
+                            emitted_any = True
                             accumulated_events.append(cast_emitted)
                             chunk_count += 1
                             yield _format_sse_event(cast_emitted)
-                    stream_completed = True
+                    stream_completed = not protocol_aborted
+                    if protocol_aborted:
+                        # Close the policy emission generator promptly so the
+                        # policy/backend stops producing; otherwise it stays
+                        # suspended until garbage collection.
+                        aclose = getattr(emissions, "aclose", None)
+                        if aclose is not None:
+                            try:
+                                await aclose()
+                            except Exception:
+                                logger.exception(
+                                    "[%s] Failed to close policy emission stream after protocol abort",
+                                    call_id,
+                                )
                 except asyncio.CancelledError:
                     # CancelledError is BaseException; without this branch
                     # cancelled-before-emit would mis-classify as empty-stream
@@ -811,7 +868,13 @@ async def _handle_execution_streaming(
                     # emitted nothing." Both are server-side empty deliveries
                     # from the receiver's POV, so 500 is defensible — flagged
                     # for clarity, not a code change.
-                    is_empty_stream = not emitted_any and not caught_exception and not cancelled
+                    # protocol_aborted is excluded: the abort path already
+                    # yielded its own structured error event; yielding the
+                    # empty-stream error too would send the client two error
+                    # events for one failure.
+                    is_empty_stream = (
+                        not emitted_any and not caught_exception and not cancelled and not protocol_aborted
+                    )
                     if is_empty_stream:
                         io.ensure_request_recorded()
                         logger.warning(
@@ -856,7 +919,12 @@ async def _handle_execution_streaming(
                     # empty-stream branch), to avoid reporting a false success
                     # for a partial delivery. Cancelled-before-emit hits
                     # `not emitted_any` and fires with success=False, http_status=499.
-                    if stream_completed or caught_exception or not emitted_any:
+                    # protocol_aborted is included: the client received a
+                    # well-formed error event (clean delivery of a failed
+                    # turn), so the webhook fires with success=False,
+                    # http_status=500 — same accounting as the mid-stream
+                    # exception path.
+                    if stream_completed or caught_exception or protocol_aborted or not emitted_any:
                         # Belt for the load-bearing-comment below: if both
                         # `stream_completed` and `not emitted_any` are true,
                         # `final_status` MUST already be 500 from the
@@ -889,28 +957,35 @@ async def _handle_execution_streaming(
                             http_status=final_status,
                         )
 
-                    # Validate streaming protocol compliance (log-and-warn).
-                    # Only validate complete streams — partial/error streams will
-                    # always fail completeness checks (missing message_stop, etc.)
-                    # and produce noisy false positives.
+                    # End-of-stream protocol checks (log-and-warn). Per-event
+                    # ordering rules are ENFORCED inline above (corrupted event
+                    # withheld, structured error event emitted, stream aborted).
+                    # The rules checked here — message_stop last, all blocks
+                    # closed — are only decidable once the stream has ended,
+                    # when every event has already been forwarded, so they
+                    # cannot gate forwarding and stay advisory.
                     #
-                    # Validation is **advisory**: a malformed stream that was still
-                    # delivered to the client keeps `success=True, http_status=200`
-                    # in the webhook payload. The bytes did get sent; the
-                    # protocol issue is for operator/policy debugging, not
-                    # delivery accounting. Consumers wanting strict
-                    # protocol-conformant accounting should also subscribe to
-                    # the `streaming.protocol_violation` event from the emitter.
+                    # Only checked for complete streams — partial/error streams
+                    # will always fail completeness checks (missing
+                    # message_stop, etc.) and produce noisy false positives.
+                    #
+                    # Advisory means: a stream flagged here was still delivered,
+                    # so the webhook keeps `success=True, http_status=200`. The
+                    # bytes did get sent; the protocol issue is for
+                    # operator/policy debugging, not delivery accounting.
+                    # Consumers wanting strict protocol-conformant accounting
+                    # should also subscribe to the
+                    # `streaming.protocol_violation` event from the emitter.
                     if accumulated_events and final_status == 200:
                         # Wrap so SDK shape drift / a validator regression
                         # can't propagate into the cleanup path and skip
                         # recorder.flush + downstream emitter calls.
                         try:
-                            validation = validate_anthropic_event_ordering(accumulated_events)
-                            if not validation.valid:
+                            end_of_stream_violations = protocol_validator.finalize()
+                            if end_of_stream_violations:
                                 violation_details = [
                                     {"rule": v.rule, "message": v.message, "event_index": v.event_index}
-                                    for v in validation.violations
+                                    for v in end_of_stream_violations
                                 ]
                                 logger.warning(
                                     "[%s] Streaming protocol violation detected: %s",
@@ -1213,6 +1288,38 @@ def _build_error_event(e: Exception, call_id: str) -> _StreamErrorEvent:
         error=_ErrorDetail(
             type=error_type,
             message=message,
+        ),
+    )
+
+
+def _build_protocol_violation_error_event(violations: list[StreamViolation], call_id: str) -> _StreamErrorEvent:
+    """Build a client-parseable error event for a corrupted outbound stream.
+
+    Emitted mid-stream (HTTP headers already sent, so no HTTP error is
+    possible) when the incremental protocol validator detects an event that
+    violates Anthropic's streaming event ordering. The corrupting event is
+    never forwarded; the client receives this error event instead and fails
+    the turn cleanly, rather than reconstructing a malformed assistant
+    message that bricks the session (the PR #356 failure mode).
+
+    Args:
+        violations: Violations detected for the withheld event.
+        call_id: Transaction ID, included so users can report the failure
+                 and operators can find the matching log/trace records.
+
+    Returns:
+        Error event dict in Anthropic's error-event format.
+    """
+    rules = ", ".join(sorted({v.rule for v in violations}))
+    return _StreamErrorEvent(
+        type="error",
+        error=_ErrorDetail(
+            type="api_error",
+            message=(
+                f"Luthien proxy detected a corrupted response stream (protocol violation: {rules}) "
+                "and stopped it before it reached your client. This response was not delivered; "
+                f"please retry the request. (transaction: {call_id})"
+            ),
         ),
     )
 

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -808,7 +808,10 @@ async def _handle_execution_streaming(
                     if protocol_aborted:
                         # Close the policy emission generator promptly so the
                         # policy/backend stops producing; otherwise it stays
-                        # suspended until garbage collection.
+                        # suspended until garbage collection. getattr guard:
+                        # emissions is typed AsyncIterator, which does not
+                        # guarantee aclose (a manually-implemented __aiter__
+                        # object would lack it); async generators always have it.
                         aclose = getattr(emissions, "aclose", None)
                         if aclose is not None:
                             try:
@@ -1008,7 +1011,14 @@ async def _handle_execution_streaming(
                     if policy_ctx.response_summary:
                         root_span.set_attribute("luthien.policy.response_summary", policy_ctx.response_summary)
 
-                    if reconstructed is not None:
+                    # protocol_aborted excluded: on abort, `reconstructed` is
+                    # only the clean prefix of a response that was never
+                    # delivered. Recording it as streaming_response_recorded
+                    # would let downstream consumers (history, activity
+                    # monitor) mistake a partial, undelivered response for a
+                    # delivered one; the `streaming.protocol_violation` event
+                    # with aborted=true is the authoritative record instead.
+                    if reconstructed is not None and not protocol_aborted:
                         # Use raw backend events for original response if buffered,
                         # Trade-off: for streaming requests, raw events are NOT buffered
                         # separately (_AnthropicPolicyIO sets _buffer_raw_events=not is_streaming).
@@ -1317,8 +1327,8 @@ def _build_protocol_violation_error_event(violations: list[StreamViolation], cal
             type="api_error",
             message=(
                 f"Luthien proxy detected a corrupted response stream (protocol violation: {rules}) "
-                "and stopped it before it reached your client. This response was not delivered; "
-                f"please retry the request. (transaction: {call_id})"
+                "and stopped it before it could corrupt this session. The response was not delivered. "
+                f"If retrying hits the same error, report transaction {call_id} to your administrator."
             ),
         ),
     )

--- a/src/luthien_proxy/pipeline/stream_protocol_validator.py
+++ b/src/luthien_proxy/pipeline/stream_protocol_validator.py
@@ -248,6 +248,11 @@ class StreamingProtocolValidator:
         """Return violations only decidable at end of stream.
 
         Rules: stream non-empty, message_stop last, all started blocks stopped.
+
+        Only well-defined for streams that were intended to complete. A stream
+        aborted mid-flight (e.g. after a protocol violation) will always fail
+        these completeness rules; callers should skip finalize() for aborted
+        streams to avoid double-reporting the same failure.
         """
         if self._event_count == 0:
             return [

--- a/src/luthien_proxy/pipeline/stream_protocol_validator.py
+++ b/src/luthien_proxy/pipeline/stream_protocol_validator.py
@@ -83,90 +83,86 @@ def _get_block_index(event: dict | object) -> int | None:
     return getattr(event, "index", None)
 
 
-def validate_anthropic_event_ordering(
-    events: list,
-) -> StreamValidationResult:
-    """Validate that a list of Anthropic streaming events follows protocol ordering.
+class StreamingProtocolValidator:
+    """Incremental Anthropic streaming protocol validator.
 
-    Args:
-        events: List of event dicts or Pydantic model objects. Each must have
-                a ``type`` field/attribute.
+    Feed events one at a time via ``observe()``; each call returns the
+    violations introduced by that event, BEFORE the caller forwards it.
+    This is what enables mid-stream enforcement: the pipeline can detect a
+    corrupted outbound stream and emit a clean client error event instead of
+    forwarding the corrupting event (the PR #356 session-bricking class).
 
-    Returns:
-        StreamValidationResult with any violations found.
+    Call ``finalize()`` after the last event for the end-of-stream rules
+    (stream non-empty, message_stop last, all blocks closed). Those rules are
+    only decidable once the stream has ended, so they cannot gate forwarding.
+
+    ``validate_anthropic_event_ordering()`` is the batch wrapper over this
+    class; both share the same rule definitions.
     """
-    result = StreamValidationResult()
 
-    if not events:
-        result.violations.append(
-            StreamViolation(
-                rule="non_empty",
-                message="Event stream is empty",
-                event_index=-1,
-                event_type="(none)",
-            )
-        )
-        return result
+    def __init__(self) -> None:
+        """Initialize validator state for a fresh stream."""
+        self._event_count = 0
+        self._message_delta_index: int | None = None
+        self._started_blocks: set[int] = set()
+        self._stopped_blocks: set[int] = set()
+        self._highest_start_index = -1
+        self._last_event_type: str | None = None
+        self._last_event_index = -1
 
-    event_types = [_get_event_type(e) for e in events]
+    def observe(self, event: dict | object) -> list[StreamViolation]:
+        """Record one event and return any violations it introduces.
 
-    # --- Rule 1: message_start must be first ---
-    if event_types[0] != "message_start":
-        result.violations.append(
-            StreamViolation(
-                rule="message_start_first",
-                message=f"First event must be message_start, got {event_types[0]!r}",
-                event_index=0,
-                event_type=event_types[0] or "(unknown)",
-            )
-        )
+        Args:
+            event: Event dict or Pydantic model with a ``type`` field/attribute.
 
-    # --- Rule 2: message_stop must be last ---
-    if event_types[-1] != "message_stop":
-        result.violations.append(
-            StreamViolation(
-                rule="message_stop_last",
-                message=f"Last event must be message_stop, got {event_types[-1]!r}",
-                event_index=len(events) - 1,
-                event_type=event_types[-1] or "(unknown)",
-            )
-        )
+        Returns:
+            Violations detectable at this event (empty list if the event is
+            protocol-conformant so far).
+        """
+        i = self._event_count
+        self._event_count += 1
+        t = _get_event_type(event)
+        self._last_event_type = t
+        self._last_event_index = i
 
-    # --- Rule 3: All content_block_* events must precede message_delta ---
-    message_delta_idx = None
-    for i, t in enumerate(event_types):
-        if t == "message_delta":
-            message_delta_idx = i
-            break
+        violations: list[StreamViolation] = []
 
-    if message_delta_idx is not None:
-        for i, t in enumerate(event_types):
-            if t in _CONTENT_BLOCK_EVENTS and i > message_delta_idx:
-                result.violations.append(
-                    StreamViolation(
-                        rule="content_before_message_delta",
-                        message=(
-                            f"Content block event at position {i} "
-                            f"appears after message_delta at position {message_delta_idx}"
-                        ),
-                        event_index=i,
-                        event_type=t,
-                    )
+        # --- Rule 1: message_start must be first ---
+        if i == 0 and t != "message_start":
+            violations.append(
+                StreamViolation(
+                    rule="message_start_first",
+                    message=f"First event must be message_start, got {t!r}",
+                    event_index=0,
+                    event_type=t or "(unknown)",
                 )
+            )
 
-    # --- Rule 4: Block lifecycle (start → delta(s) → stop) ---
-    # Track which blocks have been started and stopped
-    started_blocks: set[int] = set()
-    stopped_blocks: set[int] = set()
-    highest_start_index = -1
+        if t == "message_delta" and self._message_delta_index is None:
+            self._message_delta_index = i
 
-    for i, (event, t) in enumerate(zip(events, event_types)):
         if t not in _CONTENT_BLOCK_EVENTS:
-            continue
+            return violations
 
+        # --- Rule 3: All content_block_* events must precede message_delta ---
+        if self._message_delta_index is not None and i > self._message_delta_index:
+            violations.append(
+                StreamViolation(
+                    rule="content_before_message_delta",
+                    message=(
+                        f"Content block event at position {i} "
+                        f"appears after message_delta at position {self._message_delta_index}"
+                    ),
+                    event_index=i,
+                    event_type=t,
+                )
+            )
+
+        # --- Rule 4: Block lifecycle (start → delta(s) → stop) ---
         idx = _get_block_index(event)
         if idx is None:
-            result.violations.append(
+            violations.append(
                 StreamViolation(
                     rule="block_index_present",
                     message="Content block event missing index field",
@@ -174,12 +170,12 @@ def validate_anthropic_event_ordering(
                     event_type=t or "(unknown)",
                 )
             )
-            continue
+            return violations
 
         if t == "content_block_start":
             # Rule 5: Block indices must be non-negative and monotonically increasing for starts
             if idx < 0:
-                result.violations.append(
+                violations.append(
                     StreamViolation(
                         rule="block_index_non_negative",
                         message=f"Block index {idx} is negative",
@@ -187,25 +183,26 @@ def validate_anthropic_event_ordering(
                         event_type=t,
                     )
                 )
-            if idx <= highest_start_index:
-                result.violations.append(
+            if idx <= self._highest_start_index:
+                violations.append(
                     StreamViolation(
                         rule="block_start_monotonic",
                         message=(
-                            f"Block start index {idx} is not greater than previous start index {highest_start_index}"
+                            f"Block start index {idx} is not greater than "
+                            f"previous start index {self._highest_start_index}"
                         ),
                         event_index=i,
                         event_type=t,
                     )
                 )
             if idx >= 0:
-                highest_start_index = idx
-            started_blocks.add(idx)
+                self._highest_start_index = idx
+            self._started_blocks.add(idx)
 
         elif t == "content_block_delta":
             # Rule 6: No delta without a preceding start
-            if idx not in started_blocks:
-                result.violations.append(
+            if idx not in self._started_blocks:
+                violations.append(
                     StreamViolation(
                         rule="delta_after_start",
                         message=f"content_block_delta for index {idx} without preceding start",
@@ -214,8 +211,8 @@ def validate_anthropic_event_ordering(
                     )
                 )
             # No delta after stop
-            if idx in stopped_blocks:
-                result.violations.append(
+            if idx in self._stopped_blocks:
+                violations.append(
                     StreamViolation(
                         rule="delta_before_stop",
                         message=f"content_block_delta for index {idx} after it was already stopped",
@@ -225,8 +222,8 @@ def validate_anthropic_event_ordering(
                 )
 
         elif t == "content_block_stop":
-            if idx not in started_blocks:
-                result.violations.append(
+            if idx not in self._started_blocks:
+                violations.append(
                     StreamViolation(
                         rule="stop_after_start",
                         message=f"content_block_stop for index {idx} without preceding start",
@@ -234,8 +231,8 @@ def validate_anthropic_event_ordering(
                         event_type=t,
                     )
                 )
-            if idx in stopped_blocks:
-                result.violations.append(
+            if idx in self._stopped_blocks:
+                violations.append(
                     StreamViolation(
                         rule="block_stopped_once",
                         message=f"content_block_stop for index {idx} but block was already stopped",
@@ -243,18 +240,71 @@ def validate_anthropic_event_ordering(
                         event_type=t,
                     )
                 )
-            stopped_blocks.add(idx)
+            self._stopped_blocks.add(idx)
 
-    # All started blocks should be stopped (before message_delta)
-    unclosed = started_blocks - stopped_blocks
-    if unclosed:
-        result.violations.append(
-            StreamViolation(
-                rule="blocks_closed",
-                message=f"Content blocks started but never stopped: {sorted(unclosed)}",
-                event_index=len(events) - 1,
-                event_type="(end of stream)",
+        return violations
+
+    def finalize(self) -> list[StreamViolation]:
+        """Return violations only decidable at end of stream.
+
+        Rules: stream non-empty, message_stop last, all started blocks stopped.
+        """
+        if self._event_count == 0:
+            return [
+                StreamViolation(
+                    rule="non_empty",
+                    message="Event stream is empty",
+                    event_index=-1,
+                    event_type="(none)",
+                )
+            ]
+
+        violations: list[StreamViolation] = []
+
+        # --- Rule 2: message_stop must be last ---
+        if self._last_event_type != "message_stop":
+            violations.append(
+                StreamViolation(
+                    rule="message_stop_last",
+                    message=f"Last event must be message_stop, got {self._last_event_type!r}",
+                    event_index=self._last_event_index,
+                    event_type=self._last_event_type or "(unknown)",
+                )
             )
-        )
 
+        # All started blocks should be stopped (before message_delta)
+        unclosed = self._started_blocks - self._stopped_blocks
+        if unclosed:
+            violations.append(
+                StreamViolation(
+                    rule="blocks_closed",
+                    message=f"Content blocks started but never stopped: {sorted(unclosed)}",
+                    event_index=self._last_event_index,
+                    event_type="(end of stream)",
+                )
+            )
+
+        return violations
+
+
+def validate_anthropic_event_ordering(
+    events: list,
+) -> StreamValidationResult:
+    """Validate that a list of Anthropic streaming events follows protocol ordering.
+
+    Batch wrapper over StreamingProtocolValidator: observes every event in
+    order, then applies the end-of-stream rules.
+
+    Args:
+        events: List of event dicts or Pydantic model objects. Each must have
+                a ``type`` field/attribute.
+
+    Returns:
+        StreamValidationResult with any violations found.
+    """
+    result = StreamValidationResult()
+    validator = StreamingProtocolValidator()
+    for event in events:
+        result.violations.extend(validator.observe(event))
+    result.violations.extend(validator.finalize())
     return result

--- a/tests/luthien_proxy/fixtures/anthropic_stream_validator.py
+++ b/tests/luthien_proxy/fixtures/anthropic_stream_validator.py
@@ -5,9 +5,15 @@ This module re-exports everything so existing test imports continue to work.
 """
 
 from luthien_proxy.pipeline.stream_protocol_validator import (
+    StreamingProtocolValidator,
     StreamValidationResult,
     StreamViolation,
     validate_anthropic_event_ordering,
 )
 
-__all__ = ["StreamValidationResult", "StreamViolation", "validate_anthropic_event_ordering"]
+__all__ = [
+    "StreamingProtocolValidator",
+    "StreamValidationResult",
+    "StreamViolation",
+    "validate_anthropic_event_ordering",
+]

--- a/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
@@ -1102,6 +1102,17 @@ class TestProtocolViolationAbortsStream:
             usage={"output_tokens": 5},  # type: ignore[arg-type]
         )
 
+    @staticmethod
+    def _recorded_event_types(emitter) -> list[str]:
+        """Event types recorded on the emitter (robust to args vs kwargs call style)."""
+        types = []
+        for recorded_call in emitter.record.call_args_list:
+            if len(recorded_call.args) > 1:
+                types.append(recorded_call.args[1])
+            else:
+                types.append(recorded_call.kwargs.get("event_type"))
+        return types
+
     async def _collect_stream_chunks(self, mock_policy, backend_events: list, emitter) -> list[str]:
         """Run a streaming request through the pipeline and collect SSE chunks."""
         anthropic_body: AnthropicRequest = {
@@ -1175,9 +1186,11 @@ class TestProtocolViolationAbortsStream:
         assert not any('"index": 1' in c for c in chunks)
         assert not any("event: message_stop" in c for c in chunks)
 
-        # The violation was recorded for observability.
-        recorded_event_types = [call.args[1] for call in emitter.record.call_args_list]
+        # The violation was recorded for observability, and the partial
+        # (undelivered) response was NOT recorded as a delivered response.
+        recorded_event_types = self._recorded_event_types(emitter)
         assert "streaming.protocol_violation" in recorded_event_types
+        assert "transaction.streaming_response_recorded" not in recorded_event_types
 
     @pytest.mark.asyncio
     async def test_corrupted_first_event_yields_exactly_one_error_event(self, mock_policy):
@@ -1219,8 +1232,9 @@ class TestProtocolViolationAbortsStream:
         assert not any("event: error" in c for c in chunks)
         assert "event: message_stop" in chunks[-1]
 
-        recorded_event_types = [call.args[1] for call in emitter.record.call_args_list]
+        recorded_event_types = self._recorded_event_types(emitter)
         assert "streaming.protocol_violation" not in recorded_event_types
+        assert "transaction.streaming_response_recorded" in recorded_event_types
 
 
 class TestHandleAnthropicError:

--- a/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
@@ -1046,6 +1046,183 @@ class TestEmptyStreamErrorEvent:
         assert "policy evaluation unavailable" in last_event
 
 
+class TestProtocolViolationAbortsStream:
+    """Corrupted outbound streams are aborted with a structured client error.
+
+    COE follow-up for PR #356: the streaming protocol validator used to be
+    log-and-warn only, so a corrupted stream (content blocks after
+    message_delta) was silently forwarded, the client reconstructed a
+    malformed assistant message, and the session was bricked with persistent
+    400s. Now the corrupting event is withheld and the client receives a
+    well-formed SSE error event instead, so the turn fails cleanly and the
+    session stays usable.
+    """
+
+    @pytest.fixture
+    def mock_policy(self):
+        return NoOpPolicy()
+
+    @staticmethod
+    def _message_start_event() -> RawMessageStartEvent:
+        return RawMessageStartEvent(
+            type="message_start",
+            message={  # type: ignore[arg-type]
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": "claude-3-5-sonnet-20241022",
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            },
+        )
+
+    @staticmethod
+    def _text_block_events(index: int) -> list:
+        return [
+            RawContentBlockStartEvent(
+                type="content_block_start",
+                index=index,
+                content_block={"type": "text", "text": ""},  # type: ignore[arg-type]
+            ),
+            RawContentBlockDeltaEvent(
+                type="content_block_delta",
+                index=index,
+                delta=TextDelta(type="text_delta", text="hi"),
+            ),
+            RawContentBlockStopEvent(type="content_block_stop", index=index),
+        ]
+
+    @staticmethod
+    def _message_delta_event() -> RawMessageDeltaEvent:
+        return RawMessageDeltaEvent(
+            type="message_delta",
+            delta={"stop_reason": "end_turn", "stop_sequence": None},  # type: ignore[arg-type]
+            usage={"output_tokens": 5},  # type: ignore[arg-type]
+        )
+
+    async def _collect_stream_chunks(self, mock_policy, backend_events: list, emitter) -> list[str]:
+        """Run a streaming request through the pipeline and collect SSE chunks."""
+        anthropic_body: AnthropicRequest = {
+            "model": DEFAULT_TEST_MODEL,
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 1024,
+            "stream": True,
+        }
+
+        async def backend_stream(req, extra_headers=None):
+            for event in backend_events:
+                yield event
+
+        mock_client = MagicMock()
+        mock_client.stream = backend_stream
+
+        mock_fastapi_request = MagicMock()
+        mock_fastapi_request.headers = {}
+        mock_fastapi_request.method = "POST"
+        mock_fastapi_request.url = MagicMock()
+        mock_fastapi_request.url.path = "/v1/messages"
+        mock_fastapi_request.json = AsyncMock(return_value=anthropic_body)
+
+        with patch("luthien_proxy.pipeline.anthropic_processor.tracer") as mock_tracer:
+            mock_span = MagicMock()
+            mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
+            mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
+
+            response = await process_anthropic_request(
+                request=mock_fastapi_request,
+                policy=mock_policy,
+                anthropic_client=mock_client,
+                emitter=emitter,
+            )
+
+            chunks = []
+            async for chunk in response.body_iterator:
+                chunks.append(chunk)
+        return chunks
+
+    @pytest.mark.asyncio
+    async def test_corrupted_stream_yields_error_event_and_withholds_corrupted_events(self, mock_policy):
+        """The PR #356 fixture: content block injected after message_delta."""
+        corrupted_events = [
+            self._message_start_event(),
+            *self._text_block_events(0),
+            self._message_delta_event(),
+            # Corruption: a second content block AFTER message_delta.
+            *self._text_block_events(1),
+            RawMessageStopEvent(type="message_stop"),
+        ]
+        emitter = MagicMock()
+
+        chunks = await self._collect_stream_chunks(mock_policy, corrupted_events, emitter)
+
+        # The clean prefix (message_start .. message_delta) was forwarded.
+        assert sum(1 for c in chunks if "event: message_start" in c) == 1
+        assert sum(1 for c in chunks if "event: message_delta" in c) == 1
+
+        # The stream ends with exactly one well-formed error event.
+        error_chunks = [c for c in chunks if "event: error" in c]
+        assert len(error_chunks) == 1
+        assert chunks[-1] == error_chunks[0]
+        error_payload = json.loads(error_chunks[0].split("data: ", 1)[1])
+        assert error_payload["type"] == "error"
+        assert error_payload["error"]["type"] == "api_error"
+        assert "corrupted response stream" in error_payload["error"]["message"]
+        assert "content_before_message_delta" in error_payload["error"]["message"]
+
+        # The corrupting events were withheld: no block-1 events, no message_stop.
+        assert not any('"index": 1' in c for c in chunks)
+        assert not any("event: message_stop" in c for c in chunks)
+
+        # The violation was recorded for observability.
+        recorded_event_types = [call.args[1] for call in emitter.record.call_args_list]
+        assert "streaming.protocol_violation" in recorded_event_types
+
+    @pytest.mark.asyncio
+    async def test_corrupted_first_event_yields_exactly_one_error_event(self, mock_policy):
+        """A violation on the first event must not also trigger the empty-stream error."""
+        corrupted_events = [
+            # Corruption: stream starts with a delta (no message_start, no block start).
+            RawContentBlockDeltaEvent(
+                type="content_block_delta",
+                index=0,
+                delta=TextDelta(type="text_delta", text="hi"),
+            ),
+        ]
+        emitter = MagicMock()
+
+        chunks = await self._collect_stream_chunks(mock_policy, corrupted_events, emitter)
+
+        error_chunks = [c for c in chunks if "event: error" in c]
+        assert len(error_chunks) == 1
+        assert len(chunks) == 1  # nothing else was forwarded
+        error_payload = json.loads(error_chunks[0].split("data: ", 1)[1])
+        assert error_payload["error"]["type"] == "api_error"
+        assert "corrupted response stream" in error_payload["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_healthy_stream_is_unaffected(self, mock_policy):
+        """A protocol-conformant stream passes through with no error event."""
+        healthy_events = [
+            self._message_start_event(),
+            *self._text_block_events(0),
+            *self._text_block_events(1),
+            self._message_delta_event(),
+            RawMessageStopEvent(type="message_stop"),
+        ]
+        emitter = MagicMock()
+
+        chunks = await self._collect_stream_chunks(mock_policy, healthy_events, emitter)
+
+        assert len(chunks) == len(healthy_events)
+        assert not any("event: error" in c for c in chunks)
+        assert "event: message_stop" in chunks[-1]
+
+        recorded_event_types = [call.args[1] for call in emitter.record.call_args_list]
+        assert "streaming.protocol_violation" not in recorded_event_types
+
+
 class TestHandleAnthropicError:
     """Tests for _handle_anthropic_error error classification.
 
@@ -2141,11 +2318,24 @@ class TestStreamingWebhookGate:
 
     @staticmethod
     def _make_event() -> MessageStreamEvent:
-        """Build a minimal valid MessageStreamEvent for streaming."""
-        return RawContentBlockDeltaEvent(
-            type="content_block_delta",
-            index=0,
-            delta=TextDelta(type="text_delta", text="hi"),
+        """Build a protocol-valid opening stream event (message_start).
+
+        Must be protocol-valid: the pipeline enforces streaming protocol
+        ordering and aborts corrupted streams with a client error event,
+        which would change the webhook-gate outcomes these tests lock in.
+        """
+        return RawMessageStartEvent(
+            type="message_start",
+            message={  # type: ignore[arg-type]
+                "id": "msg_gate",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": "claude-3-5-sonnet-20241022",
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            },
         )
 
     @staticmethod
@@ -2274,8 +2464,16 @@ class TestStreamingWebhookGate:
 
         async def emissions():
             yield self._make_event()
-            yield self._make_event()
-            yield self._make_event()
+            yield RawContentBlockStartEvent(
+                type="content_block_start",
+                index=0,
+                content_block={"type": "text", "text": ""},  # type: ignore[arg-type]
+            )
+            yield RawContentBlockDeltaEvent(
+                type="content_block_delta",
+                index=0,
+                delta=TextDelta(type="text_delta", text="hi"),
+            )
 
         io, span, ctx, recorder, emitter = self._make_deps()
         webhook = MagicMock()
@@ -2638,10 +2836,20 @@ class TestWebhookFireIsolation:
         from luthien_proxy.pipeline.anthropic_processor import _handle_execution_streaming
 
         async def emissions():
-            yield RawContentBlockDeltaEvent(
-                type="content_block_delta",
-                index=0,
-                delta=TextDelta(type="text_delta", text="hi"),
+            # Protocol-valid opening event; a corrupted stream would divert
+            # into the protocol-abort path and change the webhook payload.
+            yield RawMessageStartEvent(
+                type="message_start",
+                message={  # type: ignore[arg-type]
+                    "id": "msg_iso",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": "claude-3-5-sonnet-20241022",
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 0, "output_tokens": 0},
+                },
             )
 
         io = MagicMock()

--- a/tests/luthien_proxy/unit_tests/test_anthropic_stream_validator.py
+++ b/tests/luthien_proxy/unit_tests/test_anthropic_stream_validator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from tests.luthien_proxy.fixtures.anthropic_stream_validator import (
+    StreamingProtocolValidator,
     StreamValidationResult,
     validate_anthropic_event_ordering,
 )
@@ -251,6 +252,68 @@ class TestEdgeCases:
         result = StreamValidationResult()
         assert result.valid is True
         assert result.violations == []
+
+
+# -- Incremental validator (mid-stream enforcement) ----------------------------
+
+
+class TestStreamingProtocolValidatorIncremental:
+    """The incremental validator flags a violation ON the offending event.
+
+    This is the property the pipeline relies on to withhold a corrupting
+    event before it reaches the client (COE follow-up for PR #356).
+    """
+
+    def test_valid_stream_no_violations_per_event(self):
+        validator = StreamingProtocolValidator()
+        for event in _valid_parallel_tool_stream(3):
+            assert validator.observe(event) == []
+        assert validator.finalize() == []
+
+    def test_ping_events_are_tolerated(self):
+        validator = StreamingProtocolValidator()
+        events = [_msg_start(), {"type": "ping"}, *_text_block(0), _msg_delta(), _msg_stop()]
+        for event in events:
+            assert validator.observe(event) == []
+        assert validator.finalize() == []
+
+    def test_content_block_after_message_delta_flagged_on_offending_event(self):
+        """The PR #356 bug class: the violation surfaces exactly at the corrupting event."""
+        validator = StreamingProtocolValidator()
+        clean_prefix = [_msg_start(), *_text_block(0), _msg_delta()]
+        for event in clean_prefix:
+            assert validator.observe(event) == []
+
+        violations = validator.observe(_block_start(1))
+        assert [v.rule for v in violations] == ["content_before_message_delta"]
+
+    def test_delta_without_start_flagged_on_offending_event(self):
+        validator = StreamingProtocolValidator()
+        assert validator.observe(_msg_start()) == []
+        violations = validator.observe(_block_delta(0))
+        assert any(v.rule == "delta_after_start" for v in violations)
+
+    def test_non_message_start_first_event_flagged_immediately(self):
+        validator = StreamingProtocolValidator()
+        violations = validator.observe(_block_delta(0))
+        rules = {v.rule for v in violations}
+        assert "message_start_first" in rules
+
+    def test_finalize_flags_missing_message_stop(self):
+        validator = StreamingProtocolValidator()
+        for event in [_msg_start(), *_text_block(0), _msg_delta()]:
+            assert validator.observe(event) == []
+        assert any(v.rule == "message_stop_last" for v in validator.finalize())
+
+    def test_finalize_flags_unclosed_block(self):
+        validator = StreamingProtocolValidator()
+        for event in [_msg_start(), _block_start(0), _block_delta(0), _msg_delta(), _msg_stop()]:
+            assert validator.observe(event) == []
+        assert any(v.rule == "blocks_closed" for v in validator.finalize())
+
+    def test_finalize_flags_empty_stream(self):
+        validator = StreamingProtocolValidator()
+        assert [v.rule for v in validator.finalize()] == ["non_empty"]
 
 
 # -- Works with Pydantic model objects (unit test style) -----------------------


### PR DESCRIPTION
## Summary

COE follow-up for PR #356, escalating the PR #426 streaming protocol validator from log-and-warn to enforcement. Trello: [COE audit: Emit a clean client error instead of bricking the session when the streaming validator detects a corrupted outbound stream](https://trello.com/c/S8moAYO6)

- New `StreamingProtocolValidator` class (incremental: `observe()` per event + `finalize()` at end of stream) in `stream_protocol_validator.py`. The existing batch `validate_anthropic_event_ordering()` is now a thin wrapper over it, so there is exactly one rule set; all 21 pre-existing validator tests pass unchanged.
- `_handle_execution_streaming` validates each outbound event BEFORE forwarding it. On a violation (out-of-order events, the PR #356 bug class) the pipeline:
  1. withholds the corrupting event (it never reaches the client),
  2. emits a structured SSE `error` event (`{"type": "error", "error": {"type": "api_error", "message": "Luthien proxy detected a corrupted response stream (protocol violation: <rules>) ... (transaction: <call_id>)"}}`) that Anthropic-protocol clients parse as a normal API error,
  3. ends the stream and closes the policy emission generator.
- The client fails the turn cleanly instead of reconstructing a malformed assistant message, so the session stays usable (no persistent 400s, no `/rewind` needed).
- Recorded as `streaming.protocol_violation` policy event with `aborted: true`; webhook fires with `success=False, http_status=500` (same accounting as the mid-stream exception path).
- End-of-stream rules (`message_stop` last, all blocks closed, non-empty) stay advisory log-and-warn: they are only decidable after every event has already been forwarded, so they cannot gate forwarding.

### Definition of done (from the Trello card)

- [x] When the streaming protocol validator detects out-of-order events, the proxy emits a structured error event to the client (not just a log warning)
- [x] The client session remains usable after receiving the error (no bricked state): the corrupting event is withheld, so the client never reconstructs a malformed assistant message; the error event fails the turn the same way the existing mid-stream exception path does
- [x] Covered by a unit test with a deliberately corrupted stream fixture (`TestProtocolViolationAbortsStream`, using the exact PR #356 corruption shape)

### Design tradeoff (load-bearing)

Enforcement means a validator false positive would now abort a healthy stream (one failed turn, client retries) instead of just logging. I judged this acceptable because the enforced rules are exact Anthropic protocol invariants with dedicated unit coverage, and the failure mode of a false positive (one clean failed turn) is strictly better than the failure mode it prevents (silently corrupted session). If we want a kill switch, a config field can gate enforcement back to log-and-warn in a follow-up; I kept this PR to the simplest enforcement per repo convention.

## RCA / COE

**Root cause:** PR #426 deliberately wired the protocol validator as log-and-warn, and it validated only after the stream completed, when every event had already been forwarded to the client. A corrupted stream (e.g. content blocks emitted after `message_delta`) was therefore delivered intact; the client (Claude Code) reconstructed a malformed assistant message, resent it as history on every subsequent request, and the API returned 400 on each: a bricked session recoverable only via `/rewind`.

**Why it wasn't caught:** it was, by design review rather than by an incident. PR #426's own description flagged the escalation path ("If we see violations in practice, we can escalate to aborting the stream to prevent session-bricking"), and the 2026-03-25 COE audit of PR #356 turned that into this tracked card. The gap was architectural: post-hoc batch validation cannot protect the client, because detection happens after forwarding. No test asserted what the client receives when the outbound stream is corrupted, only that violations were logged.

**Why it won't recur:** validation is now structural, on the forwarding path itself: every event passes `StreamingProtocolValidator.observe()` before it is yielded to the client, so any future policy bug in this class (PR #134 and PR #329/#356 were both this class) is contained at the proxy boundary regardless of whether the offending policy has test coverage. The batch validator is a wrapper over the same incremental class, so test-fixture rules and runtime-enforcement rules cannot drift apart. `TestProtocolViolationAbortsStream` locks in the client-observable contract: corrupted stream produces exactly one well-formed error event, corrupting events withheld, healthy streams untouched.

## Test plan

- [x] 8 new unit tests for the incremental validator (violation flagged on the offending event, finalize rules, ping tolerance, empty stream)
- [x] 3 new pipeline tests: PR #356 corruption fixture yields a single structured error event and withholds the corrupted tail; corrupted first event yields exactly one error event (empty-stream error suppressed); healthy stream forwarded unchanged with no error event
- [x] All 21 pre-existing validator tests pass unchanged against the refactored implementation
- [x] Full unit suite: 2851 passed
- [x] `scripts/dev_checks.sh` clean (ruff format + lint, pyright 0 errors)
- [x] Mock e2e tier passed, sqlite e2e tier passed (client-side stream validation in `test_mock_simple_llm_parallel_tools.py` exercises the enforced path end to end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
