### PR TITLE
fix: re-inject Anthropic keepalive pings on the streaming path so long generations don't idle out

### DIFF
--- a/changelog.d/anthropic-stream-keepalive.md
+++ b/changelog.d/anthropic-stream-keepalive.md
@@ -1,0 +1,6 @@
+---
+category: Fixes
+pr: 804
+---
+
+**Anthropic streaming: re-inject keepalive pings so long generations don't idle out**: The Anthropic SDK's typed stream (`messages.create(stream=True)`) drops the wire `ping` events Anthropic emits during long generations. A model that stays silent before emitting content (e.g. a slow or classifier-gated response) therefore produced no bytes on the proxy→client connection for the entire pre-content phase, so any intermediary with an idle timeout (load balancer, reverse proxy) would cut the healthy stream mid-flight. The gateway now re-emits an Anthropic-style `ping` whenever the upstream is idle longer than `STREAM_KEEPALIVE_SECONDS` (15s), matching the keepalive behavior a direct Anthropic connection relies on.

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -96,6 +96,73 @@ logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
 
+# --- Streaming keepalive ------------------------------------------------------
+# Anthropic's wire stream emits `ping` events during long generations to keep the
+# connection alive, but the Anthropic SDK's typed stream (messages.create(
+# stream=True)) drops them. Without re-injecting keepalives, a model that stays
+# silent for a long pre-content phase makes the proxy->client connection idle, and
+# an intermediary (e.g. the ALB idle timeout) cuts the stream mid-flight even
+# though the request is healthy. We emit an Anthropic-style `ping` whenever the
+# upstream produces no event within STREAM_KEEPALIVE_SECONDS.
+STREAM_KEEPALIVE_SECONDS = 15.0
+_KEEPALIVE_SSE = 'event: ping\ndata: {"type": "ping"}\n\n'
+_STREAM_DONE = object()
+
+
+class _Keepalive:
+    """Sentinel yielded by `_stream_with_keepalive` during an upstream gap."""
+
+
+_KEEPALIVE = _Keepalive()
+
+
+async def _anext_or_done(iterator: AsyncIterator[AnthropicPolicyEmission]) -> object:
+    """Return the next item, or the `_STREAM_DONE` sentinel when exhausted.
+
+    Converting StopAsyncIteration into a sentinel keeps it from propagating out of
+    the wrapped Task (and avoids PEP-479 surprises inside the async generator).
+    """
+    try:
+        return await iterator.__anext__()
+    except StopAsyncIteration:
+        return _STREAM_DONE
+
+
+async def _stream_with_keepalive(
+    source: AsyncIterator[AnthropicPolicyEmission],
+    interval_seconds: float,
+) -> AsyncIterator["AnthropicPolicyEmission | _Keepalive"]:
+    """Yield items from `source`, injecting a `_KEEPALIVE` sentinel whenever the
+    next item takes longer than `interval_seconds` to arrive.
+
+    The in-flight `__anext__` is shielded from the per-wait timeout, so a slow item
+    is never dropped: the timeout only triggers a keepalive and we keep waiting on
+    the same pending item. The pending task is cancelled on close.
+    """
+    iterator = source.__aiter__()
+    pending: asyncio.Task[object] | None = None
+    try:
+        while True:
+            if pending is None:
+                pending = asyncio.ensure_future(_anext_or_done(iterator))
+            try:
+                item = await asyncio.wait_for(asyncio.shield(pending), interval_seconds)
+            except asyncio.TimeoutError:
+                yield _KEEPALIVE
+                continue
+            pending = None
+            if item is _STREAM_DONE:
+                return
+            yield cast("AnthropicPolicyEmission", item)
+    finally:
+        if pending is not None and not pending.done():
+            pending.cancel()
+            try:
+                await pending
+            except BaseException:
+                pass
+
+
 class _AnthropicPolicyIO(AnthropicPolicyIOProtocol):
     """Request-scoped I/O helpers for execution-oriented Anthropic policies."""
 
