### PR TITLE
fix(sentry): never capture opentelemetry.context detach noise

### DIFF
--- a/changelog.d/sentry-ignore-otel-context-logger.md
+++ b/changelog.d/sentry-ignore-otel-context-logger.md
@@ -3,8 +3,11 @@ category: Fixes
 pr: 807
 ---
 
-Stop Sentry capturing `opentelemetry.context` "Failed to detach context" log
-noise. OTel swallows the error itself and the proxied request is unaffected,
-but via the logging integration it fired on ~every streaming request and
-exhausted the Sentry error quota within hours of enabling Sentry in
-production.
+Stop Sentry capturing OpenTelemetry's own log noise: broadened the
+`opentelemetry.context` / `opentelemetry.sdk.trace.export` ignores to the
+whole `opentelemetry.*` logger namespace. OTel already handles its own
+context-detach and exporter/collector failures and logs them itself; via the
+logging integration these fired on ~every streaming request in one case
+(~86k events in 13h) and, separately, on every collector-side export
+rejection, and together exhausted the Sentry error quota. Telemetry-pipeline
+health is the collector's own monitors' job, not Sentry's.

--- a/changelog.d/sentry-ignore-otel-context-logger.md
+++ b/changelog.d/sentry-ignore-otel-context-logger.md
@@ -1,0 +1,10 @@
+---
+category: Fixes
+pr: 807
+---
+
+Stop Sentry capturing `opentelemetry.context` "Failed to detach context" log
+noise. OTel swallows the error itself and the proxied request is unaffected,
+but via the logging integration it fired on ~every streaming request and
+exhausted the Sentry error quota within hours of enabling Sentry in
+production.

--- a/src/luthien_proxy/observability/sentry.py
+++ b/src/luthien_proxy/observability/sentry.py
@@ -142,6 +142,12 @@ def init_sentry(settings: Settings | None = None) -> None:
     # OTel exporter logs at ERROR when Tempo is unreachable — expected in
     # local dev without Docker. Don't let these burn Sentry quota.
     ignore_logger("opentelemetry.sdk.trace.export")
+    # OTel swallows context-detach failures itself ("Failed to detach context",
+    # a ValueError on cross-task token resets during streaming) and the request
+    # is unaffected. Captured through the logging integration this fired on
+    # ~every proxied request (~86k events in 13h on 2026-08-05) and exhausted
+    # the org error quota. Pure log noise — never send it.
+    ignore_logger("opentelemetry.context")
 
     sentry_sdk.init(
         dsn=settings.sentry_dsn,

--- a/src/luthien_proxy/observability/sentry.py
+++ b/src/luthien_proxy/observability/sentry.py
@@ -139,15 +139,20 @@ def init_sentry(settings: Settings | None = None) -> None:
         )
         return
 
-    # OTel exporter logs at ERROR when Tempo is unreachable — expected in
-    # local dev without Docker. Don't let these burn Sentry quota.
-    ignore_logger("opentelemetry.sdk.trace.export")
-    # OTel swallows context-detach failures itself ("Failed to detach context",
-    # a ValueError on cross-task token resets during streaming) and the request
-    # is unaffected. Captured through the logging integration this fired on
-    # ~every proxied request (~86k events in 13h on 2026-08-05) and exhausted
-    # the org error quota. Pure log noise — never send it.
-    ignore_logger("opentelemetry.context")
+    # OTel logs at ERROR for conditions that are its own concern, not ours:
+    # exporter/collector reachability (Tempo down in local dev, or the
+    # collector rejecting a batch — see LUTHIEN-C/F, which were `opentelemetry
+    # .exporter.otlp.proto.http.{trace,metric}_exporter` reporting HTTP 403
+    # from the OTel collector), and context-detach races on cross-task token
+    # resets during streaming (a ValueError OTel already catches and logs
+    # itself; the request is unaffected — this alone fired on ~every proxied
+    # request, ~86k events in 13h on 2026-08-05, and exhausted the org error
+    # quota). Telemetry-pipeline health is the collector's own monitors'
+    # job (see the Datadog monitor for luthien-proxy errors, which excludes
+    # `@logger:opentelemetry.*` for the same reason) — ignore the whole
+    # `opentelemetry.*` logger namespace here rather than chasing each
+    # sub-logger individually as new exporters/instrumentations add more.
+    ignore_logger("opentelemetry.*")
 
     sentry_sdk.init(
         dsn=settings.sentry_dsn,

--- a/tests/luthien_proxy/unit_tests/test_sentry_scrubbing.py
+++ b/tests/luthien_proxy/unit_tests/test_sentry_scrubbing.py
@@ -326,7 +326,8 @@ class TestBeforeSend:
         ):
             init_sentry(settings)
 
-        mock_ignore.assert_called_once_with("opentelemetry.sdk.trace.export")
+        ignored = {call.args[0] for call in mock_ignore.call_args_list}
+        assert ignored == {"opentelemetry.sdk.trace.export", "opentelemetry.context"}
 
 
 class TestSentryDisabledInTests:

