### PR TITLE
fix(db): add missing index on request_logs.created_at

### DIFF
--- a/changelog.d/fix-request-logs-created-at-index.md
+++ b/changelog.d/fix-request-logs-created-at-index.md
@@ -1,0 +1,12 @@
+---
+category: Fixes
+pr: 811
+---
+
+**Add missing index on `request_logs.created_at`**: `request_logs` had no
+index on `created_at`, so any time-windowed query against it (notably the
+capture-liveness monitor's "any rows in the last 15 minutes" check, run every
+5 minutes) forced a full-table `Parallel Seq Scan` -- a fixed, ever-growing
+cost independent of live traffic. Adds `idx_request_logs_created_at` via
+`CREATE INDEX CONCURRENTLY` so it can build against the live production table
+without blocking writes.

--- a/migrations/postgres/022_add_request_logs_created_at_index.sql
+++ b/migrations/postgres/022_add_request_logs_created_at_index.sql
@@ -1,0 +1,16 @@
+-- ABOUTME: Adds an index on request_logs.created_at
+-- ABOUTME: request_logs had no index on created_at, so any time-windowed query
+-- ABOUTME: (e.g. the capture-liveness monitor's "rows in the last 15 minutes"
+-- ABOUTME: check) forced a full-table Parallel Seq Scan -- a fixed cost that
+-- ABOUTME: grows with the table and is independent of live traffic.
+--
+-- CONCURRENTLY: request_logs is a live, multi-GB, multi-million-row production
+-- table. A plain CREATE INDEX takes a SHARE lock that blocks writes (INSERTs
+-- from every in-flight request) for the full build duration; CONCURRENTLY
+-- avoids that at the cost of two table scans and not running inside a
+-- transaction block. This file must contain only this one statement -- the
+-- migration runner (docker/run-migrations.sh) invokes `psql -f` per file
+-- without `-1`/`--single-transaction`, so each statement in a file already
+-- commits independently, but CONCURRENTLY additionally forbids being run
+-- inside any explicit BEGIN/COMMIT this file might otherwise add.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_request_logs_created_at ON request_logs (created_at);

--- a/migrations/sqlite/022_add_request_logs_created_at_index.sql
+++ b/migrations/sqlite/022_add_request_logs_created_at_index.sql
@@ -1,0 +1,4 @@
+-- ABOUTME: Adds an index on request_logs.created_at
+-- ABOUTME: Mirrors the Postgres migration; SQLite uses a plain index statement
+-- ABOUTME: for the dockerless single-user database path.
+CREATE INDEX IF NOT EXISTS idx_request_logs_created_at ON request_logs (created_at);

--- a/src/luthien_proxy/utils/sqlite_migrations/022_add_request_logs_created_at_index.sql
+++ b/src/luthien_proxy/utils/sqlite_migrations/022_add_request_logs_created_at_index.sql
@@ -1,0 +1,4 @@
+-- ABOUTME: Adds an index on request_logs.created_at
+-- ABOUTME: Mirrors the Postgres migration; SQLite uses a plain index statement
+-- ABOUTME: for the dockerless single-user database path.
+CREATE INDEX IF NOT EXISTS idx_request_logs_created_at ON request_logs (created_at);


### PR DESCRIPTION
## Summary

`request_logs` has no index on `created_at` (10 other indexes exist on this table, none on `created_at`). Any time-windowed query against it forces a full-table `Parallel Seq Scan` — most notably a downstream deployment's capture-liveness monitor Lambda, which runs a "rows in the last 15 minutes" check every 5 minutes forever via an EventBridge schedule. At 4.08M rows / 3.7GB, that scan reads ~475k buffer pages and takes ~380ms on **every single invocation, regardless of traffic** — a fixed, ever-growing tax on the production Aurora cluster's CPU.

This PR is one of two required parts (see Companion PR below) — the index alone or the companion query rewrite alone is **not** sufficient; both are needed together (confirmed empirically: `EXISTS()` without this index can be as slow as, or slower than, the original `count(*)`, since the planner has no way to find a matching row early without an index).

## What changed