@@ -748,7 +815,15 @@ async def _handle_execution_streaming(
                 caught_exception = False
                 try:
                     with tracer.start_as_current_span("policy_execute"):
-                        async for emitted in emissions:
+                        async for emitted in _stream_with_keepalive(emissions, STREAM_KEEPALIVE_SECONDS):
+                            if isinstance(emitted, _Keepalive):
+                                # Upstream gap: forward an Anthropic-style ping so
+                                # the connection doesn't idle out mid-generation.
+                                # Only after message_start (emitted_any) so the
+                                # wire event ordering stays intact.
+                                if emitted_any:
+                                    yield _KEEPALIVE_SSE
+                                continue
                             if _is_anthropic_response_emission(emitted):
                                 raise TypeError(
                                     "Streaming Anthropic execution policies must emit streaming events, "

--- a/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
@@ -2736,3 +2736,78 @@ class TestWebhookFireIsolation:
 
         webhook.fire_and_forget.assert_called_once()
         recorder.flush.assert_called()  # cleanup completed despite webhook failure
+
+
+
+class TestStreamWithKeepalive:
+    """`_stream_with_keepalive` injects SSE keepalives during upstream gaps without
+    dropping or reordering real events. Regression: the Anthropic SDK drops upstream
+    `ping` events, so a long silent generation idled out at the ALB timeout."""
+
+    async def test_injects_keepalive_during_gap(self):
+        from luthien_proxy.pipeline.anthropic_processor import (
+            _Keepalive,
+            _stream_with_keepalive,
+        )
+
+        async def source():
+            yield "A"
+            await asyncio.sleep(0.12)  # > interval -> keepalives expected in this gap
+            yield "B"
+
+        out = [item async for item in _stream_with_keepalive(source(), 0.02)]
+        reals = [x for x in out if not isinstance(x, _Keepalive)]
+        keepalives = [x for x in out if isinstance(x, _Keepalive)]
+        assert reals == ["A", "B"]  # order preserved, nothing dropped
+        assert len(keepalives) >= 1  # the gap produced at least one keepalive
+        assert out[0] == "A" and out[-1] == "B"  # keepalives sit between real events
+
+    async def test_no_keepalive_when_fast(self):
+        from luthien_proxy.pipeline.anthropic_processor import (
+            _Keepalive,
+            _stream_with_keepalive,
+        )
+
+        async def source():
+            yield "A"
+            yield "B"
+            yield "C"
+
+        out = [item async for item in _stream_with_keepalive(source(), 0.5)]
+        assert out == ["A", "B", "C"]
+        assert not any(isinstance(x, _Keepalive) for x in out)
+
+    async def test_empty_source_terminates(self):
+        from luthien_proxy.pipeline.anthropic_processor import _stream_with_keepalive
+
+        async def source():
+            return
+            yield  # pragma: no cover - makes this an async generator
+
+        out = [item async for item in _stream_with_keepalive(source(), 0.02)]
+        assert out == []
+
+    async def test_close_cancels_pending(self):
+        from luthien_proxy.pipeline.anthropic_processor import (
+            _Keepalive,
+            _stream_with_keepalive,
+        )
+
+        cancelled = asyncio.Event()
+
+        async def source():
+            yield "A"
+            try:
+                await asyncio.sleep(10)  # long-pending item, in flight at close
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+            yield "B"  # pragma: no cover - never reached
+
+        gen = _stream_with_keepalive(source(), 0.02)
+        assert await gen.__anext__() == "A"
+        nxt = await gen.__anext__()  # pending sleep in flight -> keepalive
+        assert isinstance(nxt, _Keepalive)
+        await gen.aclose()  # must cancel the pending __anext__, not hang
+        await asyncio.sleep(0.01)
+        assert cancelled.is_set()


### PR DESCRIPTION
## Problem
When proxying a streaming request (`messages.create(stream=True)`), the gateway can go completely silent on the client connection for the entire duration of a long generation. Any intermediary with an idle timeout (load balancer, reverse proxy, API gateway) then cuts the connection mid-stream even though the request is healthy — the client sees a truncated stream / `RemoteProtocolError` / 504 while the gateway and Anthropic both consider the request successful.

## Root cause
Anthropic's wire protocol emits periodic `event: ping` keepalives during generation (notably when a model produces no output tokens for a while — extended thinking, or a slow/gated response). The Anthropic Python SDK's typed event stream **drops these `ping` events** (they aren't part of `RawMessageStreamEvent`), so `async for event in client.messages.create(..., stream=True)` never yields them. The gateway therefore forwards nothing to the client between `message_start` and the first content event. A direct connection to `api.anthropic.com` survives the same long generation precisely because those pings keep the socket active; routed through the gateway, they're gone.

## Reproduction (observed)
A model that delivers its content in a burst near the end of a ~4-minute generation (first `content_block_delta` at ~235s), behind an intermediary with a 120s idle timeout:
- **Direct to Anthropic:** completes; max gap between received SSE events ~30s (the ping cadence).
- **Through the gateway (before):** `message_start` arrives, then silence; connection cut at ~120s (`RemoteProtocolError: peer closed connection without sending complete message body`).
- **Through the gateway (after):** max inter-event gap drops to the keepalive interval (~15s) and the stream completes normally.

## Fix
`_stream_with_keepalive` in `pipeline/anthropic_processor.py` wraps the emission stream and, whenever the upstream produces no event within `STREAM_KEEPALIVE_SECONDS` (15s), emits an Anthropic-style `event: ping` — only after `message_start`, to preserve wire event ordering. The in-flight `__anext__` is shielded from the per-wait timeout so no real event is ever dropped, and the pending read is cancelled on generator close.

## Tests
`tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py::TestStreamWithKeepalive` — 4 cases: keepalives injected during a gap without dropping/reordering real events; no keepalives when fast; empty source terminates; generator close cancels the pending read. Full processor suite passes.
