### PR TITLE
Prevent JSONB NUL payloads from dropping observability data

### DIFF
--- a/changelog.d/jsonb-nul-sanitization.md
+++ b/changelog.d/jsonb-nul-sanitization.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**Preserve observability payloads containing NUL characters**: Replace PostgreSQL-incompatible NUL characters with visible replacement characters before JSONB writes, and record the replacement count in stored payloads.

--- a/src/luthien_proxy/observability/emitter.py
+++ b/src/luthien_proxy/observability/emitter.py
@@ -10,7 +10,6 @@ via global state.
 from __future__ import annotations
 
 import asyncio
-import base64
 import json
 import logging
 import sqlite3
@@ -25,47 +24,12 @@ from luthien_proxy.observability.event_publisher import EventPublisherProtocol
 from luthien_proxy.observability.session_summary import update_session_summary
 from luthien_proxy.utils.constants import OTEL_SPAN_ID_HEX_LENGTH, OTEL_TRACE_ID_HEX_LENGTH
 from luthien_proxy.utils.db import DatabasePool
+from luthien_proxy.utils.jsonb import sanitize_for_jsonb
 
 
 def _safe_serialize(obj: Any) -> Any:
-    """Convert an object to a JSON-serializable form.
-
-    Handles common non-serializable types gracefully:
-    - datetime objects -> ISO format strings
-    - bytes -> base64-encoded strings (prefixed with "b64:")
-    - sets -> lists
-    - objects with __dict__ -> their __dict__
-    - other non-serializable objects -> their string representation
-
-    Returns a structure that json.dumps() can handle without raising.
-    """
-    if obj is None or isinstance(obj, (bool, int, float, str)):
-        return obj
-
-    if isinstance(obj, datetime):
-        return obj.isoformat()
-
-    if isinstance(obj, bytes):
-        return f"b64:{base64.b64encode(obj).decode('ascii')}"
-
-    if isinstance(obj, dict):
-        return {str(k): _safe_serialize(v) for k, v in obj.items()}
-
-    if isinstance(obj, (list, tuple)):
-        return [_safe_serialize(item) for item in obj]
-
-    if isinstance(obj, set):
-        return [_safe_serialize(item) for item in sorted(obj, key=str)]
-
-    if hasattr(obj, "model_dump"):
-        # Pydantic models
-        return _safe_serialize(obj.model_dump())
-
-    if hasattr(obj, "__dict__"):
-        return _safe_serialize(obj.__dict__)
-
-    # Fallback: convert to string representation
-    return str(obj)
+    """Convert an object to a JSON-serializable form safe for JSONB storage."""
+    return sanitize_for_jsonb(obj)
 
 
 logger = logging.getLogger(__name__)
@@ -164,7 +128,7 @@ class EventEmitter:
         if self._stdout_enabled:
             tasks.append(self._write_stdout(transaction_id, event_type, safe_data, timestamp))
         if self._db_pool:
-            tasks.append(self._write_db(transaction_id, event_type, safe_data, timestamp))
+            tasks.append(self._write_db(transaction_id, event_type, data, timestamp))
         if self._event_publisher:
             tasks.append(self._write_events(transaction_id, event_type, safe_data, timestamp))
 
@@ -271,6 +235,7 @@ class EventEmitter:
                     # conversation_events — it lives on conversation_calls (which
                     # query paths join through). Denormalizing onto every event
                     # row paid a write cost for zero readers.
+                    payload = cast(dict[str, Any], sanitize_for_jsonb(data))
                     await conn.execute(
                         """
                         INSERT INTO conversation_events (call_id, event_type, payload, created_at, session_id)
@@ -278,7 +243,7 @@ class EventEmitter:
                         """,
                         transaction_id,
                         event_type,
-                        json.dumps(data),
+                        json.dumps(payload),
                         timestamp,
                         session_id,
                     )
@@ -291,7 +256,7 @@ class EventEmitter:
                             conn,
                             session_id=session_id,
                             event_type=event_type,
-                            data=data,
+                            data=payload,
                             user_id=user_id if isinstance(user_id, str) else None,
                             timestamp=timestamp,
                         )
