### PR TITLE
fix: capture reasoning blocks from streaming responses

### DIFF
--- a/changelog.d/capture-streaming-thinking.md
+++ b/changelog.d/capture-streaming-thinking.md
@@ -1,0 +1,8 @@
+---
+category: Fixes
+---
+
+**Capture reasoning blocks from streaming responses**: `thinking` and `redacted_thinking` content blocks were dropped when rebuilding a streamed response for conversation history, so a streamed call recorded a complete-looking response with no reasoning content. The non-streaming path already stored them verbatim, so history was inconsistent between the two.
+  - `thinking` blocks accumulate `thinking_delta` text and record the `signature_delta` value.
+  - `redacted_thinking` blocks keep their opaque `data` payload.
+  - Block ordering is unchanged, so reasoning blocks still precede visible text.

--- a/src/luthien_proxy/pipeline/anthropic_processor.py
+++ b/src/luthien_proxy/pipeline/anthropic_processor.py
@@ -261,7 +261,12 @@ def _reconstruct_response_from_stream_events(
             elif cb.type == "tool_use":
                 blocks_by_index[idx] = {"type": "tool_use", "id": cb.id, "name": cb.name, "input": {}}
                 json_bufs[idx] = ""
-            # thinking blocks are intentionally excluded from history
+            elif cb.type == "thinking":
+                blocks_by_index[idx] = {"type": "thinking", "thinking": "", "signature": ""}
+            elif cb.type == "redacted_thinking":
+                # Opaque server-encrypted payload; kept verbatim because dropping it
+                # loses the only record that a reasoning block was present at all.
+                blocks_by_index[idx] = {"type": "redacted_thinking", "data": cb.data}
 
         elif t == "content_block_delta":
             idx = event.index  # type: ignore[union-attr]
@@ -272,6 +277,10 @@ def _reconstruct_response_from_stream_events(
                     block["text"] += delta.text  # type: ignore[union-attr]
                 elif delta.type == "input_json_delta" and block["type"] == "tool_use":  # type: ignore[union-attr]
                     json_bufs[idx] = json_bufs.get(idx, "") + delta.partial_json  # type: ignore[union-attr]
+                elif delta.type == "thinking_delta" and block["type"] == "thinking":  # type: ignore[union-attr]
+                    block["thinking"] += delta.thinking  # type: ignore[union-attr]
+                elif delta.type == "signature_delta" and block["type"] == "thinking":  # type: ignore[union-attr]
+                    block["signature"] = delta.signature  # type: ignore[union-attr]
 
         elif t == "content_block_stop":
             idx = event.index  # type: ignore[union-attr]

--- a/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
+++ b/tests/luthien_proxy/unit_tests/pipeline/test_anthropic_processor.py
@@ -16,7 +16,9 @@ from anthropic.types import (
     RawMessageDeltaEvent,
     RawMessageStartEvent,
     RawMessageStopEvent,
+    SignatureDelta,
     TextDelta,
+    ThinkingDelta,
 )
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
@@ -1715,6 +1717,93 @@ class TestReconstructResponseFromStreamEvents:
 
         assert result is not None
         assert result["usage"]["cache_read_input_tokens"] == 75
+
+    def test_captures_thinking_text_and_signature(self):
+        """A streamed thinking block lands in history with its text and signature.
+
+        Without this, a reasoning-extraction session captured through the proxy has no
+        same-run ground truth: the response looks healthy but carries no trace.
+        """
+        events = [
+            self._message_start("msg_think", input_tokens=7),
+            RawContentBlockStartEvent(
+                type="content_block_start",
+                index=0,
+                content_block={"type": "thinking", "thinking": "", "signature": ""},
+            ),
+            RawContentBlockDeltaEvent(
+                type="content_block_delta", index=0, delta=ThinkingDelta(type="thinking_delta", thinking="step one")
+            ),
+            RawContentBlockDeltaEvent(
+                type="content_block_delta", index=0, delta=ThinkingDelta(type="thinking_delta", thinking=" step two")
+            ),
+            RawContentBlockDeltaEvent(
+                type="content_block_delta", index=0, delta=SignatureDelta(type="signature_delta", signature="SIGVALUE")
+            ),
+            RawContentBlockStopEvent(type="content_block_stop", index=0),
+            RawMessageDeltaEvent(
+                type="message_delta",
+                delta={"stop_reason": "end_turn", "stop_sequence": None},
+                usage={"output_tokens": 4},
+            ),
+            RawMessageStopEvent(type="message_stop"),
+        ]
+
+        result = _reconstruct_response_from_stream_events(events)
+
+        assert result is not None
+        assert len(result["content"]) == 1
+        assert result["content"][0]["type"] == "thinking"
+        assert result["content"][0]["thinking"] == "step one step two"
+        assert result["content"][0]["signature"] == "SIGVALUE"
+
+    def test_preserves_thinking_before_text_in_block_order(self):
+        """Reasoning blocks keep their index order ahead of the visible answer."""
+        events = [
+            self._message_start(),
+            RawContentBlockStartEvent(
+                type="content_block_start",
+                index=0,
+                content_block={"type": "thinking", "thinking": "", "signature": ""},
+            ),
+            RawContentBlockDeltaEvent(
+                type="content_block_delta", index=0, delta=ThinkingDelta(type="thinking_delta", thinking="reasoned")
+            ),
+            RawContentBlockStopEvent(type="content_block_stop", index=0),
+            RawContentBlockStartEvent(type="content_block_start", index=1, content_block={"type": "text", "text": ""}),
+            RawContentBlockDeltaEvent(
+                type="content_block_delta", index=1, delta=TextDelta(type="text_delta", text="answer")
+            ),
+            RawContentBlockStopEvent(type="content_block_stop", index=1),
+            RawMessageStopEvent(type="message_stop"),
+        ]
+
+        result = _reconstruct_response_from_stream_events(events)
+
+        assert result is not None
+        assert [block["type"] for block in result["content"]] == ["thinking", "text"]
+        assert result["content"][0]["thinking"] == "reasoned"
+        assert result["content"][1]["text"] == "answer"
+
+    def test_captures_redacted_thinking_payload(self):
+        """A redacted_thinking block keeps its opaque data rather than vanishing."""
+        events = [
+            self._message_start(),
+            RawContentBlockStartEvent(
+                type="content_block_start",
+                index=0,
+                content_block={"type": "redacted_thinking", "data": "OPAQUEPAYLOAD"},
+            ),
+            RawContentBlockStopEvent(type="content_block_stop", index=0),
+            RawMessageStopEvent(type="message_stop"),
+        ]
+
+        result = _reconstruct_response_from_stream_events(events)
+
+        assert result is not None
+        assert len(result["content"]) == 1
+        assert result["content"][0]["type"] == "redacted_thinking"
+        assert result["content"][0]["data"] == "OPAQUEPAYLOAD"
 
 
 class TestBuildUsage:


### PR DESCRIPTION
Capture `thinking` and `redacted_thinking` blocks when rebuilding a streamed response for conversation history.

`_reconstruct_response_from_stream_events` had branches for `text` and `tool_use` only; the line this replaces read `# thinking blocks are intentionally excluded from history` with no recorded rationale (its origin is not reachable — the line predates this clone's grafted root). A streamed call therefore recorded a complete-looking response holding no reasoning content, while the non-streaming path already stored the same blocks verbatim via an unfiltered `model_dump()`. History was inconsistent between the two transports depending only on whether the client streamed.

## Change

- `thinking` blocks accumulate `thinking_delta` text and record the `signature_delta` value. The signature arrives as a separate event from the text deltas, which is the failure mode a half-implementation would hit.
- `redacted_thinking` blocks keep their opaque `data` payload — dropping it loses the only record that a reasoning block was present.
- Block ordering is untouched, so reasoning blocks still precede visible text.

## Why this is not a new data shape

Nothing under `history/`, `debug/`, `ui/` or `static/` references `thinking` at all. The event's consumers (`passthrough_materialize/payloads.py`, `debug/service.py`) handle the streaming and non-streaming events symmetrically, and already receive these blocks today from non-streaming calls. This makes streaming produce what non-streaming already produces.

## Deliberately out of scope

The streaming path's `record_inbound_response` / `record_outbound_response` pass no `body=`, so `request_logs.response_body` stays NULL for streamed calls. Filling it would duplicate every streamed body into a second table under the 8 MB truncation rule, for no gain here. Separate concern.

## Tests

Three cases added to `TestReconstructResponseFromStreamEvents`, written first and confirmed failing for the right reason (blocks dropped entirely — `len([]) == 0`):

- `test_captures_thinking_text_and_signature` — multi-delta text accumulation plus the separately-arriving signature.
- `test_preserves_thinking_before_text_in_block_order` — index ordering across mixed block types.
- `test_captures_redacted_thinking_payload` — opaque payload preserved.

`uv run pytest ...::TestReconstructResponseFromStreamEvents` → 11/11 pass.

Coverage is unit-level only. The tests construct the SDK's own pydantic event models (`RawContentBlockStartEvent`, `ThinkingDelta`, `SignatureDelta`), so a wrong block shape fails construction rather than passing a hand-rolled dict. What they do not prove is the live streaming path reaching this function — that link is exercised by the existing `text`/`tool_use` cases. `MockAnthropicServer` emits only hardcoded `text`/`tool_use` blocks, so an end-to-end `mock_e2e` case needs a new mock response type; that is a follow-on rather than scope creep here.

## Pre-existing failures, not from this change

`scripts/dev_checks.sh` reports three. They reproduce identically on unmodified `main` under xdist (`uv run -m pytest -q --no-cov -n 4`, which is what `dev_checks.sh` runs by default) and all pass single-process, so they are parallelism-sensitive and unrelated to this diff:

- `tests/luthien_cli/test_onboard.py::test_find_docker_ports_respects_env_vars`
- `tests/luthien_proxy/unit_tests/test_config_registry.py::TestResolveDefaults::test_default_value_when_no_overrides`
- `tests/luthien_proxy/unit_tests/test_config_registry.py::TestResolvePriority::test_db_ignored_for_non_db_settable`

Changelog fragment: `changelog.d/capture-streaming-thinking.md`.