- `migrations/postgres/022_add_request_logs_created_at_index.sql`: `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_request_logs_created_at ON request_logs (created_at);` — `CONCURRENTLY` because `request_logs` is a live, multi-million-row production table; a plain `CREATE INDEX` would hold a lock blocking every in-flight INSERT for the full build duration.
- `migrations/sqlite/022_add_request_logs_created_at_index.sql` + the matching bundled copy in `src/luthien_proxy/utils/sqlite_migrations/` (per `migrations/AGENTS.md`) — plain `CREATE INDEX IF NOT EXISTS` (no `CONCURRENTLY`; SQLite doesn't have/need it).
- Changelog fragment.

## Production rollout note (read before deploying)

This migration runs automatically at gateway container startup (`docker/start-gateway.sh` -> `docker/run-migrations.sh`) on the next deploy. Two things reviewers/operators should know before that happens:

1. **`docker/run-migrations.sh` invokes `psql -f` without `-v ON_ERROR_STOP=1`.** By default, `psql` scripts can exit 0 even after a SQL error mid-script, and the runner unconditionally records the migration as applied in `_migrations` right after. For most migrations this is low-risk; for this one specifically, an interrupted/failed `CREATE INDEX CONCURRENTLY` can leave an **invalid** index behind under the same name, which `IF NOT EXISTS` would then treat as "already there" on any retry — silently leaving production without a usable index while the tracker says it's applied. This is a pre-existing gap in the migration runner (not introduced by this PR, and out of scope for it), but it's a real risk specifically for this migration. Recommend fixing `run-migrations.sh` to pass `-v ON_ERROR_STOP=1` before/alongside this landing, and verifying `pg_index.indisvalid` for `idx_request_logs_created_at` after deploy regardless.
2. **Consider decoupling this from normal gateway-startup migration timing.** A downstream deployment's ECS service config explicitly notes `health_check_grace_period_seconds=120` "covers normal boot; heavy one-time migrations should still be decoupled from app startup." `CREATE INDEX CONCURRENTLY` on a live 3.7GB table is exactly that kind of heavy one-time migration — if it runs long, new ECS tasks could sit unbound behind the ALB, exceed the grace period, get killed mid-build, and loop the deployment. Recommend running this migration once as a standalone step (e.g. the existing `migrations` Docker image / `Dockerfile.migrations`, built for exactly this) against production ahead of the next gateway deploy, then verifying `EXPLAIN` shows an index scan before rolling the gateway service.

I do not have write access to production Aurora to apply or verify this migration myself (only `luthien_admin_iam`, a read-only `SELECT`/`EXPLAIN` role — confirmed via a live `CREATE INDEX` attempt returning `ERROR: must be owner of table request_logs`), so I could not execute either recommendation above myself.

## Verification

- `uv run pytest tests/luthien_proxy/unit_tests/utils/test_migration_naming.py -m "not integration"` -> 54 passed.
- `uv run pytest tests/luthien_proxy/integration_tests/test_migration_sync.py -m integration` against a fresh local `postgres:16-alpine` -> 1 passed (Postgres and SQLite migration sets produce equivalent schemas, including this migration).
- Applied the full migration set (`docker/run-migrations.sh`) against a fresh local Postgres and confirmed it applies cleanly and is correctly tracked/skipped on re-run.
- Seeded a local Postgres with 2.6M synthetic `request_logs` rows spread over 30 days and ran `EXPLAIN ANALYZE` before/after:
  - **Before** (no index): `count(*)` query -> `Parallel Seq Scan`, 99.3ms, "Rows Removed by Filter: 863718".
  - **After** (index + `ANALYZE`): both the old `count(*)` query and the new `EXISTS(...)` query (see companion PR) -> `Index Only Scan`, <1ms.
- Live production Aurora (read-only, via `luthien_admin_iam`) confirmed via `EXPLAIN (ANALYZE, BUFFERS)` that the current `count(*)` monitor query is still a `Parallel Seq Scan` today (382.670ms, 475128 buffer hits, "Rows Removed by Filter: 1394125") and that no `created_at` index exists yet on the live table.

## Companion PR

A companion change in a downstream deployment rewrites the capture-monitor Lambda's query from `count(*)` to `EXISTS(...)`.

