### PR TITLE
fix(security): localhost auth bypass refuses requests with reverse-proxy forwarding headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@
 # Authentication mode: client_key, passthrough, or both (managed via /api/admin/auth/config)
 # AUTH_MODE=both
 
-# Skip admin-route authentication for requests from localhost (proxy /v1/messages auth is unaffected; disable behind a same-host reverse proxy)
+# Skip admin-route authentication for direct loopback requests; requests carrying reverse-proxy forwarding headers (X-Forwarded-For etc.) never bypass (proxy /v1/messages auth is unaffected; disable behind a same-host reverse proxy)
 # (can also be set at runtime via admin API)
 # LOCALHOST_AUTH_BYPASS=true
 

--- a/changelog.d/localhost-bypass-forwarded-headers.md
+++ b/changelog.d/localhost-bypass-forwarded-headers.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**Security: localhost auth bypass refuses proxied requests**: the localhost auth bypass no longer applies to requests that carry reverse-proxy forwarding headers (`X-Forwarded-For`, `Forwarded`, `X-Real-IP`, `X-Forwarded-Host`, `X-Forwarded-Proto`), even when the TCP source address is loopback. A same-host reverse proxy (Caddy, nginx, Traefik) previously made every external request look like 127.0.0.1 and exposed the admin/history/debug surface unauthenticated. Direct loopback requests (local curl, dockerless dev, `luthien` CLI) still bypass as before. The gateway also logs a startup warning whenever the bypass is enabled.

--- a/src/luthien_proxy/auth.py
+++ b/src/luthien_proxy/auth.py
@@ -12,12 +12,16 @@ The proxy route `/v1/messages` uses its own verify_token() in
 gateway_routes.py, which does NOT consult this module and is therefore
 unaffected by the bypass.
 
