### PR TITLE
fix(pipeline): serialize stream events with model_dump(mode="json")

### DIFF
--- a/changelog.d/sse-datetime-serialization.md
+++ b/changelog.d/sse-datetime-serialization.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**Streaming no longer dies on code-execution responses**: `_format_sse_event` dumped SDK events in python mode, so a `message_start` carrying the code-execution container's `expires_at` datetime crashed `json.dumps` mid-stream and the client's stream ended in a generic `api_error`. Events are now dumped with `model_dump(mode="json")`, which serializes every wire field to JSON-safe values.

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -1167,16 +1167,19 @@ def _format_sse_event(event: MessageStreamEvent | _StreamErrorEvent) -> str:
 
     The client uses messages.create(stream=True), which yields only raw
     wire-protocol events — no synthetic SDK convenience events to filter.
-    model_dump() faithfully reproduces whatever the API sent, including any
-    new fields the SDK hasn't added to model_fields yet, making the proxy
-    as transparent as a direct connection.
+    model_dump(mode="json") faithfully reproduces whatever the API sent,
+    including any new fields the SDK hasn't added to model_fields yet, making
+    the proxy as transparent as a direct connection. JSON mode matters: some
+    wire fields are non-primitive in the SDK models (e.g. the code-execution
+    container's `expires_at` is a datetime), and python-mode dumps of those
+    crash json.dumps mid-stream.
     """
     if isinstance(event, dict):
         event_type = str(event.get("type", "unknown"))
         event_data: dict = dict(event)
     else:
         event_type = event.type
-        event_data = event.model_dump()
+        event_data = event.model_dump(mode="json")
 
     json_data = json.dumps(event_data)
     return f"event: {event_type}\ndata: {json_data}\n\n"

--- a/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
@@ -133,6 +133,35 @@ class TestFormatSSEEvent:
         assert data["new_api_field"] == 42
         assert data["type"] == "content_block_delta"
 
+    def test_serializes_container_expires_at_datetime(self):
+        """message_start events carry message.container.expires_at as a datetime
+        when the response used the code-execution tool. model_dump() in python
+        mode leaves it as a datetime object, which json.dumps rejects — killing
+        live streams mid-flight with TypeError('Object of type datetime is not
+        JSON serializable'). Every emitted value must be JSON-serializable."""
+        event = RawMessageStartEvent.model_validate(
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_123",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": DEFAULT_TEST_MODEL,
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 10, "output_tokens": 0},
+                    "container": {"id": "container_abc", "expires_at": "2026-08-12T11:14:56Z"},
+                },
+            }
+        )
+        result = _format_sse_event(event)
+
+        data = json.loads(result.split("data: ", 1)[1].strip())
+        expires_at = data["message"]["container"]["expires_at"]
+        assert isinstance(expires_at, str)
+        assert expires_at.startswith("2026-08-12T11:14:56")
+
 
 class TestProcessRequest:
     """Tests for _process_request helper function."""


### PR DESCRIPTION
## Problem

Streamed responses that use the code-execution tool die mid-stream. The client receives a generic `api_error` event and the stream ends. In our production deployment this failed the same sessions deterministically across retries (16 occurrences in three clusters over five days, all `stream=True` requests whose responses carried a container).

## Root cause

`_format_sse_event` serializes SDK events with `event.model_dump()` and then `json.dumps`. Python-mode `model_dump()` preserves non-primitive field types, and `Container.expires_at` is a `datetime` (anthropic SDK 0.84.0), so any `message_start` event for a code-execution response raises `TypeError: Object of type datetime is not JSON serializable`. The streaming error handler converts that into an in-stream `api_error` event and terminates the stream.

## Fix

Dump events with `model_dump(mode="json")` so every wire field serializes to JSON-safe values. Unknown wire fields still pass through unchanged (existing `test_passes_through_unknown_wire_fields` pins this). Regression test and changelog fragment included.

## Verification

- New test `test_serializes_container_expires_at_datetime` fails with the exact production `TypeError` before the fix and passes after
- `uv run pytest tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py` passes at this commit (88 passed)
- `dev_checks.sh`: ruff format, ruff lint, and pyright clean; the pytest stage shows the same three machine-local failures documented in #807 (`test_onboard.py::test_find_docker_ports_respects_env_vars`, two in `test_config_registry.py`), which pass when run standalone and are unrelated to this change