--- a/tests/luthien_proxy/unit_tests/test_sentry_scrubbing.py
+++ b/tests/luthien_proxy/unit_tests/test_sentry_scrubbing.py
@@ -327,7 +327,47 @@ class TestBeforeSend:
             init_sentry(settings)
 
         ignored = {call.args[0] for call in mock_ignore.call_args_list}
-        assert ignored == {"opentelemetry.sdk.trace.export", "opentelemetry.context"}
+        assert ignored == {"opentelemetry.*"}
+
+    def test_opentelemetry_wildcard_ignores_every_sub_logger(self, monkeypatch):
+        """Pins the fnmatch semantics `ignore_logger("opentelemetry.*")` depends on.
+
+        Covers loggers observed in production noise (LUTHIEN-C/F export 403s,
+        the context-detach ValueError) plus a hypothetical future one, so a
+        new OTel exporter/instrumentation logger is suppressed without a code
+        change here.
+        """
+        monkeypatch.setenv("SENTRY_ENABLED", "true")
+        monkeypatch.setenv("SENTRY_DSN", "https://fake@sentry.io/0")
+
+        from unittest.mock import patch
+
+        from sentry_sdk.integrations.logging import _IGNORED_LOGGERS as ignored_loggers
+        from sentry_sdk.integrations.logging import EventHandler
+
+        from luthien_proxy.observability.sentry import init_sentry
+        from luthien_proxy.settings import Settings, clear_settings_cache
+
+        clear_settings_cache()
+        settings = Settings(_env_file=None)
+
+        ignored_loggers.clear()
+        with patch("luthien_proxy.observability.sentry.sentry_sdk.init"):
+            init_sentry(settings)
+
+        handler = EventHandler()
+        for name in (
+            "opentelemetry.context",
+            "opentelemetry.sdk.trace.export",
+            "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+            "opentelemetry.exporter.otlp.proto.http.metric_exporter",
+            "opentelemetry.instrumentation.some_future_thing",
+        ):
+            record = logging.LogRecord(name, logging.ERROR, __file__, 1, "boom", (), None)
+            assert not handler._can_record(record), f"expected {name} to be ignored"
+
+        record = logging.LogRecord("luthien_proxy.pipeline", logging.ERROR, __file__, 1, "boom", (), None)
+        assert handler._can_record(record)
 
 
 class TestSentryDisabledInTests:


### PR DESCRIPTION
## Problem

With Sentry enabled, the gateway captures an error event on nearly every streaming request: `ValueError: <Token ...> was created in a different Context`, logged by `opentelemetry.context`. In our production deployment this single logger produced roughly 86k Sentry error events in 13 hours and exhausted the organization's error quota the day after Sentry was turned on.

## Root cause

OpenTelemetry detaches context tokens in `finally` blocks that can run in a different asyncio context than the one that attached them, which happens routinely on streaming paths. OTel already catches the ValueError and logs it itself (`logger.exception("Failed to detach context")` in `opentelemetry/context/__init__.py`), and the request completes normally: the captured events show 200 responses in their breadcrumbs. The Sentry logging integration then promotes each of those log records into an error event.

## Fix

Ignore the `opentelemetry.context` logger in `init_sentry()`, next to the existing `opentelemetry.sdk.trace.export` ignore that exists for the same reason. The ignore-logger test now pins both loggers. Changelog fragment included.

## Verification

- `uv run pytest tests/luthien_proxy/unit_tests/test_sentry_scrubbing.py` passes at this commit
- `ruff check` and `ruff format --check` clean on the touched files
- The `dev_checks.sh` pytest stage shows three failures on this machine (`test_onboard.py::test_find_docker_ports_respects_env_vars`, two in `test_config_registry.py`) that reproduce identically on a clean `main` checkout with `pytest -n 4`, so they are unrelated to this change

---

## Update: broadened to the whole `opentelemetry.*` namespace

Two more Sentry issues turned up on the same shared root cause but a different sub-logger, so exact-matching two logger names wasn't enough: **LUTHIEN-C** (`opentelemetry.exporter.otlp.proto.http.trace_exporter`, 2,044 events) and **LUTHIEN-F** (`opentelemetry.exporter.otlp.proto.http.metric_exporter`, 998 events) — the OTel collector rejecting exported spans/metrics with HTTP 403.

`sentry_sdk`'s `ignore_logger` matches with `fnmatch`, so `ignore_logger("opentelemetry.*")` replaces both exact-match calls and covers every current and future OTel sub-logger — exporter/instrumentation noise included — without having to chase each one individually. A new behavioral test (`test_opentelemetry_wildcard_ignores_every_sub_logger`) exercises the real `sentry_sdk` `EventHandler._can_record` against five logger names (including a hypothetical future one) plus a non-OTel logger, pinning the `fnmatch` semantics this depends on. This also matches the precedent set by the Datadog monitor for luthien-proxy errors, which already excludes `@logger:opentelemetry.*` for the same reason (telemetry-pipeline health is the collector's own monitors' job).

Silences: LUTHIEN-C, LUTHIEN-F (new), plus the original LUTHIEN context-detach noise this PR already covered.