### PR TITLE
fix(request_log): sanitize U+0000 in bodies so jsonb inserts stop dropping transcripts

### DIFF
--- a/changelog.d/fix-request-log-nul-safe-bodies.md
+++ b/changelog.d/fix-request-log-nul-safe-bodies.md
@@ -1,0 +1,5 @@
+---
+category: Fixes
+---
+
+**Request-log NUL sanitization**: Preserve request-log rows by replacing U+0000 body characters with U+FFFD before JSONB insertion.

--- a/dev/context/gotchas.md
+++ b/dev/context/gotchas.md
@@ -346,4 +346,6 @@ Policies using session-level state trackers (like `ConversationLinkPolicy`'s onc
 
 ---
 
+- 2026-09-11: PostgreSQL JSONB cannot store U+0000; request-log bodies are sanitized to U+FFFD before insert.
+
 (Add gotchas as discovered with timestamps: YYYY-MM-DD)

--- a/src/luthien_proxy/request_log/recorder.py
+++ b/src/luthien_proxy/request_log/recorder.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable
@@ -26,6 +27,16 @@ logger = logging.getLogger(__name__)
 
 # Bodies larger than this are replaced with a truncation notice
 MAX_BODY_BYTES = 1_048_576  # 1 MB
+
+# json.dumps encodes U+0000 as \u0000. PostgreSQL jsonb rejects that escape.
+# Match the NUL escape and any preceding pairs used to represent literal
+# backslashes, leaving literal "\\u0000" input unchanged.
+_JSON_NUL_ESCAPE = re.compile(r"(?<!\\)(?:\\\\)*\\u0000")
+
+
+def _replace_json_nul_escape(match: re.Match[str]) -> str:
+    """Replace the actual NUL escape while retaining literal backslashes."""
+    return f"{match.group()[: -len(r'\u0000')]}\\ufffd"
 
 
 def _log_task_exception(task: asyncio.Task[None]) -> None:
@@ -231,10 +242,18 @@ class RequestLogRecorder:
 
     @staticmethod
     def _serialize_body(body: dict[str, Any] | None) -> str | None:
-        """JSON-serialize a body dict, truncating if it exceeds MAX_BODY_BYTES."""
+        r"""JSON-serialize a body dict, sanitizing NULs and truncating oversized bodies.
+
+        PostgreSQL JSONB rejects ``\u0000`` even when JSON encodes it as an
+        escape. SQLite stores the same JSON text in TEXT, so replacing only
+        those escapes with ``\ufffd`` gives both backends one readable format;
+        U+FFFD itself visibly records the substitution without changing the body schema.
+        """
         if body is None:
             return None
         serialized = json.dumps(body)
+        if r"\u0000" in serialized:
+            serialized = _JSON_NUL_ESCAPE.sub(_replace_json_nul_escape, serialized)
         if len(serialized) > MAX_BODY_BYTES:
             return json.dumps({"_truncated": True, "_original_size_bytes": len(serialized)})
         return serialized

--- a/tests/luthien_proxy/e2e_tests/sqlite/test_request_log_body_sanitization.py
+++ b/tests/luthien_proxy/e2e_tests/sqlite/test_request_log_body_sanitization.py
@@ -1,0 +1,60 @@
+"""SQLite request-log body serialization integration tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from luthien_proxy.request_log.recorder import RequestLogRecorder
+from luthien_proxy.request_log.service import get_transaction_logs
+from luthien_proxy.utils.db import DatabasePool
+from luthien_proxy.utils.migration_check import check_migrations
+
+pytestmark = pytest.mark.sqlite_e2e
+
+
+@pytest.mark.asyncio
+async def test_nul_body_round_trips_as_replacement_character() -> None:
+    """A logged transaction retains both rows when a body contains a NUL."""
+    pool = DatabasePool("sqlite://:memory:")
+    await check_migrations(pool)
+    body = {
+        "content": "prefix\x00suffix",
+        "nested": [{"number": 7, "enabled": True, "empty": None}],
+    }
+    expected_body = {
+        "content": "prefix\ufffdsuffix",
+        "nested": [{"number": 7, "enabled": True, "empty": None}],
+    }
+    recorder = RequestLogRecorder(pool, "nul-body-transaction")
+    recorder.record_inbound_request(
+        method="POST",
+        url="http://example.test/v1/messages",
+        headers={},
+        body=body,
+    )
+    recorder.record_inbound_response(status=200)
+    recorder.record_outbound_request(body=body)
+    recorder.record_outbound_response(status=200)
+
+    try:
+        recorder.flush()
+        for _ in range(100):
+            try:
+                detail = await get_transaction_logs(pool, "nul-body-transaction")
+            except ValueError:
+                await asyncio.sleep(0.01)
+                continue
+            if detail.inbound is not None and detail.outbound is not None:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            pytest.fail("request-log writer did not persist both transaction rows")
+
+        assert detail.inbound is not None
+        assert detail.outbound is not None
+        assert detail.inbound.request_body == expected_body
+        assert detail.outbound.request_body == expected_body
+    finally:
+        await pool.close()

--- a/tests/luthien_proxy/unit_tests/request_log/test_recorder.py
+++ b/tests/luthien_proxy/unit_tests/request_log/test_recorder.py
@@ -768,6 +768,32 @@ class TestBodyTruncation:
         result = RequestLogRecorder._serialize_body(body)
         assert result == json.dumps(body)
 
+    def test_serialize_body_replaces_nul_with_replacement_character(self) -> None:
+        """NULs in nested strings become U+FFFD in JSON text."""
+        body = {
+            "message": "before\x00after",
+            "nested": ["inner\x00value", {"count": 3, "enabled": False, "empty": None}],
+        }
+
+        result = RequestLogRecorder._serialize_body(body)
+
+        assert result is not None
+        assert "\x00" not in result
+        assert r"\u0000" not in result
+        assert json.loads(result) == {
+            "message": "before\ufffdafter",
+            "nested": ["inner\ufffdvalue", {"count": 3, "enabled": False, "empty": None}],
+        }
+
+    def test_serialize_body_without_nul_is_byte_identical(self) -> None:
+        """Bodies without NULs retain the exact json.dumps representation."""
+        body = {
+            "literal_escape": r"\u0000",
+            "nested": [{"count": 3, "enabled": False, "empty": None}],
+        }
+
+        assert RequestLogRecorder._serialize_body(body) == json.dumps(body)
+
     def test_serialize_body_large_body_is_truncated(self) -> None:
         """Bodies exceeding MAX_BODY_BYTES are replaced with a truncation notice."""
         from luthien_proxy.request_log.recorder import MAX_BODY_BYTES


### PR DESCRIPTION
## Summary

Production request logging drops both rows for a transaction whenever a request or response body contains U+0000. PostgreSQL rejects the `\\u0000` JSON escape during the JSONB insert with `asyncpg.exceptions.UntranslatableCharacterError: unsupported Unicode escape sequence` and `DETAIL: \\u0000 cannot be converted to text`. Datadog recorded 488 INSERT error spans over the last seven days, representing about 244 lost transactions; the largest 15-minute bucket had 296 spans at 2026-09-09T13:15Z, with another sample at 2026-09-10T13:17:57Z. This disproportionately loses CLI-agent transcript capture with binary tool output.

`RequestLogRecorder._serialize_body` now replaces only JSON escapes emitted for actual NUL characters with `\\ufffd` before the body reaches either database. It preserves literal `\\u0000` text and otherwise returns byte-identical `json.dumps` output. PostgreSQL JSONB accepts the replacement escape, and SQLite stores the same JSON text in its TEXT request-body columns. A reader of a sanitized row sees U+FFFD in place of each NUL; no metadata field was added because request bodies have no metadata envelope and adding one would alter their schema.

## Verification

- `uv run pytest tests/luthien_proxy/unit_tests/request_log -q` passed. New unit coverage proves nested NUL strings contain neither a NUL nor `\\u0000` in the serialized payload, retain all other values, and leaves NUL-free bodies—including literal `\\u0000` text—byte-identical.
- `uv run pytest -m sqlite_e2e tests/luthien_proxy/e2e_tests/sqlite/test_request_log_body_sanitization.py --no-cov -q` passed. It drives the recorder's public `flush()` path through migrations, SQLite insertion, and request-log retrieval, observing both transaction rows and U+FFFD values.
- `./scripts/run_e2e.sh sqlite` passed: 48 passed.
- `uv run pyright` reported `0 errors, 0 warnings, 0 informations`; Ruff format and lint passed.
- `./scripts/dev_checks.sh` ran through dependency sync, ShellCheck, settings generation, Ruff, and Pyright cleanly, but its all-tests phase has three pre-existing failures: `tests/luthien_cli/test_onboard.py::test_find_docker_ports_respects_env_vars` and two `test_config_registry` default-source tests. The suite's e2e `conftest.py` loads the shared root `.env` during collection, making the latter tests observe an environment-sourced port; each fails in isolation only after that collection side effect. This change does not touch those files.

No Docker-backed PostgreSQL or real-API e2e tier was run; the available in-process SQLite tier verifies the shared serialized representation, while a PostgreSQL JSONB round trip still requires Docker and real API setup.

The Trello workflow step was skipped because this session has no Trello access.
