### PR TITLE
fix(migrations): stop swallowing failed migrations in run-migrations.sh

### DIFF
--- a/.github/workflows/dev-checks.yaml
+++ b/.github/workflows/dev-checks.yaml
@@ -70,6 +70,16 @@ jobs:
           psql -c "SELECT 1 FROM debug_logs LIMIT 0;"
           echo "✅ Schema verification passed"
 
+      - name: Run migration runner error-handling tests
+        # Scoped to this one file (not `-m integration` repo-wide): the
+        # broader integration_tests/ suite has pre-existing, unrelated
+        # failures (e.g. test_migration_sync.py) that have never run in CI
+        # because no workflow selects the `integration` marker. Fixing that
+        # gap for the whole suite is a separate concern; this wires in only
+        # the new coverage for docker/run-migrations.sh's error handling so
+        # it isn't silently dead like the rest of the marker.
+        run: uv run pytest -m integration tests/luthien_proxy/integration_tests/test_migration_runner.py -v
+
       - name: Run formatting, lint, and tests
         run: ./scripts/dev_checks.sh
 

--- a/changelog.d/migration-runner-error-stop.md
+++ b/changelog.d/migration-runner-error-stop.md
@@ -1,0 +1,24 @@
+---
+category: Fixes
+pr: 812
+---
+
+**`docker/run-migrations.sh` no longer swallows failed migrations**: `psql -f`
+ran without `-v ON_ERROR_STOP=1`, so a migration file with a failing
+statement would print the error, keep executing later statements in the same
+file, and still exit 0 -- letting the migration get recorded as applied in
+`_migrations` despite having failed. Every `psql` call in the script now goes
+through an `ON_ERROR_STOP=1` wrapper, and the one remaining pipe that could
+mask a `psql` failure (the "already applied?" check, previously
+`psql ... | tr -d ' '`) was replaced with `-t -A` so nothing sits between
+`psql`'s exit code and the script.
+  - Also closes the `CREATE INDEX CONCURRENTLY IF NOT EXISTS` retry trap:
+    that clause matches an existing index by name only, so an index left
+    INVALID by a previously interrupted concurrent build (dropped
+    connection, OOM, crash) is silently accepted as "already there" on a
+    retried deploy, with `ON_ERROR_STOP` never seeing an error to catch.
+    After a migration applies, the runner now scans it for any
+    `CREATE INDEX CONCURRENTLY` statements and refuses to record the
+    migration as applied unless `pg_index.indisvalid` is true for every
+    index it names. This specifically protects `idx_request_logs_created_at`
+    (#811) from silently shipping invalid.

--- a/docker/run-migrations.sh
+++ b/docker/run-migrations.sh
@@ -26,8 +26,18 @@ done
 
 echo "✅ Database is ready"
 
+# Every psql call in this script goes through this wrapper. Without
+# `-v ON_ERROR_STOP=1`, psql prints a failing statement's error, continues on
+# to the rest of the script, and still exits 0 -- so a migration that half
+# failed would fall straight through to the "record as applied" step below.
+# `set -e` only helps once psql itself reports failure; ON_ERROR_STOP is what
+# makes it do so.
+run_psql() {
+    psql -v ON_ERROR_STOP=1 -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" "$@"
+}
+
 # Create migrations tracking table if it doesn't exist (with content_hash for validation)
-psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" <<EOF
+run_psql <<EOF
 CREATE TABLE IF NOT EXISTS _migrations (
     filename TEXT PRIMARY KEY,
     applied_at TIMESTAMP NOT NULL DEFAULT NOW(),
@@ -60,7 +70,7 @@ compute_hash() {
 # command and GRANT wrapper changed. Update the stored hash so validation passes.
 OLD_008_HASH="49ad0e5ce7fc13692a5300ed30f1a96e"
 NEW_008_HASH="76cfa2f26a6925f00ca10e76159bb2ea"
-psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -q <<EOF
+run_psql -q <<EOF
 UPDATE _migrations
    SET content_hash = '$NEW_008_HASH'
  WHERE filename = '008_add_request_logs_table.sql'
@@ -74,7 +84,7 @@ EOF
 # The sqlite_schema.sql file has moved to migrations/sqlite/ and is no longer
 # in the Postgres migrations directory. Remove the stale tracking row to prevent
 # "file not found locally" validation errors.
-psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -q <<EOF
+run_psql -q <<EOF
 DELETE FROM _migrations WHERE filename = 'sqlite_schema.sql';
 EOF
 
@@ -84,7 +94,7 @@ EOF
 echo "🔍 Validating migration consistency..."
 
 # Get all migrations recorded in the database
-db_migrations=$(psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -t -A <<EOF
+db_migrations=$(run_psql -t -A <<EOF
 SELECT filename, COALESCE(content_hash, '') FROM _migrations ORDER BY filename;
 EOF
 )
@@ -137,21 +147,52 @@ echo "✅ Migration validation passed"
 # APPLICATION PHASE: Apply pending migrations
 # ============================================================================
 
+# A `CREATE INDEX CONCURRENTLY` build that gets interrupted (dropped
+# connection, OOM kill, crashed backend) leaves an INVALID index behind under
+# its target name -- that failure is real and already aborts this script
+# (psql reports the dropped connection as an error). But a *subsequent* run of
+# the same migration file uses `CREATE INDEX CONCURRENTLY IF NOT EXISTS`,
+# which matches by name only: it finds the (invalid) name already taken,
+# prints a NOTICE, and reports success with exit code 0. ON_ERROR_STOP cannot
+# catch this because psql never sees an error on that run. So after a
+# migration applies cleanly, verify that any index it builds CONCURRENTLY is
+# actually valid before recording the migration as applied -- otherwise a
+# retried deploy would silently record success while shipping an index
+# Postgres itself refuses to use.
+check_concurrent_indexes_valid() {
+    migration_file="$1"
+    index_names=$(sed 's/--.*$//' "$migration_file" \
+        | grep -Eio 'create[[:space:]]+(unique[[:space:]]+)?index[[:space:]]+concurrently[[:space:]]+(if[[:space:]]+not[[:space:]]+exists[[:space:]]+)?[a-z_][a-z0-9_]*' \
+        | awk '{print $NF}')
+    [ -z "$index_names" ] && return 0
+
+    for index_name in $index_names; do
+        is_valid=$(run_psql -t -A -c "SELECT indisvalid FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = '$index_name';")
+        if [ "$is_valid" != "t" ]; then
+            echo "❌ MIGRATION ERROR: index '$index_name' from '$(basename "$migration_file")' is not valid (indisvalid=$is_valid)!"
+            echo "   CREATE INDEX CONCURRENTLY IF NOT EXISTS matches by name only, so a"
+            echo "   previously failed/interrupted concurrent build leaves an INVALID index"
+            echo "   that silently 'succeeds' on retry without ever becoming usable."
+            echo "   Drop the invalid index and re-run this migration:"
+            echo "     DROP INDEX CONCURRENTLY IF EXISTS $index_name;"
+            exit 1
+        fi
+    done
+}
+
 # Apply each migration in order
 for migration in "$MIGRATIONS_SQL_DIR"/*.sql; do
     filename=$(basename "$migration")
 
     # Check if already applied
-    applied=$(psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -t <<EOF | tr -d ' '
-SELECT COUNT(*) FROM _migrations WHERE filename = '$filename';
-EOF
-)
+    applied=$(run_psql -t -A -c "SELECT COUNT(*) FROM _migrations WHERE filename = '$filename';")
 
     if [ "$applied" = "0" ]; then
         echo "📦 Applying migration: $filename"
         content_hash=$(compute_hash "$migration")
-        psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -f "$migration"
-        psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" <<EOF
+        run_psql -f "$migration"
+        check_concurrent_indexes_valid "$migration"
+        run_psql <<EOF
 INSERT INTO _migrations (filename, content_hash) VALUES ('$filename', '$content_hash');
 EOF
         echo "✅ Applied: $filename (hash: $content_hash)"

--- a/tests/luthien_proxy/integration_tests/test_migration_runner.py
+++ b/tests/luthien_proxy/integration_tests/test_migration_runner.py
@@ -1,0 +1,356 @@
+# ABOUTME: Integration tests for docker/run-migrations.sh's failure handling
+# ABOUTME: Pins two fixes: ON_ERROR_STOP=1 on every psql call, and detection of
+# ABOUTME: indexes left INVALID by an interrupted CREATE INDEX CONCURRENTLY build
+
+"""Pin `docker/run-migrations.sh`'s error-handling behavior against a real Postgres.
+
+Covers two defects fixed together:
+
+1. `psql -f` without `-v ON_ERROR_STOP=1` prints a failing statement's error,
+   continues on to later statements in the same file, and still exits 0 -- so
+   a half-failed migration would get recorded as applied.
+2. `CREATE INDEX CONCURRENTLY IF NOT EXISTS` matches an existing index by name
+   only. A previously interrupted concurrent build leaves an INVALID index
+   under that name; a retried deploy's `IF NOT EXISTS` silently "succeeds"
+   (exit 0) without the index ever becoming valid. This specifically
+   threatens PR #811's `idx_request_logs_created_at` index.
+
+Each test spins up its own scratch Postgres database (dropped afterward) so
+tests can run concurrently and don't depend on or pollute the shared
+`_migrations` state used elsewhere in the suite.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.timeout(30)]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUN_MIGRATIONS_SCRIPT = REPO_ROOT / "docker" / "run-migrations.sh"
+
+
+def _pg_env() -> dict[str, str]:
+    return {
+        "PGHOST": os.environ.get("PGHOST", "localhost"),
+        "PGPORT": os.environ.get("PGPORT", "5432"),
+        "PGUSER": os.environ.get("PGUSER", "luthien"),
+        "PGPASSWORD": os.environ.get("PGPASSWORD", "luthien"),
+    }
+
+
+def _dsn(database: str) -> str:
+    env = _pg_env()
+    return f"postgresql://{env['PGUSER']}:{env['PGPASSWORD']}@{env['PGHOST']}:{env['PGPORT']}/{database}"
+
+
+class ScratchDb:
+    """A throwaway Postgres database plus the env vars run-migrations.sh needs to reach it."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.dsn = _dsn(name)
+        self.env = {**_pg_env(), "PGDATABASE": name}
+
+    async def connect(self) -> asyncpg.Connection:
+        return await asyncpg.connect(self.dsn)
+
+    async def migration_recorded(self, filename: str) -> bool:
+        conn = await self.connect()
+        try:
+            table_exists = await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '_migrations')"
+            )
+            if not table_exists:
+                return False
+            count = await conn.fetchval("SELECT COUNT(*) FROM _migrations WHERE filename = $1", filename)
+            return bool(count)
+        finally:
+            await conn.close()
+
+
+@pytest.fixture
+async def scratch_db() -> AsyncIterator[ScratchDb]:
+    """Create an isolated scratch database on the shared Postgres instance and drop it afterward."""
+    admin_conn = await asyncpg.connect(_dsn(os.environ.get("PGDATABASE", "luthien_control")))
+    db_name = f"migration_runner_test_{uuid.uuid4().hex[:16]}"
+    await admin_conn.execute(f'CREATE DATABASE "{db_name}"')
+    try:
+        yield ScratchDb(db_name)
+    finally:
+        # A killed/failed CONCURRENTLY build can leave connections lingering;
+        # terminate them or the DROP below hangs.
+        await admin_conn.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+            db_name,
+        )
+        await admin_conn.execute(f'DROP DATABASE IF EXISTS "{db_name}" WITH (FORCE)')
+        await admin_conn.close()
+
+
+def run_migrations(migrations_dir: Path, db: ScratchDb) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, **db.env, "MIGRATIONS_DIR": str(migrations_dir)}
+    return subprocess.run(
+        [str(RUN_MIGRATIONS_SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=25,
+    )
+
+
+async def _plant_invalid_concurrent_index(db: ScratchDb, index_name: str) -> None:
+    """Leave an INVALID index named `index_name` behind, deterministically.
+
+    A `CREATE UNIQUE INDEX CONCURRENTLY` over duplicate data always fails with
+    a real Postgres error during its validation scan and leaves the partially
+    built index catalogued as invalid -- this reproduces the same on-disk
+    state a killed/interrupted concurrent build would, without any timing- or
+    process-kill-dependent race.
+    """
+    conn = await db.connect()
+    try:
+        await conn.execute("CREATE TABLE dup_source (id serial primary key, val int)")
+        await conn.execute("INSERT INTO dup_source (val) VALUES (1), (1)")
+        with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+            await conn.execute(f"CREATE UNIQUE INDEX CONCURRENTLY {index_name} ON dup_source (val)")
+        is_valid = await conn.fetchval(
+            "SELECT indisvalid FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = $1",
+            index_name,
+        )
+        assert is_valid is False, "test setup did not produce an invalid index"
+    finally:
+        await conn.close()
+
+
+async def test_bad_statement_aborts_and_is_not_recorded(scratch_db: ScratchDb, tmp_path: Path) -> None:
+    """A failing statement must abort the run and leave the migration unrecorded."""
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "900_bad.sql").write_text(
+        "CREATE TABLE scratch_demo (id INT PRIMARY KEY);\n"
+        "INSERT INTO scratch_demo (id) VALUES (1);\n"
+        "SELEKT * FROM nonexistent_table;\n"
+    )
+
+    result = run_migrations(migrations_dir, scratch_db)
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert not await scratch_db.migration_recorded("900_bad.sql")
+
+
+async def test_bad_statement_stops_before_later_statements_in_same_file(scratch_db: ScratchDb, tmp_path: Path) -> None:
+    """Statements after a failing one in the same file must never execute."""
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "900_bad.sql").write_text(
+        "CREATE TABLE scratch_demo (id INT PRIMARY KEY);\n"
+        "INSERT INTO scratch_demo (id) VALUES (1);\n"
+        "SELEKT * FROM nonexistent_table;\n"
+        "INSERT INTO scratch_demo (id) VALUES (2);\n"
+    )
+
+    run_migrations(migrations_dir, scratch_db)
+
+    conn = await scratch_db.connect()
+    try:
+        rows = await conn.fetch("SELECT id FROM scratch_demo ORDER BY id")
+    finally:
+        await conn.close()
+    assert [row["id"] for row in rows] == [1]
+
+
+async def test_multiple_migration_files_stop_at_first_failure(scratch_db: ScratchDb, tmp_path: Path) -> None:
+    """A failure in one file must prevent later files from being attempted at all."""
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "001_good.sql").write_text("CREATE TABLE already_applied (id INT);\n")
+    (migrations_dir / "002_bad.sql").write_text("SELEKT bogus;\n")
+    (migrations_dir / "003_good.sql").write_text("CREATE TABLE never_reached (id INT);\n")
+
+    result = run_migrations(migrations_dir, scratch_db)
+
+    assert result.returncode != 0
+    assert await scratch_db.migration_recorded("001_good.sql")
+    assert not await scratch_db.migration_recorded("002_bad.sql")
+    assert not await scratch_db.migration_recorded("003_good.sql")
+
+    conn = await scratch_db.connect()
+    try:
+        never_reached_exists = await conn.fetchval(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'never_reached')"
+        )
+    finally:
+        await conn.close()
+    assert never_reached_exists is False
+
+
+async def test_valid_migration_is_recorded_with_correct_content_hash(scratch_db: ScratchDb, tmp_path: Path) -> None:
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    migration_file = migrations_dir / "001_good.sql"
+    migration_file.write_text("CREATE TABLE ok_table (id INT);\n")
+
+    result = run_migrations(migrations_dir, scratch_db)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    expected_hash = hashlib.md5(migration_file.read_bytes()).hexdigest()  # noqa: S324 - matches run-migrations.sh's own hash choice
+
+    conn = await scratch_db.connect()
+    try:
+        row = await conn.fetchrow("SELECT content_hash FROM _migrations WHERE filename = $1", "001_good.sql")
+    finally:
+        await conn.close()
+    assert row is not None
+    assert row["content_hash"] == expected_hash
+
+
+async def test_already_applied_migration_is_skipped_and_not_reapplied(scratch_db: ScratchDb, tmp_path: Path) -> None:
+    """A second run must not re-execute an already-applied (non-idempotent) migration."""
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "001_seed.sql").write_text(
+        "CREATE TABLE seen (id serial primary key);\nINSERT INTO seen DEFAULT VALUES;\n"
+    )
+
+    first = run_migrations(migrations_dir, scratch_db)
+    assert first.returncode == 0, first.stdout + first.stderr
+
+    second = run_migrations(migrations_dir, scratch_db)
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert "Skipping (already applied): 001_seed.sql" in second.stdout
+
+    conn = await scratch_db.connect()
+    try:
+        count = await conn.fetchval("SELECT COUNT(*) FROM seen")
+    finally:
+        await conn.close()
+    assert count == 1
+
+
+async def test_validation_phase_rejects_missing_local_file(scratch_db: ScratchDb, tmp_path: Path) -> None:
+    """Pre-existing drift check: a migration recorded in the DB but missing locally must fail fast."""
+    first_dir = tmp_path / "migrations_v1"
+    first_dir.mkdir()
+    (first_dir / "001_only_here_first.sql").write_text("CREATE TABLE t1 (id INT);\n")
+    first = run_migrations(first_dir, scratch_db)
+    assert first.returncode == 0, first.stdout + first.stderr
+
+    second_dir = tmp_path / "migrations_v2"
+    second_dir.mkdir()
+    result = run_migrations(second_dir, scratch_db)
+
+    assert result.returncode != 0
+    assert "file not found locally" in result.stdout
+
+
+async def test_validation_phase_rejects_content_hash_mismatch(scratch_db: ScratchDb, tmp_path: Path) -> None:
+    """Pre-existing drift check: editing an already-applied migration file must fail fast."""
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    migration_file = migrations_dir / "001_mutable.sql"
+    migration_file.write_text("CREATE TABLE t1 (id INT);\n")
+    first = run_migrations(migrations_dir, scratch_db)
+    assert first.returncode == 0, first.stdout + first.stderr
+
+    migration_file.write_text("CREATE TABLE t1 (id INT); -- modified after being applied\n")
+    result = run_migrations(migrations_dir, scratch_db)
+
+    assert result.returncode != 0
+    assert "Content mismatch" in result.stdout
+
+
+async def test_preexisting_invalid_concurrent_index_blocks_recording(scratch_db: ScratchDb, tmp_path: Path) -> None:
+    """The retry trap: IF NOT EXISTS must not let a previously-invalid index pass as applied."""
+    await _plant_invalid_concurrent_index(scratch_db, "idx_dup_source_val")
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "001_add_index.sql").write_text(
+        "-- mirrors PR #811's CREATE INDEX CONCURRENTLY IF NOT EXISTS shape\n"
+        "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_dup_source_val ON dup_source (val);\n"
+    )
+
+    result = run_migrations(migrations_dir, scratch_db)
+
+    assert result.returncode != 0, "the old script exited 0 here; the invalid index must now block success"
+    assert "is not valid" in result.stdout
+    assert not await scratch_db.migration_recorded("001_add_index.sql")
+
+
+async def test_valid_concurrent_index_build_is_recorded_normally(scratch_db: ScratchDb, tmp_path: Path) -> None:
+    """No false positives: an uninterrupted CONCURRENTLY build still applies and is recorded."""
+    conn = await scratch_db.connect()
+    try:
+        await conn.execute("CREATE TABLE clean_source (id serial primary key, val int)")
+        await conn.execute("INSERT INTO clean_source (val) SELECT g FROM generate_series(1, 100) g")
+    finally:
+        await conn.close()
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "001_add_index.sql").write_text(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_clean_source_val ON clean_source (val);\n"
+    )
+
+    result = run_migrations(migrations_dir, scratch_db)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert await scratch_db.migration_recorded("001_add_index.sql")
+
+    conn = await scratch_db.connect()
+    try:
+        is_valid = await conn.fetchval(
+            "SELECT indisvalid FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid "
+            "WHERE c.relname = 'idx_clean_source_val'"
+        )
+    finally:
+        await conn.close()
+    assert is_valid is True
+
+
+async def test_concurrent_index_scan_ignores_sql_comments(scratch_db: ScratchDb, tmp_path: Path) -> None:
+    """A comment mentioning 'create index concurrently' must not be parsed as a real index name."""
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "001_commented.sql").write_text(
+        "-- note: this comment mentions create index concurrently in passing\n"
+        "CREATE TABLE commented_table (id INT); -- trailing comment: create index concurrently too\n"
+    )
+
+    result = run_migrations(migrations_dir, scratch_db)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert await scratch_db.migration_recorded("001_commented.sql")
+
+
+async def test_migration_without_concurrent_index_is_unaffected_by_index_check(
+    scratch_db: ScratchDb, tmp_path: Path
+) -> None:
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "001_plain_index.sql").write_text(
+        "CREATE TABLE plain_table (id serial primary key, val int);\n"
+        "CREATE INDEX idx_plain_table_val ON plain_table (val);\n"
+    )
+
+    result = run_migrations(migrations_dir, scratch_db)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert await scratch_db.migration_recorded("001_plain_index.sql")
+
+
+async def test_full_repository_migration_set_applies_cleanly(scratch_db: ScratchDb) -> None:
+    """Regression guard: the real migrations/postgres set must still apply end to end."""
+    result = run_migrations(REPO_ROOT / "migrations", scratch_db)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "🎉 All migrations complete!" in result.stdout


### PR DESCRIPTION
## Problem

`docker/run-migrations.sh` runs `psql -f "$migration"` without `-v ON_ERROR_STOP=1`. psql's default behavior is to print a failing statement's error, keep executing the rest of the script, and still exit 0 — so a migration whose statements partially failed still gets recorded as applied in `_migrations`. Verified locally: a migration file with `CREATE TABLE; INSERT; <bad statement>; INSERT;` runs to completion, both INSERTs commit, and the script exits 0.

This specifically endangers #811's `idx_request_logs_created_at` index migration: `CREATE INDEX CONCURRENTLY IF NOT EXISTS` matches an existing index **by name only**. If a concurrent build is ever interrupted (dropped connection, OOM, crashed backend — not a SQL error), Postgres leaves an `INVALID` index under that name. A retried deploy's `IF NOT EXISTS` then finds the name already taken, prints a NOTICE, and reports success with exit 0 — `ON_ERROR_STOP` can't catch this because psql never sees an error on that run. Reproduced locally by killing the backend mid-build, then re-running the same `CREATE INDEX CONCURRENTLY IF NOT EXISTS` statement: it reports success while the index stays permanently invalid.

## Fix

- Every `psql` invocation now goes through a `run_psql()` wrapper that adds `-v ON_ERROR_STOP=1`.
- The "already applied?" check previously piped `psql -t <<EOF | tr -d ' '`, which discards `psql`'s exit status behind `tr`'s (always 0). Replaced with `psql -t -A` so there's no pipe to mask it.
- After a migration applies without error, the runner now scans the file for `CREATE INDEX CONCURRENTLY` statements (comment-stripped, so a comment merely *mentioning* the phrase isn't misparsed) and checks `pg_index.indisvalid` for each named index before recording the migration as applied. An invalid index now hard-fails the run instead of silently "succeeding."
- Did not add `set -o pipefail`: this repo's CI runs the script directly via its `#!/bin/sh` shebang on `ubuntu-latest`, where `/bin/sh` is `dash`, which doesn't support `pipefail` (confirmed locally — it's a fatal "Illegal option" under `set -e`). The Alpine (`ash`) image this also ships in does support it, but the fix had to work in both, so the one masking pipe was removed instead.

## Tests

Added `tests/luthien_proxy/integration_tests/test_migration_runner.py` — 12 tests against a real Postgres (each in its own scratch DB), covering: aborting on a failing statement (and not recording it, and not running later statements in the same file or later files), the CONCURRENTLY/`indisvalid` retry trap (planted deterministically via a duplicate-data unique-index build, no timing races), no false positives on a clean CONCURRENTLY build or on comments mentioning the phrase, the pre-existing drift checks (missing-file / hash-mismatch), skip-if-already-applied, and a full run of the real `migrations/postgres/` set.

Wired into CI in `.github/workflows/dev-checks.yaml`, scoped to this one file rather than the whole `integration` marker: that marker is currently excluded from every workflow (`pyproject.toml`'s default addopts filters it out, and no workflow passes `-m integration`), so the pre-existing `integration_tests/` suite has never actually run in CI — confirmed locally, where `test_migration_sync.py::test_schemas_match` fails against current `main` right now. That's a separate, pre-existing gap outside this PR's scope; flagging it here rather than silently expanding the diff to fix unrelated tests.

## Related

- #811 (the `created_at` index migration this protects)