@@ -307,7 +272,12 @@ class EventEmitter:
         except (OSError, asyncpg.PostgresError, asyncpg.InternalClientError, sqlite3.Error) as e:
             EventEmitter.dropped_db_writes += 1
             logger.warning(
-                f"Failed to write event to database ({EventEmitter.dropped_db_writes} total dropped): {repr(e)}",
+                "Failed to write event to database (call_id=%s, session_id=%s, event_type=%s; %d total dropped): %r",
+                transaction_id,
+                session_id,
+                event_type,
+                EventEmitter.dropped_db_writes,
+                e,
                 exc_info=True,
             )
 

--- a/src/luthien_proxy/request_log/recorder.py
+++ b/src/luthien_proxy/request_log/recorder.py
@@ -21,6 +21,7 @@ from typing import Any, Callable
 
 from luthien_proxy.request_log.sanitize import sanitize_headers
 from luthien_proxy.utils.db import DatabasePool, DatabaseWriteError
+from luthien_proxy.utils.jsonb import sanitize_for_jsonb
 
 logger = logging.getLogger(__name__)
 
@@ -95,10 +96,10 @@ async def _insert_log_row(
             pending.direction,
             pending.http_method,
             pending.url,
-            json.dumps(pending.request_headers) if pending.request_headers else None,
+            json.dumps(sanitize_for_jsonb(pending.request_headers)) if pending.request_headers else None,
             serialize_body(pending.request_body),
             pending.response_status,
-            json.dumps(pending.response_headers) if pending.response_headers else None,
+            json.dumps(sanitize_for_jsonb(pending.response_headers)) if pending.response_headers else None,
             serialize_body(pending.response_body),
             pending.started_at,
             pending.completed_at,
@@ -234,22 +235,26 @@ class RequestLogRecorder:
         """JSON-serialize a body dict, truncating if it exceeds MAX_BODY_BYTES."""
         if body is None:
             return None
-        serialized = json.dumps(body)
+        serialized = json.dumps(sanitize_for_jsonb(body))
         if len(serialized) > MAX_BODY_BYTES:
             return json.dumps({"_truncated": True, "_original_size_bytes": len(serialized)})
         return serialized
 
     async def _write_logs(self) -> None:
         """Insert both inbound and outbound rows."""
+        failed_pending: _PendingLog | None = None
         try:
             async with self._db_pool.connection() as conn:
                 for pending in (self._inbound, self._outbound):
+                    failed_pending = pending
                     await _insert_log_row(conn, pending, self._serialize_body)
         except DatabaseWriteError as exc:
             RequestLogRecorder.dropped_writes += 1
             logger.warning(
-                "Failed to write request logs for %s (%d total dropped): %s",
+                "Failed to write request logs (call_id=%s, session_id=%s, direction=%s; %d total dropped): %s",
                 self._transaction_id,
+                failed_pending.session_id if failed_pending else None,
+                failed_pending.direction if failed_pending else "connection",
                 RequestLogRecorder.dropped_writes,
                 exc.cause,
             )

--- a/src/luthien_proxy/utils/jsonb.py
+++ b/src/luthien_proxy/utils/jsonb.py
@@ -1,0 +1,87 @@
+"""Prepare values for PostgreSQL JSONB storage."""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime
+from typing import Protocol, cast
+
+_NULL_CHARACTER = "\x00"
+_REPLACEMENT_CHARACTER = "�"
+_SANITIZATION_MARKER = "_sanitized"
+
+
+class _ModelDumpable(Protocol):
+    """Minimal protocol for Pydantic-compatible JSON serialization."""
+
+    def model_dump(self) -> object: ...
+
+
+def sanitize_for_jsonb(value: object) -> object:
+    r"""Make a value JSON-safe, replace NUL characters, and mark replacements.
+
+    PostgreSQL rejects JSONB strings containing ``\u0000``. The replacement
+    character keeps the stored payload readable while making the loss of
+    fidelity explicit to consumers of dict payloads.
+    """
+    sanitized, nul_replaced = _sanitize_json_value(value)
+    if nul_replaced == 0 or not isinstance(sanitized, dict):
+        return sanitized
+
+    marker = _SANITIZATION_MARKER
+    while marker in sanitized:
+        marker = f"_{marker}"
+    sanitized[marker] = {"nul_replaced": nul_replaced}
+    return sanitized
+
+
+def _sanitize_json_value(value: object) -> tuple[object, int]:
+    """Return a recursively JSON-safe value and its number of NUL replacements."""
+    if value is None or isinstance(value, (bool, int, float)):
+        return value, 0
+
+    if isinstance(value, str):
+        count = value.count(_NULL_CHARACTER)
+        return value.replace(_NULL_CHARACTER, _REPLACEMENT_CHARACTER), count
+
+    if isinstance(value, datetime):
+        return value.isoformat(), 0
+
+    if isinstance(value, bytes):
+        return f"b64:{base64.b64encode(value).decode('ascii')}", 0
+
+    if isinstance(value, dict):
+        sanitized: dict[str, object] = {}
+        nul_replaced = 0
+        for key, item in value.items():
+            key_text = str(key)
+            key_count = key_text.count(_NULL_CHARACTER)
+            sanitized_key = key_text.replace(_NULL_CHARACTER, _REPLACEMENT_CHARACTER)
+            sanitized_item, item_count = _sanitize_json_value(item)
+            sanitized[sanitized_key] = sanitized_item
+            nul_replaced += key_count + item_count
+        return sanitized, nul_replaced
+
+    if isinstance(value, (list, tuple)):
+        sanitized_items: list[object] = []
+        nul_replaced = 0
+        for item in value:
+            sanitized_item, item_count = _sanitize_json_value(item)
+            sanitized_items.append(sanitized_item)
+            nul_replaced += item_count
+        return sanitized_items, nul_replaced
+
+    if isinstance(value, set):
+        return _sanitize_json_value(sorted(value, key=str))
+
+    if hasattr(value, "model_dump"):
+        model = cast(_ModelDumpable, value)
+        return _sanitize_json_value(model.model_dump())
+
+    if hasattr(value, "__dict__"):
+        return _sanitize_json_value(value.__dict__)
+
+    return _sanitize_json_value(str(value))
+
+
+__all__ = ["sanitize_for_jsonb"]

--- a/tests/luthien_proxy/integration_tests/observability/test_emitter_jsonb.py
+++ b/tests/luthien_proxy/integration_tests/observability/test_emitter_jsonb.py
@@ -1,0 +1,46 @@
+"""PostgreSQL integration coverage for event JSONB storage."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from luthien_proxy.observability.emitter import EventEmitter
+from luthien_proxy.utils.db import DatabasePool
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_event_payload_with_nul_is_persisted_by_postgres() -> None:
+    """JSONB storage keeps an identifiable replacement for NUL-containing event data."""
+    db_url = os.environ["DATABASE_URL"]
+    transaction_id = str(uuid4())
+    pool = DatabasePool(db_url)
+    emitter = EventEmitter(db_pool=pool, stdout_enabled=False)
+
+    try:
+        await emitter._write_db(
+            transaction_id,
+            "transaction.request_recorded",
+            {"tool\x00output": {"content": "before\x00after"}},
+            datetime.now(UTC),
+        )
+
+        async with pool.connection() as conn:
+            event = await conn.fetchrow("SELECT payload FROM conversation_events WHERE call_id = $1", transaction_id)
+        assert event is not None
+        payload_json = event["payload"]
+        assert isinstance(payload_json, str)
+        assert json.loads(payload_json) == {
+            "tool�output": {"content": "before�after"},
+            "_sanitized": {"nul_replaced": 2},
+        }
+    finally:
+        async with pool.connection() as conn:
+            await conn.execute("DELETE FROM conversation_calls WHERE call_id = $1", transaction_id)
+        await pool.close()

--- a/tests/luthien_proxy/unit_tests/observability/test_emitter.py
+++ b/tests/luthien_proxy/unit_tests/observability/test_emitter.py
@@ -149,6 +149,15 @@ class TestSafeSerialize:
         json_str = json.dumps(result)
         assert isinstance(json_str, str)
 
+    def test_nul_characters_are_sanitized_for_jsonb(self) -> None:
+        """NUL characters must not survive the shared JSON-safe serialization path."""
+        result = _safe_serialize({"content": "before\x00after"})
+
+        assert result == {
+            "content": "before�after",
+            "_sanitized": {"nul_replaced": 1},
+        }
+
 
 class TestNullEventEmitter:
     """Tests for NullEventEmitter."""
@@ -271,7 +280,12 @@ class TestEventEmitter:
         emitter = EventEmitter(db_pool=mock_pool, stdout_enabled=False)
 
         before = EventEmitter.dropped_db_writes
-        await emitter.emit("tx-123", "test.event", {"key": "value"})
+        with patch("luthien_proxy.observability.emitter.logger") as mock_logger:
+            await emitter.emit("tx-123", "test.event", {"session_id": "sess-123"})
+
+        log_args = mock_logger.warning.call_args[0]
+        assert "call_id=%s, session_id=%s, event_type=%s" in log_args[0]
+        assert log_args[1:4] == ("tx-123", "sess-123", "test.event")
         assert EventEmitter.dropped_db_writes == before + 1
 
     @pytest.mark.asyncio
@@ -327,7 +341,10 @@ class TestWriteDbAtomicity:
 
         p = DatabasePool("sqlite://:memory:")
         await check_migrations(p)
-        return p
+        try:
+            yield p
+        finally:
+            await p.close()
 
     @pytest.mark.asyncio
     async def test_summary_failure_rolls_back_event_insert(self, pool) -> None:
@@ -372,6 +389,28 @@ class TestWriteDbAtomicity:
         assert len(events) == 1
         assert len(summaries) == 1
         assert summaries[0]["event_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_writes_nul_payload_to_sqlite(self, pool) -> None:
+        """A JSONB-bound event with NUL content stays queryable in SQLite storage."""
+        emitter = EventEmitter(db_pool=pool, stdout_enabled=False)
+        data = {
+            "session_id": "sess-4",
+            "tool\x00output": {"content": "before\x00after"},
+        }
+
+        await emitter._write_db("tx-4", "transaction.request_recorded", data, datetime.now(UTC))
+
+        async with pool.connection() as conn:
+            event = await conn.fetchrow("SELECT payload FROM conversation_events WHERE call_id = $1", "tx-4")
+        assert event is not None
+        payload_json = event["payload"]
+        assert isinstance(payload_json, str)
+        assert json.loads(payload_json) == {
+            "session_id": "sess-4",
+            "tool�output": {"content": "before�after"},
+            "_sanitized": {"nul_replaced": 2},
+        }
 
     @pytest.mark.asyncio
     async def test_sqlite_write_error_increments_dropped_counter(self, pool) -> None:

--- a/tests/luthien_proxy/unit_tests/request_log/test_recorder.py
+++ b/tests/luthien_proxy/unit_tests/request_log/test_recorder.py
@@ -478,6 +478,36 @@ class TestRequestLogRecorder:
         assert body_arg == json.dumps({"nested": {"data": "structure"}})
 
     @pytest.mark.asyncio
+    async def test_write_logs_sanitizes_nul_in_all_json_fields(self) -> None:
+        """JSONB-bound headers and bodies replace NULs and expose the replacement count."""
+        mock_conn = AsyncMock()
+        mock_conn.execute = AsyncMock()
+        db_pool = MagicMock(spec=DatabasePool)
+        db_pool.connection = MagicMock()
+        db_pool.connection.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+        db_pool.connection.return_value.__aexit__ = AsyncMock(return_value=None)
+        recorder = RequestLogRecorder(db_pool, "txn-456")
+        recorder.record_inbound_request(
+            method="POST",
+            url="http://example.com",
+            headers={"x\x00request": "header"},
+            body={"request": "body\x00"},
+        )
+        recorder.record_inbound_response(
+            status=200,
+            headers={"x\x00response": "header"},
+            body={"response": "body\x00"},
+        )
+
+        await recorder._write_logs()
+
+        args = mock_conn.execute.call_args_list[0][0]
+        assert json.loads(args[7]) == {"x�request": "header", "_sanitized": {"nul_replaced": 1}}
+        assert json.loads(args[8]) == {"request": "body�", "_sanitized": {"nul_replaced": 1}}
+        assert json.loads(args[10]) == {"x�response": "header", "_sanitized": {"nul_replaced": 1}}
+        assert json.loads(args[11]) == {"response": "body�", "_sanitized": {"nul_replaced": 1}}
+
+    @pytest.mark.asyncio
     async def test_write_logs_handles_none_json_fields(self) -> None:
         """_write_logs() passes None for missing JSON fields."""
         mock_conn = AsyncMock()
@@ -517,7 +547,9 @@ class TestRequestLogRecorder:
         db_pool.connection.return_value.__aexit__ = AsyncMock(return_value=None)
 
         recorder = RequestLogRecorder(db_pool, "txn-123")
-        recorder.record_inbound_request(method="POST", url="http://example.com", headers={}, body={})
+        recorder.record_inbound_request(
+            method="POST", url="http://example.com", headers={}, body={}, session_id="sess-123"
+        )
 
         before = RequestLogRecorder.dropped_writes
         with patch("luthien_proxy.request_log.recorder.logger") as mock_logger:
@@ -525,8 +557,8 @@ class TestRequestLogRecorder:
 
             mock_logger.warning.assert_called_once()
             call_args = mock_logger.warning.call_args[0]
-            assert "Failed to write request logs" in call_args[0]
-            assert "txn-123" in call_args[1]
+            assert "call_id=%s, session_id=%s, direction=%s" in call_args[0]
+            assert call_args[1:4] == ("txn-123", "sess-123", "inbound")
 
         assert RequestLogRecorder.dropped_writes == before + 1
 

--- a/tests/luthien_proxy/unit_tests/utils/test_jsonb.py
+++ b/tests/luthien_proxy/unit_tests/utils/test_jsonb.py
@@ -1,0 +1,27 @@
+"""Tests for PostgreSQL JSONB payload sanitization."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_sanitize_for_jsonb_replaces_nested_nuls_and_marks_payload() -> None:
+    """NUL bytes must become replacement characters without changing other JSON values."""
+    jsonb = importlib.import_module("luthien_proxy.utils.jsonb")
+
+    payload = {
+        "nul\x00key": ["first\x00", {"nested\x00key": "second\x00"}],
+        "integer": 7,
+        "boolean": False,
+        "none": None,
+    }
+
+    result = jsonb.sanitize_for_jsonb(payload)
+
+    assert result == {
+        "nul�key": ["first�", {"nested�key": "second�"}],
+        "integer": 7,
+        "boolean": False,
+        "none": None,
+        "_sanitized": {"nul_replaced": 4},
+    }


### PR DESCRIPTION
## Summary

On 2026-09-09, PostgreSQL JSONB writes dropped conversation events and request logs when captured content contained U+0000. Those losses remove the affected session tail from history, activity monitoring, and judge transcripts.

## Production evidence

The `/ecs/luthien-proxy` log group recorded `asyncpg.exceptions.UntranslatableCharacterError('unsupported Unicode escape sequence')` from `conversation_events.payload` writes. The event writer dropped 8 events at 11:43Z, about 135 from 13:24Z to 13:27Z, and about 100 from 19:13Z to 21:01Z. Its in-process counter read 111 at 21:01Z. Datadog APM recorded 28 matching `INSERT` error spans in the preceding hour and seven `luthien_proxy.utils.db.DatabaseWriteError` spans.

## Mechanism and fix

`json.dumps` escapes U+0000 as `\u0000`, which PostgreSQL JSONB rejects. A shared write-boundary serializer now converts JSON-compatible values, replaces every NUL in keys and values with U+FFFD, and adds `_sanitized: {"nul_replaced": N}` to dict payloads. Both `EventEmitter` and `RequestLogRecorder` use it immediately before JSON serialization. Database-drop warnings now identify the call ID, session ID, and event type or request-log direction.

## Verification

- Unit regression coverage verifies nested keys and values, non-string leaves, the stored marker, SQLite event storage, request-log headers and bodies, and attributed warnings: `78 passed`.
- A PostgreSQL integration test persisted an event containing NUL characters and read back U+FFFD plus `_sanitized`: `1 passed`.
- Red check with the sanitizer bypassed produced the original failed-write behavior:

  ```text
  FAILED test_unsanitized_event_payload_is_dropped_by_postgres
  WARNING Failed to write event to database (...): UntranslatableCharacterError('unsupported Unicode escape sequence')
  asyncpg.exceptions.UntranslatableCharacterError: unsupported Unicode escape sequence
  DETAIL:  \u0000 cannot be converted to text.
  ```
- `PYTEST_ADDOPTS='--ignore=tests/luthien_proxy/e2e_tests' ./scripts/dev_checks.sh` completed with Ruff and Pyright clean. The default test selection already excludes the e2e tier; this also prevents its collection-time shared `.env` loader from changing unit-test configuration.