-WARNING: is_localhost_request() inspects request.client.host (TCP source
-IP) only; it does not parse X-Forwarded-For. A reverse proxy on the same
-host (Caddy, nginx, Traefik) forwards every external request as
-127.0.0.1 and silently unauths the admin API. Set
-LOCALHOST_AUTH_BYPASS=false for any such deployment. Railway disables
-the bypass automatically at startup.
+The bypass refuses any request that carries reverse-proxy forwarding
+headers (X-Forwarded-For, Forwarded, X-Real-IP, etc.), even when the TCP
+source IP is loopback. A reverse proxy on the same host (Caddy, nginx,
+Traefik) makes every external request arrive from 127.0.0.1; the
+forwarding headers those proxies attach are the signal that the true
+client is remote. A client can also set these headers directly, but that
+only *disables* the bypass for them (fail-safe). The residual risk is a
+same-host reverse proxy configured to strip/omit all forwarding headers
+— set LOCALHOST_AUTH_BYPASS=false for any reverse-proxy deployment.
+Railway disables the bypass automatically at startup.
 """
 
 from __future__ import annotations
@@ -37,6 +41,19 @@ security = HTTPBearer(auto_error=False)
 
 _LOCALHOST_IPS = ("127.0.0.1", "::1", "::ffff:127.0.0.1")
 
+# Headers a reverse proxy attaches when forwarding a request. Their presence
+# on a loopback connection means the true client is (or may be) remote, so
+# the localhost bypass must not apply. Standard proxies set at least one of
+# these by default: Caddy and Traefik set X-Forwarded-For automatically;
+# common nginx configs set X-Forwarded-For and/or X-Real-IP.
+_FORWARDING_HEADERS = (
+    "forwarded",  # RFC 7239
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-real-ip",
+)
+
 
 def is_localhost_request(request: Request) -> bool:
     """Check whether the request originates from a loopback address."""
@@ -46,11 +63,25 @@ def is_localhost_request(request: Request) -> bool:
     return client.host in _LOCALHOST_IPS
 
 
+def has_forwarding_headers(request: Request) -> bool:
+    """Check whether the request carries reverse-proxy forwarding headers."""
+    return any(header in request.headers for header in _FORWARDING_HEADERS)
+
+
 def _should_bypass_auth(request: Request) -> bool:
-    """Return True if auth can be skipped for this request."""
+    """Return True if auth can be skipped for this request.
+
+    Requires all three:
+    1. LOCALHOST_AUTH_BYPASS enabled (default true),
+    2. loopback TCP source address, and
+    3. no reverse-proxy forwarding headers — a proxied request is not
+       treated as local even though the proxy connects from 127.0.0.1.
+    """
     if not get_settings().localhost_auth_bypass:
         return False
-    return is_localhost_request(request)
+    if not is_localhost_request(request):
+        return False
+    return not has_forwarding_headers(request)
 
 
 async def verify_admin_token(
@@ -163,5 +194,6 @@ __all__ = [
     "security",
     "check_auth_or_redirect",
     "get_base_url",
+    "has_forwarding_headers",
     "is_localhost_request",
 ]

--- a/src/luthien_proxy/config_fields.py
+++ b/src/luthien_proxy/config_fields.py
@@ -99,7 +99,7 @@ CONFIG_FIELDS: tuple[ConfigFieldMeta, ...] = (
     ),
     ConfigFieldMeta(
         "localhost_auth_bypass", "LOCALHOST_AUTH_BYPASS", bool, True,
-        "Skip admin-route authentication for requests from localhost (proxy /v1/messages auth is unaffected; disable behind a same-host reverse proxy)",
+        "Skip admin-route authentication for direct loopback requests; requests carrying reverse-proxy forwarding headers (X-Forwarded-For etc.) never bypass (proxy /v1/messages auth is unaffected; disable behind a same-host reverse proxy)",
         category="auth", db_settable=True, restart_required=False,
     ),
 

--- a/src/luthien_proxy/main.py
+++ b/src/luthien_proxy/main.py
@@ -273,6 +273,14 @@ def create_app(
         elif api_key is None and _resolved_mode == "both":
             logger.info("CLIENT_API_KEY is not set — shared-key auth unavailable, using passthrough only")
 
+        if get_settings().localhost_auth_bypass:
+            logger.warning(
+                "LOCALHOST_AUTH_BYPASS is enabled — admin, history, and debug routes skip auth for "
+                "direct loopback connections, so any local process can read stored conversations. "
+                "Requests carrying reverse-proxy forwarding headers (X-Forwarded-For etc.) never "
+                "bypass, but behind a same-host reverse proxy set LOCALHOST_AUTH_BYPASS=false."
+            )
+
         # Check if request logging is enabled
         _enable_request_logging = get_settings().enable_request_logging
         if _enable_request_logging:

--- a/tests/luthien_proxy/unit_tests/test_auth.py
+++ b/tests/luthien_proxy/unit_tests/test_auth.py
@@ -19,6 +19,7 @@ from fastapi.testclient import TestClient
 
 from luthien_proxy.auth import (
     check_auth_or_redirect,
+    has_forwarding_headers,
     is_localhost_request,
     verify_admin_token,
 )
@@ -314,6 +315,109 @@ class TestIsLocalhostRequest:
         request = MagicMock()
         request.client = None
         assert is_localhost_request(request) is False
+
+
+class TestHasForwardingHeaders:
+    """Test the has_forwarding_headers helper."""
+
+    @pytest.mark.parametrize(
+        "header",
+        ["forwarded", "x-forwarded-for", "x-forwarded-host", "x-forwarded-proto", "x-real-ip"],
+    )
+    def test_each_forwarding_header_detected(self, header):
+        request = _make_localhost_request(headers={header: "203.0.113.7"})
+        assert has_forwarding_headers(request) is True
+
+    def test_no_forwarding_headers(self):
+        request = _make_localhost_request(headers={"user-agent": "curl/8.0"})
+        assert has_forwarding_headers(request) is False
+
+
+class TestLocalhostBypassRefusesProxiedRequests:
+    """Forwarding headers on a loopback connection disable the bypass.
+
+    Regression tests for the same-host reverse proxy hole: a reverse proxy
+    (Caddy/nginx/Traefik) on the gateway's host makes every external request
+    arrive from 127.0.0.1 with X-Forwarded-For set. Those requests must not
+    get the localhost auth bypass.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_settings(self):
+        clear_settings_cache()
+        yield
+        clear_settings_cache()
+
+    @pytest.mark.parametrize(
+        "headers",
+        [
+            {"x-forwarded-for": "203.0.113.7"},
+            {"forwarded": "for=203.0.113.7"},
+            {"x-real-ip": "203.0.113.7"},
+            {"x-forwarded-for": "203.0.113.7", "x-forwarded-proto": "https", "x-forwarded-host": "proxy.example.com"},
+        ],
+    )
+    def test_forwarded_localhost_request_redirects(self, monkeypatch, headers):
+        monkeypatch.setenv("LOCALHOST_AUTH_BYPASS", "true")
+        request = _make_localhost_request(path="/activity/monitor", headers=headers)
+        result = check_auth_or_redirect(request, admin_key="secret123")
+        assert isinstance(result, RedirectResponse)
+        assert result.status_code == 303
+
+    def test_forwarded_request_with_valid_key_still_authenticates(self, monkeypatch):
+        monkeypatch.setenv("LOCALHOST_AUTH_BYPASS", "true")
+        request = _make_localhost_request(
+            path="/activity/monitor",
+            headers={"x-forwarded-for": "203.0.113.7", "authorization": "Bearer secret123"},
+        )
+        assert check_auth_or_redirect(request, admin_key="secret123") is None
+
+    def test_bare_localhost_request_still_bypasses(self, monkeypatch):
+        monkeypatch.setenv("LOCALHOST_AUTH_BYPASS", "true")
+        request = _make_localhost_request(path="/activity/monitor")
+        assert check_auth_or_redirect(request, admin_key="secret123") is None
+
+
+class TestLocalhostBypassRefusesProxiedAdminApi:
+    """verify_admin_token: proxied requests get 403, direct loopback bypasses."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_settings(self):
+        clear_settings_cache()
+        yield
+        clear_settings_cache()
+
+    @pytest.fixture
+    def client_from_localhost(self, app_with_admin_key, monkeypatch):
+        """TestClient whose requests appear to originate from 127.0.0.1."""
+        monkeypatch.setenv("LOCALHOST_AUTH_BYPASS", "true")
+        clear_settings_cache()
+        return TestClient(app_with_admin_key, client=("127.0.0.1", 50000))
+
+    def test_admin_api_403_when_forwarded_header_present(self, client_from_localhost):
+        with client_from_localhost as client:
+            response = client.get("/test", headers={"x-forwarded-for": "203.0.113.7"})
+            assert response.status_code == 403
+
+    def test_admin_api_403_when_rfc7239_forwarded_present(self, client_from_localhost):
+        with client_from_localhost as client:
+            response = client.get("/test", headers={"forwarded": "for=203.0.113.7"})
+            assert response.status_code == 403
+
+    def test_admin_api_bypasses_for_bare_localhost(self, client_from_localhost):
+        with client_from_localhost as client:
+            response = client.get("/test")
+            assert response.status_code == 200
+            assert response.json()["token"] == "localhost-bypass"
+
+    def test_forwarded_request_with_valid_key_authenticates(self, client_from_localhost):
+        with client_from_localhost as client:
+            response = client.get(
+                "/test",
+                headers={"x-forwarded-for": "203.0.113.7", "Authorization": "Bearer test-admin-key"},
+            )
+            assert response.status_code == 200
+            assert response.json()["token"] == "test-admin-key"
 
 
 class TestLocalhostBypassCheckAuthOrRedirect:


### PR DESCRIPTION
**SECURITY: needs Scott's explicit review before merge.**

Fixes the high-severity localhost auth bypass hole tracked in Trello: [security: localhost auth bypass trusts TCP source IP — same-host reverse proxy exposes admin surface](https://trello.com/c/ZLYI4skA). Corroborated by finding F5 in the 2026-07-07 security/telemetry audit (luthien-org `dev/2026-07-07_security-telemetry-data-audit.md`).

## Threat model

- `is_localhost_request()` decided the auth bypass purely from `request.client.host` (TCP source IP). It never looked at forwarding headers.
- The standard self-host topology puts a reverse proxy (Caddy, nginx, Traefik) on the same host as the gateway. Every external request then arrives at the gateway from 127.0.0.1.
- With `LOCALHOST_AUTH_BYPASS=true` (the default), the entire admin surface (`/api/admin/*`, history, request logs, debug, admin UI) was served **unauthenticated to the public internet**, regardless of whether `ADMIN_API_KEY` was set. That surface is exactly where stored conversation content is readable.
- Distinct from PR #775 (admin UI fail-closed on unset key) and issue #767: the bypass short-circuits before those checks, so this hole was open even with an admin key configured.

## Chosen behavior

The bypass now requires **all three**:

1. `LOCALHOST_AUTH_BYPASS` enabled (default unchanged: `true` — see below),
2. loopback TCP source address (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`), and
3. **no reverse-proxy forwarding headers** on the request: `Forwarded` (RFC 7239), `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Proto`, `X-Real-IP`.

Why header *presence* rather than parsing the forwarded client IP: presence-detection fails safe. Caddy and Traefik always attach `X-Forwarded-For`; standard nginx configs attach `X-Forwarded-For` and/or `X-Real-IP`. A client can also set these headers themselves, but that only *disables* the bypass for that client and drops them into normal admin-key auth — an attacker cannot gain access by adding headers, and cannot strip the headers the proxy adds on the hop the gateway sees. A trusted-proxy CIDR config (option 1 on the card) would be strictly more machinery for no additional safety on this route, and gets the trust direction wrong if misconfigured.

Also added: a startup warning whenever the bypass is enabled, stating that any local process can read stored conversations and that reverse-proxy deployments should set `LOCALHOST_AUTH_BYPASS=false` (the gateway binds 0.0.0.0 unconditionally in `main.py`, so a bind-address startup guard — option 4 on the card — would fire on every deployment; the warning covers the same ground without a new config knob).

**Residual risk (documented in `auth.py`):** a same-host reverse proxy explicitly configured to strip/omit *all* forwarding headers still looks like a direct loopback client. The guidance to set `LOCALHOST_AUTH_BYPASS=false` behind any reverse proxy stays in the module docstring, the config-field description, and the startup warning.

**Default NOT changed:** `LOCALHOST_AUTH_BYPASS` still defaults to `true`. Flipping it to `false` (opt-in bypass) is the stronger long-term posture but is a breaking change to the local dev / dockerless browse-the-dashboard-without-logging-in workflow, and deserves an explicit product decision. Input for that decision: the `luthien` CLI does **not** depend on the bypass (onboard generates an `ADMIN_API_KEY` and `gateway_client.py` sends it as a Bearer token), so the flip would mainly cost browser UX — a one-time `/login` with the key from `.env`. Left as a follow-up decision on the Trello card rather than bundled here (one PR = one concern).

## What still works (unchanged behavior)

- Direct `curl http://localhost:8000/api/admin/...` from the same box, no proxy: bypass applies as before.
- `/v1/messages` proxy auth (`verify_token` in `gateway_routes.py`): never consulted this module; unaffected.
- Railway: already disables the bypass at startup; unaffected.
- Authenticating with a valid admin key or session cookie through a reverse proxy: works (the proxied request falls through to normal auth).

## RCA

- **Root cause:** the localhost check conflated "TCP peer is loopback" with "client is local." Behind a same-host reverse proxy those are different parties, and the check ignored the one signal the proxy provides to distinguish them (forwarding headers).
- **Why it wasn't caught:** the foot-gun was known and documented — the `auth.py:15-20` docstring literally described this attack — but the mitigation was left to the operator reading source comments and flipping a non-obvious env var. No test modeled the proxied topology; every bypass test used a bare loopback request. A security posture that lives only in a docstring is not a control.
- **Why it won't recur:** the dangerous topology is now handled in code, fail-safe by construction (header presence can only narrow the bypass, never widen it). Regression tests pin the proxied case for both auth paths (`verify_admin_token` → 403, `check_auth_or_redirect` → login redirect) across each forwarding header, plus bare-loopback and valid-key-through-proxy cases, so a future refactor of `_should_bypass_auth` that drops the header check fails CI.

## Tests

- New in `tests/luthien_proxy/unit_tests/test_auth.py`: `TestHasForwardingHeaders`, `TestLocalhostBypassRefusesProxiedRequests`, `TestLocalhostBypassRefusesProxiedAdminApi` — bypass works for bare localhost; refuses per forwarding header; admin API returns 403 in the proxied case; valid admin key still authenticates when proxied.
- `./scripts/dev_checks.sh` fully green: ruff format + lint, pyright (0 errors, 0 warnings), full unit + integration pytest run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
